### PR TITLE
fix(org): validate owner email format in public org signup

### DIFF
--- a/server/src/services/__tests__/organizationService.test.ts
+++ b/server/src/services/__tests__/organizationService.test.ts
@@ -380,6 +380,18 @@ describe("organizationService.publicRequestOrganization", () => {
     expect(mockedRegister).not.toHaveBeenCalled();
   });
 
+  it("throws if the owner email format is invalid", async () => {
+    await expect(
+      organizationService.publicRequestOrganization({
+        ...input,
+        ownerEmail: "not-an-email",
+      })
+    ).rejects.toThrow("כתובת האימייל אינה תקינה");
+
+    expect(mockedRepo.findOrganizationByName).not.toHaveBeenCalled();
+    expect(mockedRegister).not.toHaveBeenCalled();
+  });
+
   it("rolls back the created user if organization creation fails on a duplicate name", async () => {
     mockedRepo.findOrganizationByName.mockResolvedValue(null as any);
     mockedRegister.mockResolvedValue({ user: { _id: "user1" } } as any);

--- a/server/src/services/organizationService.ts
+++ b/server/src/services/organizationService.ts
@@ -191,6 +191,8 @@ export async function getPendingOrganizationsForAdmin() {
  * required — this IS the registration for org owners. Called from a public,
  * unauthenticated endpoint.
  */
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export async function publicRequestOrganization(data: {
   ownerName: string;
   ownerEmail: string;
@@ -198,6 +200,10 @@ export async function publicRequestOrganization(data: {
   orgName: string;
   orgDescription?: string;
 }) {
+  if (!EMAIL_REGEX.test(data.ownerEmail)) {
+    throw new Error("כתובת האימייל אינה תקינה");
+  }
+
   // בדיקה מוקדמת - נמנעת מיצירת משתמש כשברור מראש ששם הארגון תפוס
   const existingOrg = await repo.findOrganizationByName(data.orgName);
   if (existingOrg) {


### PR DESCRIPTION
## Summary
- Closes #132
- Adds email-format validation in `organizationService.publicRequestOrganization`, before creating the user/organization. Prevents malformed emails from silently breaking later approval/rejection email sends.

## Test plan
- [x] organizationService.test.ts updated and passing (40 tests)
- [ ] CI green