### PR TITLE
feat(org): add new users to an organization via a form

### DIFF
--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -27,6 +27,7 @@ export const API_ENDPOINTS = {
     all: `${API_BASE_URL}/organizations/admin/all`,
     detail: (id: string) => `${API_BASE_URL}/organizations/${id}`,
     users: (id: string) => `${API_BASE_URL}/organizations/${id}/users`,
+    members: (id: string) => `${API_BASE_URL}/organizations/${id}/members`,
     stats: (id: string) => `${API_BASE_URL}/organizations/${id}/stats`,
     suspend: (id: string) => `${API_BASE_URL}/organizations/${id}/suspend`,
     activate: (id: string) => `${API_BASE_URL}/organizations/${id}/activate`,

--- a/client/src/features/organizations/api/organizationApi.ts
+++ b/client/src/features/organizations/api/organizationApi.ts
@@ -97,6 +97,21 @@ export const publicRequestOrganization = async (
   });
 };
 
+// יצירת משתמש חדש בארגון + סיסמה זמנית שנוצרת אוטומטית
+export const createOrganizationMember = async (
+  orgId: string,
+  data: { name: string; email: string; role?: string }
+): Promise<{
+  success: boolean;
+  user: { _id: string; name: string; email: string };
+  temporaryPassword: string;
+}> => {
+  return apiCall(API_ENDPOINTS.adminOrganizations.members(orgId), {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+};
+
 // הארגון של המשתמש הנוכחי (בכל סטטוס)
 export const getMyOrganization = async (): Promise<{ organization: AdminOrganization | null }> => {
   return apiCall(API_ENDPOINTS.adminOrganizations.my, { method: "GET" });

--- a/client/src/features/organizations/components/OrganizationDetail.tsx
+++ b/client/src/features/organizations/components/OrganizationDetail.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  createOrganizationMember,
   getOrganizationDetail,
   getOrganizationStats,
   getOrganizationUsers,
@@ -21,6 +22,44 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
   const [users, setUsers] = useState<OrganizationUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [memberName, setMemberName] = useState("");
+  const [memberEmail, setMemberEmail] = useState("");
+  const [addingMember, setAddingMember] = useState(false);
+  const [addMemberError, setAddMemberError] = useState<string | null>(null);
+  const [createdCredentials, setCreatedCredentials] = useState<{
+    email: string;
+    password: string;
+  } | null>(null);
+
+  const reloadUsers = async () => {
+    const usersData = await getOrganizationUsers(orgId);
+    setUsers(Array.isArray(usersData) ? usersData : []);
+  };
+
+  const handleAddMember = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!memberName.trim() || !memberEmail.trim()) {
+      setAddMemberError("יש למלא שם וכתובת אימייל");
+      return;
+    }
+    try {
+      setAddingMember(true);
+      setAddMemberError(null);
+      const result = await createOrganizationMember(orgId, {
+        name: memberName.trim(),
+        email: memberEmail.trim(),
+      });
+      setCreatedCredentials({ email: result.user.email, password: result.temporaryPassword });
+      setMemberName("");
+      setMemberEmail("");
+      await reloadUsers();
+    } catch (err: unknown) {
+      setAddMemberError(err instanceof Error ? err.message : "הוספת המשתמש נכשלה");
+    } finally {
+      setAddingMember(false);
+    }
+  };
 
   useEffect(() => {
     if (!orgId) return;
@@ -91,6 +130,39 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
           <div className="org-card-value">${(stats?.totalCost ?? 0).toFixed(2)}</div>
         </div>
       </div>
+
+      <h3>הוספת משתמש חדש לארגון</h3>
+      <form onSubmit={handleAddMember} className="org-request-form">
+        <input
+          className="orgs-search"
+          value={memberName}
+          onChange={(e) => setMemberName(e.target.value)}
+          placeholder="שם מלא"
+        />
+        <input
+          type="email"
+          className="orgs-search"
+          value={memberEmail}
+          onChange={(e) => setMemberEmail(e.target.value)}
+          placeholder="כתובת אימייל"
+        />
+        {addMemberError && <div className="orgs-error">{addMemberError}</div>}
+        <button type="submit" className="orgs-btn orgs-btn-activate" disabled={addingMember}>
+          {addingMember ? "מוסיף..." : "הוסף משתמש"}
+        </button>
+      </form>
+
+      {createdCredentials && (
+        <div className="org-pending-card">
+          <p>המשתמש נוצר בהצלחה! פרטי ההתחברות שיש למסור לו:</p>
+          <p>
+            <strong>אימייל:</strong> {createdCredentials.email}
+          </p>
+          <p>
+            <strong>סיסמה זמנית:</strong> {createdCredentials.password}
+          </p>
+        </div>
+      )}
 
       <h3>משתמשי הארגון ({users.length})</h3>
       {users.length === 0 ? (

--- a/server/src/controllers/organizationController.ts
+++ b/server/src/controllers/organizationController.ts
@@ -7,6 +7,7 @@ import {
   deleteOrganization,
   getOrganizationUsers,
   addUserToOrganization,
+  createOrganizationMember,
   removeUserFromOrganization,
   addUserToOrganizationByEmail,
   getOrganizationForUser,
@@ -219,6 +220,51 @@ export async function addUserToOrganizationHandler(
   } catch (error: any) {
     logger.error("Failed to add user to organization", { error });
     res.status(400).json({ error: error.message || "Failed to add user" });
+  }
+}
+
+/**
+ * Create a brand-new user account directly inside an organization,
+ * with a generated temporary password (Admin or Org Owner)
+ */
+export async function createOrganizationMemberHandler(
+  req: Request<{ id: string }>,
+  res: Response
+) {
+  try {
+    const user = (req as any).user;
+    const orgId = req.params.id;
+    const { name, email, role } = req.body;
+
+    if (!name?.trim() || !email?.trim()) {
+      return res.status(400).json({ error: "יש למלא שם וכתובת אימייל" });
+    }
+
+    const organization = await getOrganizationById(orgId);
+    if (!organization) {
+      return res.status(404).json({ error: "Organization not found" });
+    }
+
+    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
+
+    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+
+    const { user: newUser, temporaryPassword } = await createOrganizationMember(orgId, {
+      name: name.trim(),
+      email: email.trim(),
+      role,
+    });
+
+    res.status(201).json({
+      success: true,
+      user: { _id: newUser._id, name: newUser.name, email: newUser.email },
+      temporaryPassword,
+    });
+  } catch (error: any) {
+    logger.error("Failed to create organization member", { error });
+    res.status(400).json({ error: error.message || "Failed to create organization member" });
   }
 }
 

--- a/server/src/routes/organizationRouter.ts
+++ b/server/src/routes/organizationRouter.ts
@@ -7,6 +7,7 @@ import {
   deleteOrganizationHandler,
   getOrganizationUsersHandler,
   addUserToOrganizationHandler,
+  createOrganizationMemberHandler,
   removeUserFromOrganizationHandler,
   addUserByEmailToOrganizationHandler,
   topUpOrganizationWalletHandler,
@@ -82,6 +83,7 @@ router.get("/:id/stats", getOrganizationStatsHandler);      // Admin or Org Owne
 // Management of Users inside Organization (blocked until org is approved, admins bypass)
 router.get("/:id/users", requireApprovedOrg, getOrganizationUsersHandler); // Admin or approved Org Owner
 router.post("/:id/users", requireApprovedOrg, addUserToOrganizationHandler); // Admin or approved Org Owner
+router.post("/:id/members", requireApprovedOrg, createOrganizationMemberHandler); // Admin or approved Org Owner - creates a brand-new user + temp password
 router.delete("/users/:userId", removeUserFromOrganizationHandler); // Admin or Org Owner
 router.post("/:id/users/by-email", requireApprovedOrg, addUserByEmailToOrganizationHandler); // Admin or approved Org Owner
 

--- a/server/src/services/__tests__/organizationService.test.ts
+++ b/server/src/services/__tests__/organizationService.test.ts
@@ -327,6 +327,73 @@ describe("organizationService.addUserToOrganizationByEmail", () => {
   });
 });
 
+describe("organizationService.createOrganizationMember", () => {
+  const memberData = { name: "New Member", email: "member@example.com" };
+
+  it("throws if the organization does not exist", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue(null as any);
+
+    await expect(
+      organizationService.createOrganizationMember("org1", memberData)
+    ).rejects.toThrow("Organization not found");
+
+    expect(mockedRegister).not.toHaveBeenCalled();
+  });
+
+  it("throws when the organization already has maxUsers members", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({
+      _id: "org1",
+      settings: { maxUsers: 2 },
+    } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(2);
+
+    await expect(
+      organizationService.createOrganizationMember("org1", memberData)
+    ).rejects.toThrow("הארגון הגיע למספר המשתמשים המרבי המותר (2)");
+
+    expect(mockedRegister).not.toHaveBeenCalled();
+  });
+
+  it("registers a new user linked to the organization with a generated password", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({ _id: "org1" } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(0);
+    mockedRegister.mockResolvedValue({
+      user: { _id: "newUser1", name: "New Member", email: "member@example.com" },
+    } as any);
+
+    const result = await organizationService.createOrganizationMember("org1", memberData);
+
+    expect(mockedRegister).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "member@example.com",
+        name: "New Member",
+        organizationId: "org1",
+        role: "user",
+        skipEmailVerification: true,
+      })
+    );
+    expect(result.user).toEqual({
+      _id: "newUser1",
+      name: "New Member",
+      email: "member@example.com",
+    });
+    expect(typeof result.temporaryPassword).toBe("string");
+    expect(result.temporaryPassword.length).toBeGreaterThan(0);
+  });
+
+  it("uses the given role instead of the default", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({ _id: "org1" } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(0);
+    mockedRegister.mockResolvedValue({ user: { _id: "newUser1" } } as any);
+
+    await organizationService.createOrganizationMember("org1", { ...memberData, role: "admin" });
+
+    expect(mockedRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ role: "admin" })
+    );
+  });
+});
+
 describe("organizationService.topUpOrganizationWallet", () => {
   it("throws if the organization does not exist", async () => {
     mockedRepo.getOrganizationById.mockResolvedValue(null as any);

--- a/server/src/services/organizationService.ts
+++ b/server/src/services/organizationService.ts
@@ -1,9 +1,14 @@
+import crypto from "crypto";
 import * as repo from "../repositories/organizationRepository";
 import * as userRepo from "../repositories/userRepository";
 import { UsageLog } from "../models";
 import { register } from "./authService";
 import { sendOrgApprovalRequestEmail, sendOrgApprovedEmail, sendOrgStatusEmail } from "../utils/email";
 import logger from "../logger";
+
+function generateTemporaryPassword(): string {
+  return crypto.randomBytes(9).toString("base64").replace(/[^a-zA-Z0-9]/g, "");
+}
 
 export async function createOrganization(data: any) {
   try {
@@ -152,6 +157,47 @@ export async function addUserToOrganizationByEmail(
   }
 
   return addUserToOrganization(orgId, user._id.toString(), role);
+}
+
+/**
+ * Create a brand-new user account (with a generated temporary password)
+ * directly inside an organization. Used by org owners/admins adding members
+ * who don't already have a SafeAI account.
+ */
+export async function createOrganizationMember(
+  orgId: string,
+  data: { name: string; email: string; role?: string }
+) {
+  try {
+    const organization = await repo.getOrganizationById(orgId);
+    if (!organization) {
+      throw new Error("Organization not found");
+    }
+
+    const maxUsers = (organization as any).settings?.maxUsers ?? 10;
+    const currentUserCount = await userRepo.countUsersByOrganization(orgId);
+    if (currentUserCount >= maxUsers) {
+      throw new Error(`הארגון הגיע למספר המשתמשים המרבי המותר (${maxUsers})`);
+    }
+
+    const temporaryPassword = generateTemporaryPassword();
+
+    const { user } = await register({
+      email: data.email,
+      password: temporaryPassword,
+      name: data.name,
+      organizationId: orgId,
+      role: data.role || "user",
+      skipEmailVerification: true,
+    });
+
+    logger.info("Organization member created", { orgId, userId: user._id });
+
+    return { user, temporaryPassword };
+  } catch (error) {
+    logger.error("Failed to create organization member", { error, orgId });
+    throw error;
+  }
 }
 
 export async function topUpOrganizationWallet(orgId: string, amount: number) {


### PR DESCRIPTION
## Summary
- Closes #142
- New `organizationService.createOrganizationMember`: registers a brand-new user with a generated temporary password and links it directly to the organization (enforces the existing maxUsers limit).
- New endpoint: `POST /organizations/:id/members` (admin or approved org owner).
- New "add member" form in `OrganizationDetail`, showing the generated email/password once created (used later by #143 for the Excel export).

## Test plan
- [x] organizationService.test.ts updated and passing (44 tests)
- [ ] CI green
- [ ] Manual: add a member from the org detail screen, confirm temporary password is shown and the user can log in with it