### PR TITLE
fix(org): require admin on GET /organizations/pending (#124)

### DIFF
--- a/server/src/routes/organizationRouter.ts
+++ b/server/src/routes/organizationRouter.ts
@@ -53,7 +53,7 @@ router.post("/public-request", publicRequestOrganizationHandler);
 router.use(authenticateToken);
 
 // 1. PROTECTED STATIC ROUTES (נתיבים סטטיים תמיד ראשונים)
-router.get("/pending", getPendingOrganizationsHandler); // System Admin only
+router.get("/pending", requireAdmin, getPendingOrganizationsHandler); // System Admin only
 router.patch("/pending/:id", requireAdmin, updateOrganizationHandler); // מעדכן את הסטטוס של הארגון הממתין מול ה-DB - Admin only
 router.get("/admin/all", requireAdmin, getAllOrganizationsHandler); // System Admin only - full list with stats
 router.get("/my", getMyOrganizationHandler); // Current user's own organization (any status)


### PR DESCRIPTION
Any authenticated user, including plain 'user' role, could list every pending organization request - exposing the requesting owner's name, email, and org description. Added requireAdmin, matching the other admin-only routes in this router. Verified: plain user now gets 403, admin still gets 200.