### PR TITLE
chore(org): remove duplicate schema index on name (#129)

### DIFF
--- a/server/src/models/organization.ts
+++ b/server/src/models/organization.ts
@@ -42,9 +42,9 @@ const OrganizationSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-// Index for faster lookups
+// Index for faster lookups (name's unique index is already created by
+// `unique: true` on the field above - no need to declare it again here)
 OrganizationSchema.index({ ownerId: 1 });
-OrganizationSchema.index({ name: 1 });
 
 OrganizationSchema.set("toJSON", {
   transform: (_doc, ret) => {


### PR DESCRIPTION
The name field already declares unique: true, which creates a unique index automatically. The separate OrganizationSchema.index({name: 1}) call was a second, redundant index on the same field - the source of the 'Duplicate schema index on {name:1} for model Organization' warning on every server start. Verified: warning no longer appears on startup.