### PR TITLE
feat: refactor filter logic into modular workflow pipeline

### DIFF
--- a/client/src/features/landing/Products.tsx
+++ b/client/src/features/landing/Products.tsx
@@ -20,6 +20,7 @@ export default function Products() {
               height="480"
               allow="autoplay"
               allowFullScreen
+              
             ></iframe>
           </div>
         </div>

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -2,16 +2,16 @@
 
 services:
   # 1. בסיס הנתונים PostgreSQL
-  db:
-    image: postgres:16-alpine
-    container_name: litellm-db
-    restart: unless-stopped
-    environment:
-      - POSTGRES_USER=llm_user
-      - POSTGRES_PASSWORD=llm_pass
-      - POSTGRES_DB=litellm_db
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
+  # db:
+  #   image: postgres:16-alpine
+  #   container_name: litellm-db
+  #   restart: unless-stopped
+  #   environment:
+  #     - POSTGRES_USER=llm_user
+  #     - POSTGRES_PASSWORD=llm_pass
+  #     - POSTGRES_DB=litellm_db
+  #   volumes:
+  #     - postgres_data:/var/lib/postgresql/data
 
   # 2. MongoDB
   # mongodb:
@@ -28,8 +28,8 @@ services:
     image: ghcr.io/berriai/litellm:main-latest
     container_name: litellm-proxy
     restart: unless-stopped
-    depends_on:
-      - db
+    # depends_on:
+    #   - db
     ports:
       - "4000:4000"
     volumes:

--- a/server/http/costs.http
+++ b/server/http/costs.http
@@ -1,7 +1,7 @@
 ###
 
 POST http://localhost:3001/v1/messages
-Authorization: Bearer sk-safeai-???
+Authorization: Bearer sk-safeai-6???
 Content-Type: application/json
 anthropic-version: 2023-06-01
 
@@ -56,14 +56,14 @@ anthropic-version: 2023-06-01
 
 POST http://localhost:3001/v1/chat/completions
 Content-Type: application/json
-Authorization: Bearer sk-safeai-???
+Authorization: Bearer sk-safeai-68e1???
 
 {
   "model": "gpt-5.4-mini",
   "messages": [
     {
       "role": "user",
-      "content": "What is aws in 3 words?"
+      "content": "  What is AWS?`"
     }
   ]
 }

--- a/server/src/controllers/filterController.ts
+++ b/server/src/controllers/filterController.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from "express";
 import {
   createEmbedding,
-  evaluateText,
   getEmbeddings,
 } from "../services/filterService";
 
@@ -9,6 +8,7 @@ import {
   createProfile,
   getProfiles,
 } from "../services/profileService";
+import { evaluateText } from "../workflows/input/evaluate";
 
 export async function healthHandler(_req: Request, res: Response) {
   res.send("AI Filter Service running");

--- a/server/src/models/evaluationLog.ts
+++ b/server/src/models/evaluationLog.ts
@@ -17,7 +17,8 @@ export interface EvaluationLogDoc extends mongoose.Document {
   initialDecision: string;
   llmFinalDecision: string;
   isManuallyReviewed: boolean;
-
+  blockedBy?: string;
+  trace?: Record<string, unknown>[];
 }
 
 const EvaluationLogSchema = new mongoose.Schema(
@@ -31,6 +32,8 @@ const EvaluationLogSchema = new mongoose.Schema(
     initialDecision: String,
     llmFinalDecision: String,
     isManuallyReviewed: { type: Boolean, default: false },
+    blockedBy: { type: String },
+    trace: { type: [mongoose.Schema.Types.Mixed] },
   },
   { timestamps: true },
 );

--- a/server/src/services/filterService.ts
+++ b/server/src/services/filterService.ts
@@ -16,7 +16,7 @@ import {
 import { openai } from "../config/openai";
 import { getFullProfileById } from "../repositories/profileRepository";
 
-import { runInputFilter } from "../workflows/input/inputFilterWorkflow";
+import { runInputWorkflow } from "../workflows/input/inputFilterWorkflow";
 import { NodeTrace } from "../workflows/types";
 
 /* ---------- Embeddings (לא בשימוש בזרימה הנוכחית, נשמר לעתיד) ---------- */

--- a/server/src/services/filterService.ts
+++ b/server/src/services/filterService.ts
@@ -1,27 +1,25 @@
 /**
  * server/src/services/filterService.ts
  *
- * Business logic for creating embeddings and evaluating text against
- * user-defined AI profiles and embedding categories.
+ * הערכת טקסט מול פרופיל. הלוגיקה עברה ל-input workflow;
+ * הקובץ הזה נשאר נקודת הכניסה ושומר את ה-EvaluationLog (כולל trace).
  */
 
-import OpenAI from "openai";
 import logger from "../logger";
 import { Embedding } from "../models";
-import {
-  getEmbeddingVectorsByCategory,
-  addEmbeddingToCache,
-} from "../cache/embeddingCache";
-import { getLLMDecision } from "./llmService";
-import { cosineSimilarity } from "../utils/cosineSimilarity";
+import { addEmbeddingToCache } from "../cache/embeddingCache";
 import {
   EmbeddingRequest,
   EvaluateRequest,
   EvaluateResponse,
 } from "../types/proxyTypes";
-
 import { openai } from "../config/openai";
 import { getFullProfileById } from "../repositories/profileRepository";
+
+import { runInputFilter } from "../workflows/input/inputFilterWorkflow";
+import { NodeTrace } from "../workflows/types";
+
+/* ---------- Embeddings (לא בשימוש בזרימה הנוכחית, נשמר לעתיד) ---------- */
 
 export async function getEmbeddings(categories: string[] = []) {
   return Embedding.find({ category: { $in: categories } });
@@ -42,115 +40,4 @@ export async function createEmbedding(req: EmbeddingRequest) {
 
   await Embedding.create({ category, originText, vector });
   addEmbeddingToCache(category, vector);
-}
-
-export async function evaluateText(
-  req: EvaluateRequest,
-): Promise<EvaluateResponse> {
-  const { profileId, text, auditDisabled } = req;
-
-  if (!profileId || !text) {
-    throw new Error("profileId and text are required");
-  }
-
-  const { EvaluationLog } = await import("../models");
-
-  const profile = await getFullProfileById(profileId);
-  if (!profile) {
-    throw new Error("AIProfile not found");
-  }
-
-  //----------------Embedding Filter (Futute)----------------
-  // const response = await openai.embeddings.create({
-  //   model: "text-embedding-3-small",
-  //   input: text,
-  // });
-
-  // const inputVector = response.data?.[0]?.embedding;
-  // if (!inputVector) {
-  //   throw new Error("Embedding failed");
-  // }
-
-  // let bestAllowed = 0;
-  // let bestBlocked = 0;
-
-  // for (const category of profile.allowedCategories ?? []) {
-  //   const vectors = getEmbeddingVectorsByCategory(category);
-  //   for (const vector of vectors) {
-  //     const score = cosineSimilarity(inputVector, vector);
-  //     if (score > bestAllowed) bestAllowed = score;
-  //   }
-  // }
-
-  // for (const category of profile.blockedCategories ?? []) {
-  //   const vectors = getEmbeddingVectorsByCategory(category);
-  //   for (const vector of vectors) {
-  //     const score = cosineSimilarity(inputVector, vector);
-  //     if (score > bestBlocked) bestBlocked = score;
-  //   }
-  // }
-
-  // const diff = bestAllowed - bestBlocked;
-
-  // logger.info(
-  //   `Profile=${profile.name} | allowed=${bestAllowed.toFixed(4)} blocked=${bestBlocked.toFixed(4)} diff=${diff.toFixed(
-  //     4,
-  //   )}`,
-  // );
-
-  let finalAllowed = false;
-  let reason = "low-confidence";
-
-  // if (bestBlocked > profile.thresholdBlocked && bestBlocked > bestAllowed) {
-  //   reason = "blocked-category";
-  // } else if (
-  //   bestAllowed > profile.thresholdAllowed &&
-  //   diff > profile.similarityMargin
-  // ) {
-  //   finalAllowed = true;
-  //   reason = "passed-vector";
-  // }
-
-  // if (!finalAllowed) {
-  if (!auditDisabled) {
-    logger.info(
-      "Low confidence or blocked by vector. Consulting GPT-4o-mini...",
-    );
-  }
-
-  // const isSafeByLLM = true;
-  const profileDesc =
-    "allowed categories:" +
-    (profile.allowedCategories ?? []).join(", ") +
-    " " +
-    "blocked categories:" +
-    (profile.blockedCategories ?? []).join(", ");
-
-  logger.info("profileDesc: " + profileDesc);
-
-  
-  const isSafeByLLM = await getLLMDecision(text, profile.name, profileDesc);
-
-  if (isSafeByLLM) {
-    finalAllowed = true;
-    reason = "allowed-by-llm";
-  } else {
-    reason = "blocked-by-llm";
-  }
-  // }
-
-  if (!auditDisabled) {
-    await EvaluationLog.create({
-      profileId: profile._id,
-      text,
-      vectorScores: {},
-      initialDecision: reason,
-      llmFinalDecision: finalAllowed ? "allowed" : "blocked",
-    });
-  }
-
-  return {
-    allowed: finalAllowed,
-    reason,
-  };
 }

--- a/server/src/services/promptBuilder.ts
+++ b/server/src/services/promptBuilder.ts
@@ -2,11 +2,16 @@
  * server/src/services/promptBuilder.ts
  *
  */
+import logger from "../logger";
 import { PromptService } from "./promptService";
 
 
 export async function buildSystemPrompt(profile: any): Promise<string> {
+
   const dbPrompt = await PromptService.getPromptByCode("SYSTEM_PROMPT");
+
+  logger.info(`Building system prompt for profile: ${profile?.name || "N/A"} PROMPT: ${dbPrompt}`);
+
 
   return [
     dbPrompt.content,
@@ -25,6 +30,9 @@ export async function buildFilterPrompt(
   profileDesc: string,
 ): Promise<string> {
   const dbPrompt = await PromptService.getPromptByCode("FILTER_PROMPT");
+
+
+  logger.info(`Building filter prompt for profile: ${profileName}\n ${profileDesc}\n PROMPT: ${dbPrompt}`);
 
   return `
 ${dbPrompt.content}

--- a/server/src/services/proxyService.ts
+++ b/server/src/services/proxyService.ts
@@ -1,4 +1,3 @@
-import { evaluateText } from "./filterService";
 import { AIProfile } from "../models";
 import { decryptSecret } from "../utils/crypto";
 import {
@@ -17,6 +16,7 @@ import {
 } from "../utils/costs";
 import logger from "../logger";
 import { buildSystemPrompt } from "./promptBuilder";
+import { guardInput } from "../workflows/proxyFilter";
 /**
  * מזהה provider מתוך model
  */
@@ -201,7 +201,7 @@ function extractLastInputsForResponses(input: any[], count = 3): string {
 }
 
 export async function proxyChatCompletion(user: any, body: any) {
-  const startTime = Date.now();
+  
   const model = body.model;
 
   if (!model) {
@@ -237,25 +237,16 @@ export async function proxyChatCompletion(user: any, body: any) {
 
   // חילוץ ההודעה האחרונה מהמערך
   let userQuery = extractLastMessagesForFilter(body.messages || [], 3);
+  if (!userQuery || userQuery.trim() === "") userQuery = "No text content";
 
-  // בדיקה אם נמצא טקסט לסינון
-  if (!userQuery || userQuery.trim() === "") {
-    // אם אין טקסט (למשל רק קובץ/תמונה), אפשר להחליט אם לחסום או להמשיך
-    // כאן בחרתי להמשיך עם טקסט ריק כדי לא לשבור את הזרימה אם אין "שאלה"
-    userQuery = "No text content";
-  }
-
-  const result = await evaluateText({
-    profileId: profile ? profile._id?.toString() : "",
+  const blocked = await guardInput({
+    profile,
     text: userQuery,
+    model,
+    api: "chat",
+    stream: body.stream,
   });
-
-  if (!result.allowed) {
-    throw new Error(
-      "Content blocked By SafeAI Filter: " +
-        (result.reason || "Unknown reason"),
-    );
-  }
+  if (blocked) return blocked;
 
   // 4. הוספת system prompts
 
@@ -286,6 +277,10 @@ export async function proxyChatCompletion(user: any, body: any) {
   logger.debug("---------------------------");
   logger.debug("🚀 DEPLOYMENT CHECK: Version 1.0.5 - Headers: api-key present");
 
+  logger.debug("🔑 LiteLLM URL:", process.env.LITELLM_PROXY_URL);
+  logger.debug("🔑 LiteLLM Key (last 4):", decryptedLiteLLMKey?.slice(-4));
+  logger.debug("🔑 LiteLLM Key length:", decryptedLiteLLMKey?.length);
+  const startTime = Date.now();
   const litellmResponse = await fetch(
     `${process.env.LITELLM_PROXY_URL}/v1/chat/completions`,
     {
@@ -508,7 +503,7 @@ export async function proxyResponses(user: any, body: any) {
   if (!model) throw new Error("Model is required");
 
   const provider = getProviderFromModel(model);
-  console.log("Responses provider", provider);
+
 
   const providerKeyDoc =
     user.mode === "MANAGED"
@@ -529,30 +524,22 @@ export async function proxyResponses(user: any, body: any) {
   const profile = await AIProfile.findById(user.profileId);
   if (!profile) throw new Error("Profile not found");
 
-  console.log(JSON.stringify(body.input, null, 2));
-  // חילוץ טקסט מ-input (יכול להיות string או מערך)
-  let userQuery = "";
+  let userQuery =
+    typeof body.input === "string"
+      ? body.input
+      : Array.isArray(body.input)
+        ? extractLastInputsForResponses(body.input, 3)
+        : "";
+  if (!userQuery.trim()) userQuery = "No text content";
 
-  if (typeof body.input === "string") {
-    userQuery = body.input;
-  } else if (Array.isArray(body.input)) {
-    userQuery = extractLastInputsForResponses(body.input, 3);
-  }
-
-  if (!userQuery.trim()) {
-    userQuery = "No text content";
-  }
-
-  const filterResult = await evaluateText({
-    profileId: profile._id?.toString(),
+  const blocked = await guardInput({
+    profile,
     text: userQuery,
+    model,
+    api: "responses",
+    stream: body.stream,
   });
-  if (!filterResult.allowed) {
-    throw new Error(
-      "Content blocked By SafeAI Filter: " +
-        (filterResult.reason || "Unknown reason"),
-    );
-  }
+  if (blocked) return blocked;
 
   // System prompt מה-profile
   const systemPrompt = await buildSystemPrompt(profile);
@@ -755,17 +742,13 @@ export async function proxyImageGeneration(user: any, body: any) {
       ? body.prompt
       : "No text content";
 
-  const filterResult = await evaluateText({
-    profileId: profile ? profile._id?.toString() : "",
+  const blocked = await guardInput({
+    profile,
     text: imagePrompt,
+    model,
+    api: "chat",
   });
-
-  if (!filterResult.allowed) {
-    throw new Error(
-      "Content blocked By SafeAI Filter: " +
-        (filterResult.reason || "Unknown reason"),
-    );
-  }
+  if (blocked) return blocked;
 
   if (!decryptedLiteLLMKey) throw new Error("LiteLLM key missing");
 
@@ -965,22 +948,16 @@ export async function proxyAnthropicMessages(user: any, body: any) {
   }
 
   let userQuery = extractUserIntentForFilter(body.messages || [], 3);
+  if (!userQuery || userQuery.trim() === "") userQuery = "No text content";
 
-  if (!userQuery || userQuery.trim() === "") {
-    userQuery = "No text content";
-  }
-
-  const result = await evaluateText({
-    profileId: profile._id?.toString(),
+  const blocked = await guardInput({
+    profile,
     text: userQuery,
+    model,
+    api: "anthropic",
+    stream: body.stream,
   });
-
-  if (!result.allowed) {
-    throw new Error(
-      "Content blocked By SafeAI Filter: " +
-        (result.reason || "Unknown reason"),
-    );
-  }
+  if (blocked) return blocked;
 
   const systemPrompt = await buildSystemPrompt(profile);
 

--- a/server/src/workflows/blockedResponse.ts
+++ b/server/src/workflows/blockedResponse.ts
@@ -1,0 +1,92 @@
+/**
+ * server/src/workflows/blockedResponse.ts
+ *
+ * הופך verdict חוסם ל"תשובת דמה" בצורת תשובת LLM אמיתית,
+ * במקום לזרוק Error שהופך ל-500/400 ושובר את הלקוח.
+ *
+ * יש פורמט נפרד לכל API (chat completions / responses / anthropic messages),
+ * ועטיפת SSE למקרה של stream:true.
+ */
+
+/** הטקסט שהמשתמש יראה כתשובת ה-assistant. */
+export function blockedMessageText(reason: string): string {
+  return `הבקשה נחסמה ע"י מסנן התוכן של SafeAI (${reason}). אנא נסחו מחדש בהתאם למדיניות הפרופיל.`;
+}
+
+/* ============================================================
+ * Non-streaming shapes
+ * ============================================================ */
+
+/** OpenAI Chat Completions shape. */
+export function buildBlockedChatCompletion(model: string, reason: string) {
+  return {
+    id: `safeai-blocked-${Date.now()}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: blockedMessageText(reason) },
+        finish_reason: "content_filter",
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    safeai: { blocked: true, reason },
+  };
+}
+
+/** OpenAI Responses API shape. */
+export function buildBlockedResponsesApi(model: string, reason: string) {
+  return {
+    id: `safeai-blocked-${Date.now()}`,
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    model,
+    status: "completed",
+    output: [
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: blockedMessageText(reason) }],
+      },
+    ],
+    usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+    safeai: { blocked: true, reason },
+  };
+}
+
+/** Anthropic Messages shape. */
+export function buildBlockedAnthropicMessage(model: string, reason: string) {
+  return {
+    id: `safeai-blocked-${Date.now()}`,
+    type: "message",
+    role: "assistant",
+    model,
+    stop_reason: "end_turn",
+    content: [{ type: "text", text: blockedMessageText(reason) }],
+    usage: { input_tokens: 0, output_tokens: 0 },
+    safeai: { blocked: true, reason },
+  };
+}
+
+/* ============================================================
+ * Streaming wrapper
+ * ============================================================ */
+
+/**
+ * עוטף אובייקט JSON כ-SSE stream בעל chunk אחד + [DONE],
+ * כדי שלקוח שמצפה ל-stream יקבל תשובת חסימה בלי להיתקע.
+ */
+export function toSSEStream(payload: unknown): ReadableStream {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(`data: ${JSON.stringify(payload)}\n\n`),
+      );
+      controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+      controller.close();
+    },
+  });
+}

--- a/server/src/workflows/input/evaluate.ts
+++ b/server/src/workflows/input/evaluate.ts
@@ -1,0 +1,67 @@
+/**
+ * server/src/workflows/input/evaluate.ts
+ *
+ * evaluateText — נקודת הכניסה לשכבת האורקסטרציה של סינון הקלט.
+ * מביא את הפרופיל, מריץ את ה-input workflow (runInputWorkflow ), ושומר אודיט.
+ *
+ * נקרא משני מקומות:
+ *   - הפרוקסי, דרך guardInput (proxyFilter) — שמתרגם חסימה לתשובת דמה.
+ *   - ה-endpoint הישיר /evaluate (evaluateHandler) — שמחזיר את הוורדיקט כ-JSON.
+ *
+ * runInputWorkflow עצמו (inputFilterWorkflow.ts) נשאר טהור וללא DB.
+ * כאן נוספת שכבת האודיט בלבד.
+ */
+
+import logger from "../../logger";
+import { getFullProfileById } from "../../repositories/profileRepository";
+import { EvaluateRequest, EvaluateResponse } from "../../types/proxyTypes";
+import { runInputWorkflow  } from "./inputFilterWorkflow";
+import { NodeTrace } from "../types";
+
+export async function evaluateText(
+  req: EvaluateRequest,
+): Promise<EvaluateResponse & { blockedBy?: string; trace?: NodeTrace[] }> {
+  const { profileId, text, auditDisabled } = req;
+
+  if (!profileId || !text) {
+    throw new Error("profileId and text are required");
+  }
+
+  const { EvaluationLog } = await import("../../models");
+
+  const profile = await getFullProfileById(profileId);
+  if (!profile) {
+    throw new Error("AIProfile not found");
+  }
+
+  // הרצת ה-Input workflow (כרגע: llm-decision בלבד).
+  const result = await runInputWorkflow({
+    text,
+    profile,
+    profileId: profile._id?.toString() ?? profileId,
+  });
+
+  // אודיט — כולל ה-trace המלא של ה-nodes.
+  if (!auditDisabled) {
+    try {
+      await EvaluationLog.create({
+        profileId: profile._id,
+        text,
+        vectorScores: {},
+        initialDecision: result.reason,
+        llmFinalDecision: result.allowed ? "allowed" : "blocked",
+        trace: result.trace, // ודאי שהשדה קיים בסכמה (אופציונלי)
+        blockedBy: result.blockedBy,
+      });
+    } catch (err: any) {
+      logger.error("Failed to write EvaluationLog: " + err?.message);
+    }
+  }
+
+  return {
+    allowed: result.allowed,
+    reason: result.reason,
+    blockedBy: result.blockedBy,
+    trace: result.trace,
+  };
+}

--- a/server/src/workflows/input/evaluate.ts
+++ b/server/src/workflows/input/evaluate.ts
@@ -50,18 +50,19 @@ export async function evaluateText(
         vectorScores: {},
         initialDecision: result.reason,
         llmFinalDecision: result.allowed ? "allowed" : "blocked",
-        trace: result.trace, // ודאי שהשדה קיים בסכמה (אופציונלי)
-        blockedBy: result.blockedBy,
+        trace: result.trace as unknown as Record<string, unknown>[],
+        ...(result.blockedBy !== undefined ? { blockedBy: result.blockedBy } : {}),
       });
     } catch (err: any) {
       logger.error("Failed to write EvaluationLog: " + err?.message);
     }
   }
 
-  return {
+  const ret: EvaluateResponse & { blockedBy?: string; trace?: NodeTrace[] } = {
     allowed: result.allowed,
     reason: result.reason,
-    blockedBy: result.blockedBy,
     trace: result.trace,
   };
+  if (result.blockedBy !== undefined) ret.blockedBy = result.blockedBy;
+  return ret;
 }

--- a/server/src/workflows/input/inputFilterWorkflow.ts
+++ b/server/src/workflows/input/inputFilterWorkflow.ts
@@ -1,0 +1,26 @@
+/**
+ * server/src/workflows/input/inputFilterWorkflow.ts
+ *
+ * ה-Input workflow: רשימת ה-guard nodes לפי סדר ריצה.
+ * כרגע יש רק llm-decision. כדי להוסיף שלב — מוסיפים node למערך.
+ */
+
+import { runGuardPipeline } from "../runner";
+import { GuardContext, GuardWorkflowResult } from "../types";
+import { llmDecisionNode } from "./nodes/llmDecisionNode";
+
+/**
+ * סדר ה-nodes = סדר הסינון. ה-pipeline עוצר בראשון שחוסם (fail-fast),
+ * אז כדאי לשים שלבים זולים/ודאיים קודם.
+ *
+ * עתידי:
+ *   import { embeddingGuardNode, promptInjectionNode } from "./nodes/llmDecisionNode";
+ *   export const INPUT_NODES = [promptInjectionNode, embeddingGuardNode, llmDecisionNode];
+ */
+export const INPUT_NODES = [llmDecisionNode];
+
+export async function runInputWorkflow (
+  ctx: GuardContext,
+): Promise<GuardWorkflowResult> {
+  return runGuardPipeline("input-filter", INPUT_NODES, ctx);
+}

--- a/server/src/workflows/input/nodes/llmDecisionNode.ts
+++ b/server/src/workflows/input/nodes/llmDecisionNode.ts
@@ -1,0 +1,58 @@
+/**
+ * server/src/workflows/input/nodes/llmDecisionNode.ts
+ *
+ * ה-node היחיד שפעיל כרגע ב-Input workflow.
+ * עוטף את getLLMDecision הקיים — בלי לשנות את הלוגיקה שלו.
+ */
+
+import logger from "../../../logger";
+import { getLLMDecision } from "../../../services/llmService";
+import { GuardNode } from "../../types";
+
+/** בונה את תיאור הפרופיל ל-LLM (הועבר לכאן מתוך evaluateText). */
+function buildProfileDesc(profile: any): string {
+  return (
+    "allowed categories:" +
+    (profile.allowedCategories ?? []).join(", ") +
+    " " +
+    "blocked categories:" +
+    (profile.blockedCategories ?? []).join(", ")
+  );
+}
+
+export const llmDecisionNode: GuardNode = {
+  name: "llm-decision",
+
+  async run(ctx) {
+    const profileDesc = buildProfileDesc(ctx.profile);
+    logger.info("profileDesc: " + profileDesc);
+
+    const isSafe = await getLLMDecision(
+      ctx.text,
+      ctx.profile.name,
+      profileDesc,
+    );
+
+    return {
+      verdict: isSafe ? "allow" : "block",
+      reason: isSafe ? "allowed-by-llm" : "blocked-by-llm",
+      metadata: { profileDesc },
+    };
+  },
+};
+
+/* ------------------------------------------------------------
+ * נקודות הרחבה עתידיות (לדוגמה בלבד — לא פעילות):
+ *
+ *   export const embeddingGuardNode: GuardNode = {
+ *     name: "embedding-guardrail",
+ *     async run(ctx) { ... cosineSimilarity מול allowed/blocked categories ... }
+ *   };
+ *
+ *   export const promptInjectionNode: GuardNode = {
+ *     name: "prompt-injection-guardrail",
+ *     async run(ctx) { ... }
+ *   };
+ *
+ * מוסיפים אותן פשוט למערך ב-inputFilterWorkflow.ts לפי הסדר הרצוי.
+ * ------------------------------------------------------------ */

--- a/server/src/workflows/instructions/instructionsWorkflow.ts
+++ b/server/src/workflows/instructions/instructionsWorkflow.ts
@@ -1,0 +1,22 @@
+/**
+ * server/src/workflows/instructions/instructionsWorkflow.ts
+ *
+ * ה-Instructions workflow: בונה את ה-system prompt שנשלח לפרוקסי.
+ * מחזיר את ה-prompt + trace, כדי שיהיה אפשר לעקוב מה כל node הוסיף.
+ */
+
+import { runTransformPipeline } from "../runner";
+import { InstructionsContext } from "../types";
+import { systemPromptNode } from "./nodes/systemPromptNode";
+
+export const INSTRUCTIONS_NODES = [systemPromptNode];
+
+export async function runInstructionsWorkflow (profile: any): Promise<string> {
+  const { context } = await runTransformPipeline<InstructionsContext>(
+    "instructions",
+    INSTRUCTIONS_NODES,
+    { profile, systemPrompt: "" },
+  );
+
+  return context.systemPrompt;
+}

--- a/server/src/workflows/instructions/nodes/systemPromptNode.ts
+++ b/server/src/workflows/instructions/nodes/systemPromptNode.ts
@@ -1,0 +1,29 @@
+/**
+ * server/src/workflows/instructions/nodes/systemPromptNode.ts
+ *
+ * Transform node שבונה את ה-system prompt מתוך הפרופיל.
+ * עוטף את buildSystemPrompt הקיים.
+ */
+
+import { buildSystemPrompt } from "../../../services/promptBuilder";
+import { InstructionsContext, TransformNode } from "../../types";
+
+export const systemPromptNode: TransformNode<InstructionsContext> = {
+  name: "system-prompt",
+
+  async run(ctx) {
+    const prompt = await buildSystemPrompt(ctx.profile);
+    return {
+      ...ctx,
+      systemPrompt: prompt ?? "",
+    };
+  },
+};
+
+/* ------------------------------------------------------------
+ * נקודות הרחבה עתידיות:
+ *   - guardrailsNode: מוסיף הוראות בטיחות קבועות ל-system prompt
+ *   - localeNode: מזריק שפה/טון לפי הפרופיל
+ *   - policyNode: מצרף מדיניות ארגונית
+ * כל אחד מהם מקבל ctx ומחזיר ctx עם systemPrompt מועשר.
+ * ------------------------------------------------------------ */

--- a/server/src/workflows/output/outputFilterWorkflow.ts
+++ b/server/src/workflows/output/outputFilterWorkflow.ts
@@ -1,0 +1,20 @@
+/**
+ * server/src/workflows/output/outputFilterWorkflow.ts
+ *
+ * ה-Output workflow: ריק כרגע (אין nodes), כך שתמיד עובר.
+ * כשנרצה לסנן את תשובת ה-LLM (PII redaction, toxicity, policy) —
+ * מוסיפים GuardNode-ים למערך OUTPUT_NODES והכול כבר מחווט.
+ */
+
+import { runGuardPipeline } from "../runner";
+import { GuardContext, GuardNode, GuardWorkflowResult } from "../types";
+
+/** ריק בכוונה — נקודת ההרחבה העתידית. */
+export const OUTPUT_NODES: GuardNode[] = [];
+
+export async function runOutputWorkflow (
+  ctx: GuardContext,
+): Promise<GuardWorkflowResult> {
+  // pipeline ריק → תמיד allowed, אבל כבר מייצר trace ולוגים עקביים.
+  return runGuardPipeline("output-filter", OUTPUT_NODES, ctx);
+}

--- a/server/src/workflows/proxyFilter.ts
+++ b/server/src/workflows/proxyFilter.ts
@@ -1,0 +1,72 @@
+/**
+ * server/src/workflows/proxyFilter.ts
+ *
+ * Glue בין שכבת הפרוקסי ל-workflows, כדי לחסל את הכפילות
+ * שחזרה ב-6 פונקציות ה-proxy (extract → evaluateText → throw).
+ *
+ * שימוש בכל פונקציית proxy:
+ *
+ *   const blocked = await guardInput({
+ *     profile, text: userQuery, model, api: "chat", stream: body.stream,
+ *   });
+ *   if (blocked) return blocked;   // תשובת דמה, לא Error
+ */
+
+import logger from "../logger";
+import {
+  buildBlockedAnthropicMessage,
+  buildBlockedChatCompletion,
+  buildBlockedResponsesApi,
+  toSSEStream,
+} from "./blockedResponse";
+import { evaluateText } from "./input/evaluate";
+
+export type ProxyApi = "chat" | "responses" | "anthropic";
+
+interface GuardInputArgs {
+  profile: any;
+  text: string;
+  model: string;
+  api: ProxyApi;
+  stream?: boolean;
+}
+
+/**
+ * מפעיל את הערכת הקלט דרך evaluateText
+ * (= input workflow + כתיבת EvaluationLog).
+ * אושר → null (המשך רגיל). נחסם → תשובת דמה לפי ה-API.
+ */
+export async function guardInput(
+  args: GuardInputArgs,
+): Promise<object | ReadableStream | null> {
+  const { profile, text, model, api, stream } = args;
+
+  const result = await evaluateText({
+    profileId: profile?._id?.toString() ?? "",
+    text,
+  });
+
+  if (result.allowed) {
+    return null;
+  }
+
+  const reason = result.reason || "Unknown reason";
+  logger.info(
+    JSON.stringify({
+      event: "proxy.blocked",
+      api,
+      model,
+      reason,
+      blockedBy: result.blockedBy,
+    }),
+  );
+
+  const payload =
+    api === "anthropic"
+      ? buildBlockedAnthropicMessage(model, reason)
+      : api === "responses"
+        ? buildBlockedResponsesApi(model, reason)
+        : buildBlockedChatCompletion(model, reason);
+
+  return stream ? toSSEStream(payload) : payload;
+}

--- a/server/src/workflows/runner.ts
+++ b/server/src/workflows/runner.ts
@@ -1,0 +1,189 @@
+/**
+ * server/src/workflows/runner.ts
+ *
+ * ה-runners הגנריים. שני סוגים:
+ *  - runGuardPipeline     → עוצר ב-node הראשון שחוסם (fail-fast). מחזיר verdict + trace מלא.
+ *  - runTransformPipeline → מריץ את כל ה-nodes ברצף וצובר context (בניית הנחיות / output).
+ *
+ * שני ה-runners מודדים זמן ומוציאים structured JSON log לכל שלב.
+ */
+
+import logger from "../logger";
+import {
+  GuardContext,
+  GuardNode,
+  GuardWorkflowResult,
+  NodeStatus,
+  NodeTrace,
+  TransformNode,
+} from "./types";
+
+/** קיצור טקסט ל-log line כדי לא להציף; ה-trace המוחזר שומר את המלא. */
+function preview(value: unknown, max = 300): unknown {
+  if (typeof value === "string") {
+    return value.length > max ? value.slice(0, max) + "…" : value;
+  }
+  return value;
+}
+
+function logStep(
+  workflow: string,
+  trace: NodeTrace,
+  extra: Record<string, unknown> = {},
+): void {
+  // structured JSON — שורה אחת לכל node, קל לפרסר ב-log aggregator.
+  const line = JSON.stringify({
+    workflow,
+    event: "node.completed",
+    node: trace.node,
+    status: trace.status,
+    reason: trace.reason,
+    durationMs: trace.durationMs,
+    input: preview(trace.input),
+    output: trace.output,
+    ...extra,
+  });
+
+  if (trace.status === "error") logger.error(line);
+  else logger.info(line);
+}
+
+/* ============================================================
+ * Guard pipeline (Input / Output filtering)
+ * ============================================================ */
+
+export async function runGuardPipeline(
+  workflowName: string,
+  nodes: GuardNode[],
+  ctx: GuardContext,
+): Promise<GuardWorkflowResult> {
+  const trace: NodeTrace[] = [];
+
+  logger.info(
+    JSON.stringify({
+      workflow: workflowName,
+      event: "workflow.start",
+      profileId: ctx.profileId,
+      nodeCount: nodes.length,
+    }),
+  );
+
+  for (const node of nodes) {
+    const start = Date.now();
+
+    try {
+      const result = await node.run(ctx);
+      const durationMs = Date.now() - start;
+
+      const entry: NodeTrace = {
+        node: node.name,
+        status: result.verdict as NodeStatus,
+        reason: result.reason,
+        durationMs,
+        input: ctx.text,
+        output: { verdict: result.verdict, reason: result.reason },
+        metadata: result.metadata,
+      };
+      trace.push(entry);
+      logStep(workflowName, entry, { profileId: ctx.profileId });
+
+      // fail-fast: ה-node הראשון שחוסם עוצר את ה-pipeline.
+      if (result.verdict === "block") {
+        logger.info(
+          JSON.stringify({
+            workflow: workflowName,
+            event: "workflow.blocked",
+            blockedBy: node.name,
+            reason: result.reason,
+            profileId: ctx.profileId,
+          }),
+        );
+        return {
+          allowed: false,
+          reason: result.reason,
+          blockedBy: node.name,
+          trace,
+        };
+      }
+    } catch (err: any) {
+      // fail-closed: שגיאה ב-node נחשבת חסימה (כמו getLLMDecision שמחזיר false בכשל).
+      const durationMs = Date.now() - start;
+      const entry: NodeTrace = {
+        node: node.name,
+        status: "error",
+        reason: err?.message ?? "node-error",
+        durationMs,
+        input: ctx.text,
+      };
+      trace.push(entry);
+      logStep(workflowName, entry, {
+        profileId: ctx.profileId,
+        stack: err?.stack,
+      });
+
+      return {
+        allowed: false,
+        reason: `error-in-${node.name}`,
+        blockedBy: node.name,
+        trace,
+      };
+    }
+  }
+
+  logger.info(
+    JSON.stringify({
+      workflow: workflowName,
+      event: "workflow.passed",
+      profileId: ctx.profileId,
+    }),
+  );
+
+  return { allowed: true, reason: "passed-all-nodes", trace };
+}
+
+/* ============================================================
+ * Transform pipeline (Instructions building)
+ * ============================================================ */
+
+export async function runTransformPipeline<TCtx>(
+  workflowName: string,
+  nodes: TransformNode<TCtx>[],
+  initial: TCtx,
+): Promise<{ context: TCtx; trace: NodeTrace[] }> {
+  const trace: NodeTrace[] = [];
+  let ctx = initial;
+
+  for (const node of nodes) {
+    const start = Date.now();
+    const before = ctx;
+
+    try {
+      ctx = await node.run(ctx);
+      const durationMs = Date.now() - start;
+
+      const entry: NodeTrace = {
+        node: node.name,
+        status: "ok",
+        durationMs,
+        input: before,
+        output: ctx,
+      };
+      trace.push(entry);
+      logStep(workflowName, entry);
+    } catch (err: any) {
+      const durationMs = Date.now() - start;
+      const entry: NodeTrace = {
+        node: node.name,
+        status: "error",
+        reason: err?.message ?? "node-error",
+        durationMs,
+        input: before,
+      };
+      trace.push(entry);
+      logStep(workflowName, entry, { stack: err?.stack });
+      throw err; // בניית הנחיות שנכשלת — לא בולעים בשקט.
+    }
+  }
+
+  return { context: ctx, trace };
+}

--- a/server/src/workflows/runner.ts
+++ b/server/src/workflows/runner.ts
@@ -82,7 +82,7 @@ export async function runGuardPipeline(
         durationMs,
         input: ctx.text,
         output: { verdict: result.verdict, reason: result.reason },
-        metadata: result.metadata,
+        metadata: result.metadata ?? {},
       };
       trace.push(entry);
       logStep(workflowName, entry, { profileId: ctx.profileId });

--- a/server/src/workflows/types.ts
+++ b/server/src/workflows/types.ts
@@ -1,0 +1,85 @@
+/**
+ * server/src/workflows/types.ts
+ *
+ * טיפוסים משותפים לכל ה-workflows (Input / Instructions / Output).
+ *
+ * שני סוגי nodes:
+ *  - GuardNode      → מחזיר verdict (allow/block). משמש ל-Input ו-Output filtering.
+ *  - TransformNode  → ממיר/מעשיר context. משמש לבניית ההנחיות (Instructions).
+ */
+
+/* ============================================================
+ * Guard nodes (Input / Output filtering)
+ * ============================================================ */
+
+export type Verdict = "allow" | "block";
+
+/** מה ש-node בודק מחזיר פנימית (לא exception). */
+export interface NodeResult {
+  verdict: Verdict;
+  /** מזהה קצר וקריא של הסיבה, למשל "blocked-by-llm" / "allowed-by-llm". */
+  reason: string;
+  /** מידע נוסף לטובת ה-trace ובניית תשובת הדמה (אופציונלי). */
+  metadata?: Record<string, unknown>;
+}
+
+/** ה-context שזורם דרך guard pipeline. */
+export interface GuardContext {
+  /** הטקסט שמסונן. */
+  text: string;
+  /** הפרופיל המלא (כמו שמגיע מ-getFullProfileById). */
+  profile: any;
+  /** מזהה לפרופיל ללוגים. */
+  profileId: string;
+}
+
+export interface GuardNode {
+  /** שם ייחודי וקריא — מופיע ב-trace וב-structured logs. */
+  name: string;
+  run(ctx: GuardContext): Promise<NodeResult> | NodeResult;
+}
+
+/* ============================================================
+ * Transform nodes (Instructions building)
+ * ============================================================ */
+
+/** ה-context שזורם דרך transform pipeline (בניית ההנחיות). */
+export interface InstructionsContext {
+  profile: any;
+  /** מחרוזת ה-system prompt שנבנית בהדרגה ע"י ה-nodes. */
+  systemPrompt: string;
+}
+
+export interface TransformNode<TCtx> {
+  name: string;
+  run(ctx: TCtx): Promise<TCtx> | TCtx;
+}
+
+/* ============================================================
+ * Trace & results
+ * ============================================================ */
+
+export type NodeStatus = Verdict | "error" | "ok";
+
+/** רשומת trace לכל node שרץ — input + output + זמן. */
+export interface NodeTrace {
+  node: string;
+  status: NodeStatus;
+  reason?: string;
+  durationMs: number;
+  /** snapshot של מה שה-node קיבל. */
+  input?: unknown;
+  /** snapshot של מה שה-node החזיר. */
+  output?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+/** תוצאת guard pipeline (input/output). */
+export interface GuardWorkflowResult {
+  allowed: boolean;
+  reason: string;
+  /** שם ה-node שחסם (אם נחסם). */
+  blockedBy?: string;
+  /** trace מלא של כל ה-nodes שרצו. */
+  trace: NodeTrace[];
+}


### PR DESCRIPTION
- Extract content filtering into dedicated workflows (input/output/instructions)
- Add workflow runner with typed nodes and shared types
- Simplify filterService by delegating to workflow pipeline
- Add blockedResponse helper for consistent block responses
- Wire proxyFilter into all proxy routes (chat, responses, anthropic, images)