### PR TITLE
fix(org): remove dead plaintext apiKey field from ProviderKey schema (#277)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -78,7 +78,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1021,7 +1020,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -1757,7 +1755,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.2.tgz",
       "integrity": "sha512-zRWROdDbeIghFIT05ZYc+0cCkQFBy7sN/VjFc41qJ1fuq+lfgGDotVUXLuVqVe288jSpo/VGmy/iFLIQTc9mwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2019,7 +2016,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.2.tgz",
       "integrity": "sha512-SsVnh5ruM9QjgOGbhJjegHAIADuoE+9Sb0UV+lyxAeuEwO98JpVmE926Yur9abzUAA9MWZZ/XBIzoA5q0a4dBQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2138,7 +2134,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.2.tgz",
       "integrity": "sha512-kgGg3LXYnEEttqM6CsiSLxRVU5055vON1T5xipskmbdDtV/xXTykzbISiX3ND5zYw+BG7hF8COEKLt1iLo6LbA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2165,7 +2160,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.2.tgz",
       "integrity": "sha512-WPmMf6+CXEgVpsxFGj20DYLt0gNU2zBATmxSPN5L+sDUx3gKXVjFtQxhKvrhaba5ubO45rIV1hJdo0AGu9TmBA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2180,7 +2174,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.2.tgz",
       "integrity": "sha512-4eBV9Fx16ZZUJuO4AvHzykxdYXfF/iMjpoI8q9PHvxOe+xx8tNa4ONhZMKJLpgCKEECJiBkQmr0gOmarzB0MtA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.4.1",
         "prosemirror-commands": "^1.7.1",
@@ -2394,7 +2387,6 @@
       "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2410,7 +2402,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2420,7 +2411,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2491,7 +2481,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2745,7 +2734,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3087,7 +3075,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4007,7 +3994,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6720,7 +6706,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6961,7 +6946,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6971,7 +6955,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6983,8 +6966,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7018,7 +7000,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7156,8 +7137,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7969,7 +7949,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8235,7 +8214,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8491,7 +8469,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/components/TopNavigation.tsx
+++ b/client/src/components/TopNavigation.tsx
@@ -28,10 +28,12 @@ export default function TopNavigation() {
   }, []);
 
   // Close menus on navigation
-  useEffect(() => {
+  const [prevLocationKey, setPrevLocationKey] = useState(location.key);
+  if (location.key !== prevLocationKey) {
+    setPrevLocationKey(location.key);
     setShowUserMenu(false);
     setShowDevMenu(false);
-  }, [location]);
+  }
 
   const handleLogout = () => {
     logout();

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -64,6 +64,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth(): AuthContextValue {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error("useAuth must be used inside AuthProvider");

--- a/client/src/features/auth/LoginForm.tsx
+++ b/client/src/features/auth/LoginForm.tsx
@@ -15,7 +15,7 @@ interface User {
   email: string;
   name: string;
   role: string;
-  mode: string;
+  mode: "BYOK" | "MANAGED";
   profileId?: string;
 }
 

--- a/client/src/features/forum/AddPostModal.tsx
+++ b/client/src/features/forum/AddPostModal.tsx
@@ -25,7 +25,7 @@ export const AddPostModal: React.FC<AddPostModalProps> = ({ isOpen, onClose, onP
     fetch('http://localhost:5000/api/tags')
       .then((res) => res.json())
       .then((data) => {
-        const formatted = Array.isArray(data) ? data.map((tag: any) => ({
+        const formatted = Array.isArray(data) ? data.map((tag: { _id?: string; name: string }) => ({
           value: tag._id || tag.name,
           label: tag.name
         })) : [];
@@ -188,7 +188,7 @@ const response = await fetch('http://localhost:5000/api/posts', {
                   <small style={{ color: '#065f46', fontWeight: 'bold', display: 'block', marginBottom: '5px' }}>
                     💡 אולי כבר יש מענה לפוסט שלך? בדקי פוסטים דומים:
                   </small>
-                  {similarPosts.map((post: any) => (
+                  {similarPosts.map((post: { _id: string; title: string }) => (
                     <div key={post._id} style={{ marginBottom: '4px' }}>
                       <a href={`/forum/post/${post._id}`} target="_blank" rel="noreferrer" style={{ fontSize: '13px', color: '#059669', textDecoration: 'underline' }}>
                         {post.title}
@@ -244,7 +244,7 @@ const response = await fetch('http://localhost:5000/api/posts', {
               isMulti
               options={allTags}
               value={selectedTags}
-              onChange={(newValue: any) => setSelectedTags(newValue || [])}
+              onChange={(newValue: readonly { value: string; label: string }[] | null) => setSelectedTags(newValue ? [...newValue] : [])}
               inputValue={tagInputValue}
               onInputChange={(val) => setTagInputValue(val)}
               placeholder="נא להכניס לפחות 3 אותיות"

--- a/client/src/features/forum/ForumPage.tsx
+++ b/client/src/features/forum/ForumPage.tsx
@@ -343,7 +343,7 @@ export const ForumPage: React.FC = () => {
                         {post.tags && Array.isArray(post.tags) && post.tags.map((tag: { _id: string; name: string } | string) => {
                           const tagName = typeof tag === 'object' && tag !== null ? tag.name : tag;
                           return (
-                            <span key={tag._id || tagName} onClick={(e) => { e.stopPropagation(); setSearchQuery(tagName); setCurrentPage(1); }} style={{ backgroundColor: '#f1f5f9', color: '#475569', padding: '1px 8px', borderRadius: '12px', fontSize: '11px', fontWeight: '500', border: '1px solid #e2e8f0', cursor: 'pointer' }}>
+                            <span key={typeof tag === 'object' ? tag._id : tag} onClick={(e) => { e.stopPropagation(); setSearchQuery(tagName); setCurrentPage(1); }} style={{ backgroundColor: '#f1f5f9', color: '#475569', padding: '1px 8px', borderRadius: '12px', fontSize: '11px', fontWeight: '500', border: '1px solid #e2e8f0', cursor: 'pointer' }}>
                              {tagName}
                             </span>
                           );

--- a/client/src/features/forum/ForumPage.tsx
+++ b/client/src/features/forum/ForumPage.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AddPostModal } from './AddPostModal';
-import TextStyle from '@tiptap/extension-text-style';
-import Color from '@tiptap/extension-color';
-import Highlight from '@tiptap/extension-highlight';
-import FontFamily from '@tiptap/extension-font-family';
-import TextAlign from '@tiptap/extension-text-align';
 
 interface Post {
   _id: string;
@@ -68,7 +63,7 @@ export const ForumPage: React.FC = () => {
           setCurrentPage(data.currentPage || page);
           setTotalPages(data.totalPages || 1);
 
-          localStorage.setItem('user_posts_backup', JSON.stringify(data.posts.map((p: any) => ({ _id: p._id, title: p.title }))));
+          localStorage.setItem('user_posts_backup', JSON.stringify(data.posts.map((p: { _id: string; title: string }) => ({ _id: p._id, title: p.title }))));
         } else {
           setPosts(Array.isArray(data) ? data : []);
           setCurrentPage(1);
@@ -118,12 +113,12 @@ export const ForumPage: React.FC = () => {
             const currentPostIds = posts.map(p => p._id);
             
             // 1. סינון פוסטים שמוצגים כרגע בעמוד
-            let filtered = data.filter((p: any) => !currentPostIds.includes(p._id));
+            const filtered = data.filter((p: { _id: string }) => !currentPostIds.includes(p._id));
 
             // 2. מניעת כפילויות פנימיות
             const uniqueMap = new Map();
             filtered.forEach(p => uniqueMap.set(p._id, p));
-            let finalRecommendations = Array.from(uniqueMap.values());
+            const finalRecommendations = Array.from(uniqueMap.values());
 
             // 3. מנגנון השלמה (Fallback): אם נשארו פחות מ-3 פוסטים לאחר הסינון,
             // ניקח פוסטים אחרים מהעמוד הנוכחי כדי להשלים לשלשה קבועה
@@ -345,7 +340,7 @@ export const ForumPage: React.FC = () => {
                         {post.isLocked && <span style={{ backgroundColor: '#f59e0b', color: 'white', padding: '1px 6px', borderRadius: '3px', fontSize: '11px', fontWeight: 'bold' }}>🔒 נעול</span>}
 
                         <h3 style={{ margin: 0, fontSize: '21px', color: '#0f172a', fontWeight: 'bold', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{post.title}</h3>
-                        {post.tags && Array.isArray(post.tags) && post.tags.map((tag: any) => {
+                        {post.tags && Array.isArray(post.tags) && post.tags.map((tag: { _id: string; name: string } | string) => {
                           const tagName = typeof tag === 'object' && tag !== null ? tag.name : tag;
                           return (
                             <span key={tag._id || tagName} onClick={(e) => { e.stopPropagation(); setSearchQuery(tagName); setCurrentPage(1); }} style={{ backgroundColor: '#f1f5f9', color: '#475569', padding: '1px 8px', borderRadius: '12px', fontSize: '11px', fontWeight: '500', border: '1px solid #e2e8f0', cursor: 'pointer' }}>

--- a/client/src/features/forum/PostThreadPage.tsx
+++ b/client/src/features/forum/PostThreadPage.tsx
@@ -93,11 +93,11 @@ export const PostThreadPage: React.FC = () => {
             .then((res) => res.json())
             .then((similarData) => {
               if (Array.isArray(similarData)) {
-                let filtered = similarData.filter((p: any) => p._id !== data.post._id);
+                const filtered = similarData.filter((p: { _id: string }) => p._id !== data.post._id);
 
                 const uniqueMap = new Map();
                 filtered.forEach(p => uniqueMap.set(p._id, p));
-                let finalSimilar = Array.from(uniqueMap.values());
+                const finalSimilar = Array.from(uniqueMap.values());
 
                 if (finalSimilar.length < 3) {
                   const backupPosts = JSON.parse(localStorage.getItem('user_posts_backup') || '[]');
@@ -388,7 +388,7 @@ export const PostThreadPage: React.FC = () => {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '10px' }}>
             {post.tags && post.tags.length > 0 && (
               <div style={{ display: 'flex', gap: '5px', flexWrap: 'wrap' }}>
-                {post.tags.map((tag: any, idx) => {
+                {post.tags.map((tag: { name: string } | string, idx: number) => {
                   const tagName = typeof tag === 'object' && tag !== null ? tag.name : tag;
                   return (
                     <span key={idx} style={{ backgroundColor: '#f0fdf4', color: '#16a34a', padding: '1px 6px', borderRadius: '4px', fontSize: '11px', border: '1px solid #bbf7d0', fontWeight: 'bold' }}>
@@ -607,7 +607,7 @@ export const PostThreadPage: React.FC = () => {
                   onChange={(e) => {
                     const val = e.target.value;
                     if (val === 'p') editor.chain().focus().setParagraph().run();
-                    else editor.chain().focus().toggleHeading({ level: Number(val) as any }).run();
+                    else editor.chain().focus().toggleHeading({ level: Number(val) as 1 | 2 | 3 | 4 | 5 | 6 }).run();
                   }}
                   style={{ border: '1px solid #e5e7eb', borderRadius: '4px', padding: '2px 4px', fontSize: '12px', color: '#374151', outline: 'none' }}
                 >

--- a/client/src/features/safeai-ui/UserApiKeysPage.tsx
+++ b/client/src/features/safeai-ui/UserApiKeysPage.tsx
@@ -153,7 +153,7 @@ export default function UserApiKeysPage() {
     return <div className="loading-state">טוען...</div>;
   }
 
-  if (!user) {
+  if (!user || !user._id) {
     return (
       <div className="empty-state">
         <h2>לא מחובר</h2>
@@ -161,6 +161,8 @@ export default function UserApiKeysPage() {
       </div>
     );
   }
+
+  const userId = user._id;
 
   return (
     <div>
@@ -330,11 +332,11 @@ export default function UserApiKeysPage() {
 
       {showAddModal && user && (
         <ProviderKeysManagement
-          userId={user._id}
+          userId={userId}
           userEmail={user.email}
           onClose={() => {
             setShowAddModal(false);
-            fetchKeys(user._id);
+            fetchKeys(userId);
           }}
         />
       )}

--- a/client/src/features/safeai-ui/UserDashboard.tsx
+++ b/client/src/features/safeai-ui/UserDashboard.tsx
@@ -38,7 +38,7 @@ export default function UserDashboard({ user }: UserDashboardProps) {
           u.profileId && typeof u.profileId === "object"
             ? String((u.profileId as { _id: unknown })._id)
             : (u.profileId as string | undefined);
-        setUser({ ...(u as Parameters<typeof setUser>[0]), profileId });
+        setUser({ ...(u as unknown as Parameters<typeof setUser>[0]), profileId });
       })
       .catch(() => {});
     return () => controller.abort();

--- a/client/src/features/tenders/CreateTender.tsx
+++ b/client/src/features/tenders/CreateTender.tsx
@@ -124,7 +124,7 @@ export default function CreateTender({ onSuccess }: CreateTenderProps) {
     setFormData((current) => ({
       ...current,
       [name]: type === 'checkbox' ? (event.target as HTMLInputElement).checked : value,
-    } as any))
+    } as TenderFormData))
   }
 
   const handleAgentChange = (index: number, value: string) => {
@@ -449,7 +449,7 @@ export default function CreateTender({ onSuccess }: CreateTenderProps) {
                 id="duration-unit"
                 name="duration-unit"
                 value={formData.duration.unit}
-                onChange={(e) => setFormData((c) => ({ ...c, duration: { ...c.duration, unit: e.target.value as any } }))}
+                onChange={(e) => setFormData((c) => ({ ...c, duration: { ...c.duration, unit: e.target.value as TenderFormData['duration']['unit'] } }))}
               >
                 {timeUnits.map((u) => (
                   <option key={u} value={u}>{u}</option>

--- a/client/src/features/tenders/ManageTenderDetails.tsx
+++ b/client/src/features/tenders/ManageTenderDetails.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { apiCall, API_ENDPOINTS } from '../../config/api'
-import type { Tender } from './types'
+import type { Tender, TenderTime, TenderTimeUnit } from './types'
 
 interface ManageTenderDetailsProps {
   tender: Tender
@@ -292,16 +292,16 @@ export default function ManageTenderDetails({
             <div style={{ display: 'flex', gap: '8px' }}>
               <input
                 id="tender-timeRequired-value"
-                value={(draftTender.timeRequired as any)?.value ?? 0}
-                onChange={(e) => handleFieldChange('timeRequired', { ...(draftTender.timeRequired as any), value: Number(e.target.value) } as any)}
+                value={draftTender.timeRequired?.value ?? 0}
+                onChange={(e) => handleFieldChange('timeRequired', { ...draftTender.timeRequired, value: Number(e.target.value) } as TenderTime)}
                 style={{ padding: '10px', borderRadius: '6px', border: '1px solid #ccc', width: '40%' }}
                 type="number"
                 min={0}
               />
               <select
                 id="tender-timeRequired-unit"
-                value={(draftTender.timeRequired as any)?.unit ?? 'ימים'}
-                onChange={(e) => handleFieldChange('timeRequired', { ...(draftTender.timeRequired as any), unit: e.target.value } as any)}
+                value={draftTender.timeRequired?.unit ?? 'ימים'}
+                onChange={(e) => handleFieldChange('timeRequired', { ...draftTender.timeRequired, unit: e.target.value as TenderTimeUnit } as TenderTime)}
                 style={{ padding: '10px', borderRadius: '6px', border: '1px solid #ccc', width: '60%' }}
               >
                 {timeUnits.map((u) => (
@@ -314,7 +314,7 @@ export default function ManageTenderDetails({
             <label htmlFor="tender-budget" style={{ display: 'block', fontWeight: 'bold', marginBottom: '6px' }}>תקציב</label>
             <input
               id="tender-budget"
-              value={(draftTender.budget as any) ?? 0}
+              value={draftTender.budget ?? 0}
               onChange={(e) => handleFieldChange('budget', Number(e.target.value))}
               style={{ width: '100%', padding: '10px', borderRadius: '6px', border: '1px solid #ccc' }}
               type="number"

--- a/client/src/pages/OrganizationUsersPage.tsx
+++ b/client/src/pages/OrganizationUsersPage.tsx
@@ -248,6 +248,22 @@ export default function OrganizationUsersPage() {
     }
   };
 
+  const handleDownloadAllUsersExcel = () => {
+    const rows = users.map((u) => ({
+      "אימייל": u.email,
+      "שם": u.name || "",
+      "תפקיד":
+        u.role === "org_owner" ? "בעל ארגון" : u.role === "admin" ? "מנהל מערכת" : "משתמש",
+      "סטטוס": u.isActive ? "פעיל" : "לא פעיל",
+      "סטטוס הצטרפות": u.lastLogin ? "הצטרף" : "ממתין להתחברות ראשונה",
+      "תאריך הצטרפות": new Date(u.createdAt).toLocaleDateString(),
+    }));
+    const worksheet = XLSX.utils.json_to_sheet(rows);
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, worksheet, "משתמשי הארגון");
+    XLSX.writeFile(workbook, `כל-משתמשי-${organization?.name || "ארגון"}.xlsx`);
+  };
+
   const handleDownloadExcel = () => {
     const loginUrl = `${window.location.origin}/login`;
     const rows = createdMembers.map((m) => ({
@@ -429,7 +445,14 @@ export default function OrganizationUsersPage() {
         </div>
       )}
 
-      <h3>משתמשים בארגון ({users.length})</h3>
+      <div className="org-info-header">
+        <h3>משתמשים בארגון ({users.length})</h3>
+        {users.length > 0 && (
+          <button type="button" className="topup-button" onClick={handleDownloadAllUsersExcel}>
+            ייצוא רשימת משתמשים לאקסל
+          </button>
+        )}
+      </div>
 
       {users.length === 0 ? (
         <p>לא נמצאו משתמשים בארגון זה.</p>

--- a/server/.env.example
+++ b/server/.env.example
@@ -41,3 +41,4 @@ LITELLM_MASTER_KEY=master_key
 # AWS_ACCESS_KEY_ID=הקי_שלך
 # AWS_SECRET_ACCESS_KEY=הסוד_שלך
 # AWS_S3_BUCKET_NAME=שם_הבאקט_שלך
+# AWS_REGION=us-east-1

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,35 +1,32 @@
 # version: "3.8"
 
 services:
-  # 1. בסיס הנתונים PostgreSQL
-  # db:
-  #   image: postgres:16-alpine
-  #   container_name: litellm-db
-  #   restart: unless-stopped
-  #   environment:
-  #     - POSTGRES_USER=llm_user
-  #     - POSTGRES_PASSWORD=llm_pass
-  #     - POSTGRES_DB=litellm_db
-  #   volumes:
-  #     - postgres_data:/var/lib/postgresql/data
+  db:
+    image: postgres:16-alpine
+    container_name: litellm-db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=llm_user
+      - POSTGRES_PASSWORD=llm_pass
+      - POSTGRES_DB=litellm_db
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
-  # 2. MongoDB
-  # mongodb:
-  #   image: mongo:7-jammy
-  #   container_name: safe-ai-mongodb
-  #   restart: unless-stopped
-  #   ports:
-  #     - "27017:27017"
-  #   volumes:
-  #     - mongodb_data:/data/db
+  mongodb:
+    image: mongo:7-jammy
+    container_name: safe-ai-mongodb
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
 
-  # 3. LiteLLM Proxy
   litellm:
     image: ghcr.io/berriai/litellm:main-latest
     container_name: litellm-proxy
     restart: unless-stopped
-    # depends_on:
-    #   - db
+    depends_on:
+      - db
     ports:
       - "4000:4000"
     volumes:
@@ -41,7 +38,6 @@ services:
       - HTTPX_SSL_VERIFY=false
     command: ["--config", "/app/config.yaml", "--port", "4000"]
 
-  # 4. השרת שלך
   server:
     build:
       context: .
@@ -50,7 +46,7 @@ services:
     restart: unless-stopped
     depends_on:
       - litellm
-      # - mongodb
+      - mongodb
     ports:
       - "3001:3001"
     volumes:
@@ -59,7 +55,7 @@ services:
     environment:
       - NODE_ENV=production
       - LITELLM_PROXY_URL=http://litellm:4000
-      - MONGO_URI=${MONGO_URI}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017/safeai}
 
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - SMTP_HOST=${SMTP_HOST}
@@ -70,5 +66,5 @@ services:
       - EMAIL_FROM=${EMAIL_FROM}
 volumes:
   postgres_data:
-  # mongodb_data:
+  mongodb_data:
   node_modules:

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1080.0",
+        "@aws-sdk/s3-request-presigner": "^3.1080.0",
         "@jest/globals": "^30.3.0",
         "@types/multer": "^2.1.0",
         "axios": "^1.13.6",
@@ -20,6 +22,7 @@
         "express-rate-limit": "^8.3.1",
         "google-auth-library": "^10.6.2",
         "jsonwebtoken": "^9.0.3",
+        "langsmith": "^0.7.16",
         "litellm": "^0.12.0",
         "mongoose": "^9.2.2",
         "multer": "^2.2.0",
@@ -27,6 +30,7 @@
         "nodemailer": "^8.0.4",
         "openai": "^6.22.0",
         "resend": "^6.16.0",
+        "uuid": "^14.0.1",
         "winston": "^3.19.0",
         "zod": "^4.3.6"
       },
@@ -40,6 +44,7 @@
         "@types/node": "^25.2.3",
         "@types/nodemailer": "^7.0.11",
         "@types/supertest": "^6.0.2",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "eslint": "^8.57.0",
@@ -103,6 +108,331 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.13.tgz",
+      "integrity": "sha512-USI1N1d+NbCcfjeiYLKIl94PSYykl5IIjj4X3WqdL33Ln5qktA6sjXYct0o/gG2Cte7cuzbXKkDBkzUA4VPHrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1080.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1080.0.tgz",
+      "integrity": "sha512-erKuxbwhYLKs0ZviBeTDvXxC0E4AtugHXLbt5kFk8u9/rQMglh/QJNK5f9KuLjlMrbFSJgkBmjNSY5O03YoK4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.13",
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/credential-provider-node": "^3.972.63",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.59",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.28.tgz",
+      "integrity": "sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@aws-sdk/xml-builder": "^3.972.33",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.0",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.54.tgz",
+      "integrity": "sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.56.tgz",
+      "integrity": "sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.61.tgz",
+      "integrity": "sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/credential-provider-env": "^3.972.54",
+        "@aws-sdk/credential-provider-http": "^3.972.56",
+        "@aws-sdk/credential-provider-login": "^3.972.60",
+        "@aws-sdk/credential-provider-process": "^3.972.54",
+        "@aws-sdk/credential-provider-sso": "^3.972.60",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.60",
+        "@aws-sdk/nested-clients": "^3.997.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.60.tgz",
+      "integrity": "sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/nested-clients": "^3.997.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.63.tgz",
+      "integrity": "sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.54",
+        "@aws-sdk/credential-provider-http": "^3.972.56",
+        "@aws-sdk/credential-provider-ini": "^3.972.61",
+        "@aws-sdk/credential-provider-process": "^3.972.54",
+        "@aws-sdk/credential-provider-sso": "^3.972.60",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.60",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/credential-provider-imds": "^4.4.5",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.54.tgz",
+      "integrity": "sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.60.tgz",
+      "integrity": "sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/nested-clients": "^3.997.28",
+        "@aws-sdk/token-providers": "3.1080.0",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.60",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.60.tgz",
+      "integrity": "sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/nested-clients": "^3.997.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.59.tgz",
+      "integrity": "sha512-KCf/UjbnzV3QIXR1C2MeE9eRUG8EUXUf0V4y65hf2bKWQXzol5f3I8wOhE6OBdEYohn8zHfnC/cyy5+s7/HwLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.28.tgz",
+      "integrity": "sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/fetch-http-handler": "^5.6.2",
+        "@smithy/node-http-handler": "^4.9.2",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1080.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1080.0.tgz",
+      "integrity": "sha512-htvnMiDGioaV5zOEkXi6EBI6md1s2tYVD/h3ihAhvpJpZZ3bS6xsfq313IK8orMi7LpOWIT3ha1fPgXrhc+TCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.38",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.38.tgz",
+      "integrity": "sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/signature-v4": "^5.6.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1080.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1080.0.tgz",
+      "integrity": "sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.28",
+        "@aws-sdk/nested-clients": "^3.997.28",
+        "@aws-sdk/types": "^3.973.15",
+        "@smithy/core": "^3.29.0",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.15.tgz",
+      "integrity": "sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.33.tgz",
+      "integrity": "sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -131,7 +461,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1807,6 +2136,87 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.1.tgz",
+      "integrity": "sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.6.tgz",
+      "integrity": "sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.3.tgz",
+      "integrity": "sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.3.tgz",
+      "integrity": "sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.2.tgz",
+      "integrity": "sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.1",
+        "@smithy/types": "^4.15.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -1954,7 +2364,6 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -2202,7 +2611,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2308,6 +2716,13 @@
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -2378,7 +2793,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2569,7 +2983,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2988,6 +3401,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
@@ -3030,7 +3449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3969,7 +4387,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4169,6 +4586,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
@@ -4233,7 +4656,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7878,6 +8300,39 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
     },
+    "node_modules/langsmith": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.16.tgz",
+      "integrity": "sha512-Cn4PL7ujYQwxAOotesBhOuF2xsEIcW6mwKW41SXhu3WyjmU0R+ywCdbHYMSYh6QCaLg9pTluJMw2+L5ApyrZHg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-queue": "6.6.2"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*",
+        "ws": ">=7"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8716,6 +9171,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8746,6 +9210,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -10008,7 +10500,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10129,6 +10620,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10190,7 +10687,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10273,6 +10769,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -10529,7 +11038,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1080.0",
+    "@aws-sdk/s3-request-presigner": "^3.1080.0",
     "@jest/globals": "^30.3.0",
     "@types/multer": "^2.1.0",
     "axios": "^1.13.6",
@@ -30,6 +32,7 @@
     "express-rate-limit": "^8.3.1",
     "google-auth-library": "^10.6.2",
     "jsonwebtoken": "^9.0.3",
+    "langsmith": "^0.7.16",
     "litellm": "^0.12.0",
     "mongoose": "^9.2.2",
     "multer": "^2.2.0",
@@ -37,6 +40,7 @@
     "nodemailer": "^8.0.4",
     "openai": "^6.22.0",
     "resend": "^6.16.0",
+    "uuid": "^14.0.1",
     "winston": "^3.19.0",
     "zod": "^4.3.6"
   },
@@ -50,6 +54,7 @@
     "@types/node": "^25.2.3",
     "@types/nodemailer": "^7.0.11",
     "@types/supertest": "^6.0.2",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.0",

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -11,6 +11,10 @@ import {
   activateOrganizationHandler,
   addUserToOrganizationHandler,
   removeUserFromOrganizationHandler,
+  createOrganizationMemberHandler,
+  addOrganizationProviderKeyHandler,
+  listOrganizationProviderKeysHandler,
+  deleteOrganizationProviderKeyHandler,
 } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
@@ -26,6 +30,10 @@ jest.mock("../../services/organizationService", () => ({
   removeUserFromOrganization: jest.fn(),
   rejectOrganization: jest.fn(),
   setOrganizationActive: jest.fn(),
+  createOrganizationMember: jest.fn(),
+  addOrganizationProviderKey: jest.fn(),
+  listOrganizationProviderKeys: jest.fn(),
+  deleteOrganizationProviderKey: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -545,5 +553,116 @@ describe("organizationController.removeUserFromOrganizationHandler (#233 ORG-06)
 
     expect(mockedService.removeUserFromOrganization).toHaveBeenCalledWith("user-1");
     expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+});
+
+describe("organizationController.createOrganizationMemberHandler mode (#144 MANAGED_ORG)", () => {
+  it("passes the mode through to createOrganizationMember", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.createOrganizationMember.mockResolvedValue({
+      user: { _id: "newUser1", name: "New Member", email: "member@example.com" },
+      temporaryPassword: "temp123",
+    } as any);
+
+    const req = {
+      params: { id: "org-A" },
+      user: { userId: "owner-A", role: "org_owner" },
+      body: { name: "New Member", email: "member@example.com", mode: "MANAGED_ORG" },
+    } as any;
+    const res = mockRes();
+
+    await createOrganizationMemberHandler(req, res);
+
+    expect(mockedService.createOrganizationMember).toHaveBeenCalledWith(
+      "org-A",
+      expect.objectContaining({
+        name: "New Member",
+        email: "member@example.com",
+        mode: "MANAGED_ORG",
+      })
+    );
+  });
+});
+
+describe("organizationController provider-key endpoints (#144 MANAGED_ORG)", () => {
+  it("addOrganizationProviderKeyHandler adds a key when the org_owner owns the organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.addOrganizationProviderKey.mockResolvedValue({ _id: "key1" } as any);
+
+    const req = {
+      params: { id: "org-A" },
+      user: { userId: "owner-A", role: "org_owner" },
+      body: { provider: "openai", apiKey: "sk-test" },
+    } as any;
+    const res = mockRes();
+
+    await addOrganizationProviderKeyHandler(req, res);
+
+    expect(mockedService.addOrganizationProviderKey).toHaveBeenCalledWith("org-A", {
+      provider: "openai",
+      apiKey: "sk-test",
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("addOrganizationProviderKeyHandler returns 403 for a cross-org attempt", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = {
+      params: { id: "org-B" },
+      user: { userId: "owner-A", role: "org_owner" },
+      body: { provider: "openai", apiKey: "sk-test" },
+    } as any;
+    const res = mockRes();
+
+    await addOrganizationProviderKeyHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedService.addOrganizationProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("listOrganizationProviderKeysHandler lists keys for the owning org_owner", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.listOrganizationProviderKeys.mockResolvedValue([{ _id: "key1" }] as any);
+
+    const req = {
+      params: { id: "org-A" },
+      user: { userId: "owner-A", role: "org_owner" },
+    } as any;
+    const res = mockRes();
+
+    await listOrganizationProviderKeysHandler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith([{ _id: "key1" }]);
+  });
+
+  it("deleteOrganizationProviderKeyHandler deletes a key when an admin requests it", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = {
+      params: { id: "org-B", keyId: "key1" },
+      user: { userId: "admin-1", role: "admin" },
+    } as any;
+    const res = mockRes();
+
+    await deleteOrganizationProviderKeyHandler(req, res);
+
+    expect(mockedService.deleteOrganizationProviderKey).toHaveBeenCalledWith("key1");
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -9,6 +9,8 @@ import {
   rejectOrganizationHandler,
   suspendOrganizationHandler,
   activateOrganizationHandler,
+  addUserToOrganizationHandler,
+  removeUserFromOrganizationHandler,
 } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
@@ -19,6 +21,9 @@ jest.mock("../../services/organizationService", () => ({
   publicRequestOrganization: jest.fn(),
   topUpOrganizationWallet: jest.fn(),
   approveOrganization: jest.fn(),
+  addUserToOrganization: jest.fn(),
+  getOrganizationForUser: jest.fn(),
+  removeUserFromOrganization: jest.fn(),
   rejectOrganization: jest.fn(),
   setOrganizationActive: jest.fn(),
 }));
@@ -408,5 +413,137 @@ describe("organizationController.suspend/activateOrganizationHandler (#231 ORG-0
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ success: true, organization: expect.objectContaining({ isActive: true }) })
     );
+  });
+});
+
+describe("organizationController.addUserToOrganizationHandler (#232 ORG-05)", () => {
+  it("adds a user when the org_owner owns the organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+
+    const req = {
+      params: { id: "org-A" },
+      user: { userId: "owner-A", role: "org_owner" },
+      body: { userId: "user-1", role: "user" },
+    } as any;
+    const res = mockRes();
+
+    await addUserToOrganizationHandler(req, res);
+
+    expect(mockedService.addUserToOrganization).toHaveBeenCalledWith("org-A", "user-1", "user");
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it("returns 403 when an org_owner tries to add a user to a different organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = {
+      params: { id: "org-B" },
+      user: { userId: "owner-A", role: "org_owner" },
+      body: { userId: "user-1" },
+    } as any;
+    const res = mockRes();
+
+    await addUserToOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedService.addUserToOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the organization already reached its maxUsers limit", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.addUserToOrganization.mockRejectedValue(
+      new Error("הארגון הגיע למספר המשתמשים המרבי המותר (10)")
+    );
+
+    const req = {
+      params: { id: "org-A" },
+      user: { userId: "owner-A", role: "org_owner" },
+      body: { userId: "user-1" },
+    } as any;
+    const res = mockRes();
+
+    await addUserToOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe("organizationController.removeUserFromOrganizationHandler (#233 ORG-06)", () => {
+  it("removes a user when the org_owner owns the target user's organization", async () => {
+    mockedService.getOrganizationForUser.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+
+    const req = {
+      params: { userId: "user-1" },
+      user: { userId: "owner-A", role: "org_owner" },
+    } as any;
+    const res = mockRes();
+
+    await removeUserFromOrganizationHandler(req, res);
+
+    expect(mockedService.removeUserFromOrganization).toHaveBeenCalledWith("user-1");
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it("returns 403 when an org_owner tries to remove a user from a different organization (IDOR)", async () => {
+    mockedService.getOrganizationForUser.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = {
+      params: { userId: "user-1" },
+      user: { userId: "owner-A", role: "org_owner" },
+    } as any;
+    const res = mockRes();
+
+    await removeUserFromOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedService.removeUserFromOrganization).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the target user is not in any organization", async () => {
+    mockedService.getOrganizationForUser.mockResolvedValue(null as any);
+
+    const req = {
+      params: { userId: "user-1" },
+      user: { userId: "owner-A", role: "org_owner" },
+    } as any;
+    const res = mockRes();
+
+    await removeUserFromOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(mockedService.removeUserFromOrganization).not.toHaveBeenCalled();
+  });
+
+  it("allows an admin to remove a user from any organization", async () => {
+    mockedService.getOrganizationForUser.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = {
+      params: { userId: "user-1" },
+      user: { userId: "admin-1", role: "admin" },
+    } as any;
+    const res = mockRes();
+
+    await removeUserFromOrganizationHandler(req, res);
+
+    expect(mockedService.removeUserFromOrganization).toHaveBeenCalledWith("user-1");
+    expect(res.status).not.toHaveBeenCalledWith(403);
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -15,6 +15,7 @@ import {
   addOrganizationProviderKeyHandler,
   listOrganizationProviderKeysHandler,
   deleteOrganizationProviderKeyHandler,
+  getPendingOrganizationsHandler,
 } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
@@ -34,6 +35,7 @@ jest.mock("../../services/organizationService", () => ({
   addOrganizationProviderKey: jest.fn(),
   listOrganizationProviderKeys: jest.fn(),
   deleteOrganizationProviderKey: jest.fn(),
+  getPendingOrganizationsForAdmin: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -664,5 +666,25 @@ describe("organizationController provider-key endpoints (#144 MANAGED_ORG)", () 
 
     expect(mockedService.deleteOrganizationProviderKey).toHaveBeenCalledWith("key1");
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+});
+
+describe("organizationController.getPendingOrganizationsHandler (#228 ORG-01)", () => {
+  it("returns a newly-created pending organization so an admin can review it", async () => {
+    mockedService.getPendingOrganizationsForAdmin.mockResolvedValue([
+      { _id: "org1", name: "Acme", status: "pending" },
+    ] as any);
+
+    const req = {} as any;
+    const res = mockRes();
+
+    await getPendingOrganizationsHandler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: [expect.objectContaining({ name: "Acme", status: "pending" })],
+      })
+    );
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -6,6 +6,9 @@ import {
   publicRequestOrganizationHandler,
   topUpOrganizationWalletHandler,
   approveOrganizationHandler,
+  rejectOrganizationHandler,
+  suspendOrganizationHandler,
+  activateOrganizationHandler,
 } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
@@ -16,6 +19,8 @@ jest.mock("../../services/organizationService", () => ({
   publicRequestOrganization: jest.fn(),
   topUpOrganizationWallet: jest.fn(),
   approveOrganization: jest.fn(),
+  rejectOrganization: jest.fn(),
+  setOrganizationActive: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -317,6 +322,91 @@ describe("organizationController.approveOrganizationHandler (#229 ORG-02)", () =
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ error: "ניתן לאשר רק ארגון שממתין לאישור" })
+    );
+  });
+});
+
+describe("organizationController.rejectOrganizationHandler (#230 ORG-03)", () => {
+  it("rejects a pending organization and returns the updated organization", async () => {
+    mockedService.rejectOrganization.mockResolvedValue({
+      _id: "org-A",
+      status: "rejected",
+      isActive: false,
+    } as any);
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await rejectOrganizationHandler(req, res);
+
+    expect(mockedService.rejectOrganization).toHaveBeenCalledWith("org-A");
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        organization: expect.objectContaining({ status: "rejected" }),
+      })
+    );
+  });
+
+  it("returns 400 when the organization is not pending", async () => {
+    mockedService.rejectOrganization.mockRejectedValue(
+      new Error("ניתן לדחות רק ארגון שממתין לאישור")
+    );
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await rejectOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe("organizationController.suspend/activateOrganizationHandler (#231 ORG-04)", () => {
+  it("suspends an active approved organization", async () => {
+    mockedService.setOrganizationActive.mockResolvedValue({
+      _id: "org-A",
+      isActive: false,
+    } as any);
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await suspendOrganizationHandler(req, res);
+
+    expect(mockedService.setOrganizationActive).toHaveBeenCalledWith("org-A", false);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, organization: expect.objectContaining({ isActive: false }) })
+    );
+  });
+
+  it("returns 400 when suspending an organization that isn't approved", async () => {
+    mockedService.setOrganizationActive.mockRejectedValue(
+      new Error("ניתן להשעות או להפעיל מחדש רק ארגון מאושר")
+    );
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await suspendOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("reactivates a suspended organization", async () => {
+    mockedService.setOrganizationActive.mockResolvedValue({
+      _id: "org-A",
+      isActive: true,
+    } as any);
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await activateOrganizationHandler(req, res);
+
+    expect(mockedService.setOrganizationActive).toHaveBeenCalledWith("org-A", true);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, organization: expect.objectContaining({ isActive: true }) })
     );
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -655,6 +655,7 @@ describe("organizationController provider-key endpoints (#144 MANAGED_ORG)", () 
       _id: "org-B",
       ownerId: "owner-B",
     } as any);
+    mockedService.deleteOrganizationProviderKey.mockResolvedValue({ _id: "key1" } as any);
 
     const req = {
       params: { id: "org-B", keyId: "key1" },
@@ -664,8 +665,27 @@ describe("organizationController provider-key endpoints (#144 MANAGED_ORG)", () 
 
     await deleteOrganizationProviderKeyHandler(req, res);
 
-    expect(mockedService.deleteOrganizationProviderKey).toHaveBeenCalledWith("key1");
+    expect(mockedService.deleteOrganizationProviderKey).toHaveBeenCalledWith("org-B", "key1");
     expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
+  it("deleteOrganizationProviderKeyHandler returns 404 when the key does not belong to the organization (#276 IDOR)", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.deleteOrganizationProviderKey.mockResolvedValue(null as any);
+
+    const req = {
+      params: { id: "org-A", keyId: "key-of-org-B" },
+      user: { userId: "owner-A", role: "org_owner" },
+    } as any;
+    const res = mockRes();
+
+    await deleteOrganizationProviderKeyHandler(req, res);
+
+    expect(mockedService.deleteOrganizationProviderKey).toHaveBeenCalledWith("org-A", "key-of-org-B");
+    expect(res.status).toHaveBeenCalledWith(404);
   });
 });
 

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -5,6 +5,7 @@ import {
   updateOrganizationHandler,
   publicRequestOrganizationHandler,
   topUpOrganizationWalletHandler,
+  approveOrganizationHandler,
 } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
@@ -14,6 +15,7 @@ jest.mock("../../services/organizationService", () => ({
   updateOrganization: jest.fn(),
   publicRequestOrganization: jest.fn(),
   topUpOrganizationWallet: jest.fn(),
+  approveOrganization: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -277,5 +279,44 @@ describe("organizationController.topUpOrganizationWalletHandler", () => {
 
     expect(res.status).toHaveBeenCalledWith(403);
     expect(mockedService.topUpOrganizationWallet).not.toHaveBeenCalled();
+  });
+});
+
+describe("organizationController.approveOrganizationHandler (#229 ORG-02)", () => {
+  it("approves a pending organization and returns the updated organization", async () => {
+    mockedService.approveOrganization.mockResolvedValue({
+      _id: "org-A",
+      status: "approved",
+      isActive: true,
+    } as any);
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await approveOrganizationHandler(req, res);
+
+    expect(mockedService.approveOrganization).toHaveBeenCalledWith("org-A");
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        organization: expect.objectContaining({ status: "approved", isActive: true }),
+      })
+    );
+  });
+
+  it("returns 400 when the organization is not pending", async () => {
+    mockedService.approveOrganization.mockRejectedValue(
+      new Error("ניתן לאשר רק ארגון שממתין לאישור")
+    );
+
+    const req = { params: { id: "org-A" } } as any;
+    const res = mockRes();
+
+    await approveOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "ניתן לאשר רק ארגון שממתין לאישור" })
+    );
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { Request, Response } from "express";
-import { getOrganizationUsersHandler } from "../organizationController";
+import { getOrganizationUsersHandler, updateOrganizationHandler } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
 jest.mock("../../services/organizationService", () => ({
   getOrganizationById: jest.fn(),
   getOrganizationUsers: jest.fn(),
+  updateOrganization: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -17,8 +18,8 @@ function mockRes(): Response {
   return res as Response;
 }
 
-function mockReq(orgId: string, user: { userId: string; role: string }): Request<{ id: string }> {
-  return { params: { id: orgId }, user } as any;
+function mockReq(orgId: string, user: { userId: string; role: string }, body: any = {}): Request<{ id: string }> {
+  return { params: { id: orgId }, user, body } as any;
 }
 
 beforeEach(() => {
@@ -102,5 +103,70 @@ describe("organizationController.getOrganizationUsersHandler", () => {
 
     expect(res.status).toHaveBeenCalledWith(404);
     expect(mockedService.getOrganizationUsers).not.toHaveBeenCalled();
+  });
+});
+
+describe("organizationController.updateOrganizationHandler", () => {
+  it("strips walletBalance, ownerId and isActive when a non-admin owner updates their organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.updateOrganization.mockResolvedValue({ _id: "org-A" } as any);
+
+    const req = mockReq("org-A", { userId: "owner-A", role: "org_owner" }, {
+      name: "New Name",
+      description: "New description",
+      walletBalance: 999999,
+      ownerId: "attacker-id",
+      isActive: true,
+      status: "approved",
+    });
+    const res = mockRes();
+
+    await updateOrganizationHandler(req, res);
+
+    expect(mockedService.updateOrganization).toHaveBeenCalledWith("org-A", {
+      name: "New Name",
+      description: "New description",
+    });
+  });
+
+  it("returns 403 when an org_owner tries to update a different organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = mockReq("org-B", { userId: "owner-A", role: "org_owner" }, {
+      walletBalance: 999999,
+    });
+    const res = mockRes();
+
+    await updateOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedService.updateOrganization).not.toHaveBeenCalled();
+  });
+
+  it("allows an admin to update any field, including walletBalance and ownerId", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+    mockedService.updateOrganization.mockResolvedValue({ _id: "org-B" } as any);
+
+    const req = mockReq("org-B", { userId: "admin-1", role: "admin" }, {
+      walletBalance: 999999,
+      ownerId: "new-owner",
+    });
+    const res = mockRes();
+
+    await updateOrganizationHandler(req, res);
+
+    expect(mockedService.updateOrganization).toHaveBeenCalledWith("org-B", {
+      walletBalance: 999999,
+      ownerId: "new-owner",
+    });
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { Request, Response } from "express";
+import { getOrganizationUsersHandler } from "../organizationController";
+import * as organizationService from "../../services/organizationService";
+
+jest.mock("../../services/organizationService", () => ({
+  getOrganizationById: jest.fn(),
+  getOrganizationUsers: jest.fn(),
+}));
+
+const mockedService = jest.mocked(organizationService);
+
+function mockRes(): Response {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+function mockReq(orgId: string, user: { userId: string; role: string }): Request<{ id: string }> {
+  return { params: { id: orgId }, user } as any;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("organizationController.getOrganizationUsersHandler", () => {
+  it("returns 403 when an org_owner requests users of a different organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = mockReq("org-B", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+
+    await getOrganizationUsersHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(String) })
+    );
+    expect(mockedService.getOrganizationUsers).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when ownerId is a populated object belonging to a different owner", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: { _id: "owner-B", name: "Owner B" },
+    } as any);
+
+    const req = mockReq("org-B", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+
+    await getOrganizationUsersHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedService.getOrganizationUsers).not.toHaveBeenCalled();
+  });
+
+  it("returns the users when the org_owner owns the requested organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.getOrganizationUsers.mockResolvedValue([{ _id: "u1" }] as any);
+
+    const req = mockReq("org-A", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+
+    await getOrganizationUsersHandler(req, res);
+
+    expect(mockedService.getOrganizationUsers).toHaveBeenCalledWith("org-A");
+    expect(res.json).toHaveBeenCalledWith([{ _id: "u1" }]);
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+
+  it("allows an admin to access any organization's users", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+    mockedService.getOrganizationUsers.mockResolvedValue([]);
+
+    const req = mockReq("org-B", { userId: "admin-1", role: "admin" });
+    const res = mockRes();
+
+    await getOrganizationUsersHandler(req, res);
+
+    expect(mockedService.getOrganizationUsers).toHaveBeenCalledWith("org-B");
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+
+  it("returns 404 when the organization does not exist", async () => {
+    mockedService.getOrganizationById.mockResolvedValue(null as any);
+
+    const req = mockReq("missing-org", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+
+    await getOrganizationUsersHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(mockedService.getOrganizationUsers).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import { Request, Response } from "express";
-import { getOrganizationUsersHandler, updateOrganizationHandler } from "../organizationController";
+import {
+  getOrganizationUsersHandler,
+  updateOrganizationHandler,
+  publicRequestOrganizationHandler,
+} from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
 jest.mock("../../services/organizationService", () => ({
   getOrganizationById: jest.fn(),
   getOrganizationUsers: jest.fn(),
   updateOrganization: jest.fn(),
+  publicRequestOrganization: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -168,5 +173,49 @@ describe("organizationController.updateOrganizationHandler", () => {
       walletBalance: 999999,
       ownerId: "new-owner",
     });
+  });
+});
+
+describe("organizationController.publicRequestOrganizationHandler", () => {
+  it("rejects the request instead of creating an organization when the owner email is invalid", async () => {
+    mockedService.publicRequestOrganization.mockRejectedValue(
+      new Error("כתובת האימייל אינה תקינה")
+    );
+
+    const req = {
+      body: {
+        ownerName: "Owner",
+        ownerEmail: "not-an-email",
+        ownerPassword: "secret123",
+        orgName: "Acme",
+      },
+    } as any;
+    const res = mockRes();
+
+    await publicRequestOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "כתובת האימייל אינה תקינה" })
+    );
+    expect(res.status).not.toHaveBeenCalledWith(201);
+  });
+
+  it("creates the organization when the request is valid", async () => {
+    mockedService.publicRequestOrganization.mockResolvedValue({ _id: "org-1" } as any);
+
+    const req = {
+      body: {
+        ownerName: "Owner",
+        ownerEmail: "owner@example.com",
+        ownerPassword: "secret123",
+        orgName: "Acme",
+      },
+    } as any;
+    const res = mockRes();
+
+    await publicRequestOrganizationHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(201);
   });
 });

--- a/server/src/controllers/__tests__/organizationController.test.ts
+++ b/server/src/controllers/__tests__/organizationController.test.ts
@@ -4,6 +4,7 @@ import {
   getOrganizationUsersHandler,
   updateOrganizationHandler,
   publicRequestOrganizationHandler,
+  topUpOrganizationWalletHandler,
 } from "../organizationController";
 import * as organizationService from "../../services/organizationService";
 
@@ -12,6 +13,7 @@ jest.mock("../../services/organizationService", () => ({
   getOrganizationUsers: jest.fn(),
   updateOrganization: jest.fn(),
   publicRequestOrganization: jest.fn(),
+  topUpOrganizationWallet: jest.fn(),
 }));
 
 const mockedService = jest.mocked(organizationService);
@@ -217,5 +219,63 @@ describe("organizationController.publicRequestOrganizationHandler", () => {
     await publicRequestOrganizationHandler(req, res);
 
     expect(res.status).toHaveBeenCalledWith(201);
+  });
+});
+
+describe("organizationController.topUpOrganizationWalletHandler", () => {
+  it.each([0, -50, -0.01])(
+    "rejects a top-up amount of %p with 400 and does not touch the wallet",
+    async (amount) => {
+      const req = { params: { id: "org-A" }, user: { userId: "owner-A", role: "org_owner" }, body: { amount } } as any;
+      const res = mockRes();
+
+      await topUpOrganizationWalletHandler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(mockedService.getOrganizationById).not.toHaveBeenCalled();
+      expect(mockedService.topUpOrganizationWallet).not.toHaveBeenCalled();
+    }
+  );
+
+  it("rejects a non-numeric amount with 400", async () => {
+    const req = { params: { id: "org-A" }, user: { userId: "owner-A", role: "org_owner" }, body: { amount: "100" } } as any;
+    const res = mockRes();
+
+    await topUpOrganizationWalletHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockedService.topUpOrganizationWallet).not.toHaveBeenCalled();
+  });
+
+  it("tops up the wallet for a valid positive amount when the org_owner owns the organization", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      ownerId: "owner-A",
+    } as any);
+    mockedService.topUpOrganizationWallet.mockResolvedValue({ _id: "org-A", walletBalance: 150 } as any);
+
+    const req = { params: { id: "org-A" }, user: { userId: "owner-A", role: "org_owner" }, body: { amount: 50 } } as any;
+    const res = mockRes();
+
+    await topUpOrganizationWalletHandler(req, res);
+
+    expect(mockedService.topUpOrganizationWallet).toHaveBeenCalledWith("org-A", 50);
+    expect(res.status).not.toHaveBeenCalledWith(400);
+    expect(res.status).not.toHaveBeenCalledWith(403);
+  });
+
+  it("returns 403 when an org_owner tries to top up a different organization's wallet", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-B",
+      ownerId: "owner-B",
+    } as any);
+
+    const req = { params: { id: "org-B" }, user: { userId: "owner-A", role: "org_owner" }, body: { amount: 50 } } as any;
+    const res = mockRes();
+
+    await topUpOrganizationWalletHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(mockedService.topUpOrganizationWallet).not.toHaveBeenCalled();
   });
 });

--- a/server/src/controllers/organizationController.ts
+++ b/server/src/controllers/organizationController.ts
@@ -20,12 +20,12 @@ import {
   approveOrganization,
   rejectOrganization,
   getMyOrganization,
+  addOrganizationProviderKey,
+  listOrganizationProviderKeys,
+  deleteOrganizationProviderKey,
 } from "../services/organizationService";
 import logger from "../logger";
 
-/**
- * Create a new organization (Admin only)
- */
 export async function createOrganizationHandler(req: Request, res: Response) {
   try {
     const adminUser = (req as any).user;
@@ -40,9 +40,6 @@ export async function createOrganizationHandler(req: Request, res: Response) {
   }
 }
 
-/**
- * List organizations (Admin sees all, Org Owner sees theirs)
- */
 export async function listOrganizationsHandler(req: Request, res: Response) {
   try {
     const user = (req as any).user;
@@ -72,9 +69,6 @@ export async function listOrganizationsHandler(req: Request, res: Response) {
   }
 }
 
-/**
- * Get organization by ID (Admin or Org Owner)
- */
 export async function getOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -101,9 +95,6 @@ export async function getOrganizationHandler(
   }
 }
 
-/**
- * Update organization (Admin or Org Owner)
- */
 export async function updateOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -124,9 +115,6 @@ export async function updateOrganizationHandler(
       return res.status(403).json({ error: "Access denied" });
     }
 
-    // Non-admin owners may only edit their own profile fields - not status,
-    // walletBalance, isActive, ownerId, etc. Those go through their own
-    // dedicated admin-only routes (approve/reject/suspend/activate/top-up).
     const updateData = isAdmin
       ? req.body
       : { name: req.body.name, description: req.body.description };
@@ -139,9 +127,6 @@ export async function updateOrganizationHandler(
   }
 }
 
-/**
- * Delete organization (Admin only)
- */
 export async function deleteOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -160,9 +145,6 @@ export async function deleteOrganizationHandler(
   }
 }
 
-/**
- * Get users of an organization (Admin or Org Owner)
- */
 export async function getOrganizationUsersHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -192,9 +174,6 @@ export async function getOrganizationUsersHandler(
   }
 }
 
-/**
- * Add an existing user to an organization by ID (Admin or Org Owner)
- */
 export async function addUserToOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -223,10 +202,6 @@ export async function addUserToOrganizationHandler(
   }
 }
 
-/**
- * Create a brand-new user account directly inside an organization,
- * with a generated temporary password (Admin or Org Owner)
- */
 export async function createOrganizationMemberHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -234,7 +209,7 @@ export async function createOrganizationMemberHandler(
   try {
     const user = (req as any).user;
     const orgId = req.params.id;
-    const { name, email, role } = req.body;
+    const { name, email, role, mode } = req.body;
 
     if (!name?.trim() || !email?.trim()) {
       return res.status(400).json({ error: "יש למלא שם וכתובת אימייל" });
@@ -255,6 +230,7 @@ export async function createOrganizationMemberHandler(
       name: name.trim(),
       email: email.trim(),
       role,
+      mode,
     });
 
     res.status(201).json({
@@ -268,9 +244,85 @@ export async function createOrganizationMemberHandler(
   }
 }
 
-/**
- * Add a user to organization by Email (Admin or Org Owner)
- */
+export async function addOrganizationProviderKeyHandler(
+  req: Request<{ id: string }>,
+  res: Response
+) {
+  try {
+    const user = (req as any).user;
+    const orgId = req.params.id;
+    const { provider, apiKey } = req.body;
+
+    const organization = await getOrganizationById(orgId);
+    if (!organization) {
+      return res.status(404).json({ error: "Organization not found" });
+    }
+
+    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
+    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+
+    const key = await addOrganizationProviderKey(orgId, { provider, apiKey });
+    res.status(201).json({ success: true, key });
+  } catch (error: any) {
+    logger.error("Failed to add organization provider key", { error });
+    res.status(400).json({ error: error.message || "Failed to add provider key" });
+  }
+}
+
+export async function listOrganizationProviderKeysHandler(
+  req: Request<{ id: string }>,
+  res: Response
+) {
+  try {
+    const user = (req as any).user;
+    const orgId = req.params.id;
+
+    const organization = await getOrganizationById(orgId);
+    if (!organization) {
+      return res.status(404).json({ error: "Organization not found" });
+    }
+
+    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
+    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+
+    const keys = await listOrganizationProviderKeys(orgId);
+    res.json(keys);
+  } catch (error) {
+    logger.error("Failed to list organization provider keys", { error });
+    res.status(500).json({ error: "Failed to list provider keys" });
+  }
+}
+
+export async function deleteOrganizationProviderKeyHandler(
+  req: Request<{ id: string; keyId: string }>,
+  res: Response
+) {
+  try {
+    const user = (req as any).user;
+    const orgId = req.params.id;
+
+    const organization = await getOrganizationById(orgId);
+    if (!organization) {
+      return res.status(404).json({ error: "Organization not found" });
+    }
+
+    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
+    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+      return res.status(403).json({ error: "Access denied" });
+    }
+
+    await deleteOrganizationProviderKey(req.params.keyId);
+    res.json({ success: true });
+  } catch (error) {
+    logger.error("Failed to delete organization provider key", { error });
+    res.status(500).json({ error: "Failed to delete provider key" });
+  }
+}
+
 export async function addUserByEmailToOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -313,9 +365,6 @@ export async function addUserByEmailToOrganizationHandler(
   }
 }
 
-/**
- * Remove a user from an organization (Admin or Org Owner)
- */
 export async function removeUserFromOrganizationHandler(
   req: Request<{ userId: string }>,
   res: Response
@@ -346,9 +395,6 @@ export async function removeUserFromOrganizationHandler(
   }
 }
 
-/**
- * Get all pending organizations for authorization (Admin only)
- */
 export async function getPendingOrganizationsHandler(
   req: Request,
   res: Response
@@ -369,9 +415,6 @@ export async function getPendingOrganizationsHandler(
   }
 }
 
-/**
- * Top up organization wallet (Admin or Org Owner) - Mock Only
- */
 export async function topUpOrganizationWalletHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -408,9 +451,6 @@ export async function topUpOrganizationWalletHandler(
   }
 }
 
-/**
- * List ALL organizations with user counts + wallet balance (Admin only)
- */
 export async function getAllOrganizationsHandler(_req: Request, res: Response) {
   try {
     const organizations = await listAllOrganizationsWithStats();
@@ -421,9 +461,6 @@ export async function getAllOrganizationsHandler(_req: Request, res: Response) {
   }
 }
 
-/**
- * Suspend an organization (Admin only) -> isActive: false
- */
 export async function suspendOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -437,9 +474,6 @@ export async function suspendOrganizationHandler(
   }
 }
 
-/**
- * Reactivate a suspended organization (Admin only) -> isActive: true
- */
 export async function activateOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -453,9 +487,6 @@ export async function activateOrganizationHandler(
   }
 }
 
-/**
- * Get organization usage summary + wallet balance (Admin or Org Owner)
- */
 export async function getOrganizationStatsHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -485,10 +516,6 @@ export async function getOrganizationStatsHandler(
   }
 }
 
-/**
- * PUBLIC: create org-owner account + pending organization together.
- * No authentication required — this IS the sign-up for org owners.
- */
 export async function publicRequestOrganizationHandler(req: Request, res: Response) {
   try {
     const { ownerName, ownerEmail, ownerPassword, orgName, orgDescription } = req.body;
@@ -515,9 +542,6 @@ export async function publicRequestOrganizationHandler(req: Request, res: Respon
     });
   } catch (error: any) {
     logger.error("Failed public organization request", { error });
-    // register() ו-publicRequestOrganization() כבר זורקים הודעות עבריות ברורות
-    // ומובחנות עבור התנגשות אימייל לעומת התנגשות שם ארגון - מציגים אותן כמו
-    // שהן במקום למפות כל שגיאה גורפת ל"אימייל כבר רשום".
     if (error?.message?.includes("אימייל") || error?.message?.includes("שם הארגון")) {
       return res.status(409).json({ error: error.message });
     }
@@ -525,10 +549,6 @@ export async function publicRequestOrganizationHandler(req: Request, res: Respon
   }
 }
 
-/**
- * Get the current user's own organization (with status). Accessible to the owner
- * regardless of approval state, so the frontend can show the right screen.
- */
 export async function getMyOrganizationHandler(req: Request, res: Response) {
   try {
     const user = (req as any).user;
@@ -540,9 +560,6 @@ export async function getMyOrganizationHandler(req: Request, res: Response) {
   }
 }
 
-/**
- * Approve a pending organization (Admin only) -> status=approved, isActive=true, email owner
- */
 export async function approveOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response
@@ -556,9 +573,6 @@ export async function approveOrganizationHandler(
   }
 }
 
-/**
- * Reject a pending organization (Admin only) -> status=rejected, isActive=false
- */
 export async function rejectOrganizationHandler(
   req: Request<{ id: string }>,
   res: Response

--- a/server/src/controllers/organizationController.ts
+++ b/server/src/controllers/organizationController.ts
@@ -315,7 +315,11 @@ export async function deleteOrganizationProviderKeyHandler(
       return res.status(403).json({ error: "Access denied" });
     }
 
-    await deleteOrganizationProviderKey(req.params.keyId);
+    const deleted = await deleteOrganizationProviderKey(orgId, req.params.keyId);
+    if (!deleted) {
+      return res.status(404).json({ error: "Provider key not found" });
+    }
+
     res.json({ success: true });
   } catch (error) {
     logger.error("Failed to delete organization provider key", { error });

--- a/server/src/controllers/uploadController.ts
+++ b/server/src/controllers/uploadController.ts
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 
 // אתחול החיבור מול AWS עם הגדרת משתני הסביבה
 const s3 = new S3Client({
-  region: process.env.AWS_REGION || "",
+  region: process.env.AWS_REGION || "us-east-1",
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",

--- a/server/src/middleware/__tests__/rateLimiter.test.ts
+++ b/server/src/middleware/__tests__/rateLimiter.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { Response, NextFunction } from "express";
+import { rateLimiter } from "../rateLimiter";
+import { UsageLog } from "../../models";
+import { checkAndResetMonthlyBudget } from "../../services/usageTracker";
+
+jest.mock("../../models", () => ({
+  UsageLog: { countDocuments: jest.fn() },
+}));
+jest.mock("../../services/usageTracker", () => ({
+  checkAndResetMonthlyBudget: jest.fn(),
+}));
+
+const mockedUsageLog = jest.mocked(UsageLog);
+const mockedCheckReset = jest.mocked(checkAndResetMonthlyBudget);
+
+function mockRes(): Response {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+function mockReq(user: any): any {
+  return { user };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedCheckReset.mockResolvedValue(undefined);
+  mockedUsageLog.countDocuments.mockResolvedValue(0 as any);
+});
+
+describe("rateLimiter (#236 ORG-09 — MANAGED monthly budget enforcement)", () => {
+  it("blocks the request with 402 when a MANAGED user has reached their monthly budget", async () => {
+    const req = mockReq({
+      _id: "user-1",
+      mode: "MANAGED",
+      costLimits: { monthlyBudget: 10, currentMonthSpent: 10 },
+    });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await rateLimiter(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "Budget exceeded" })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("blocks the request when spending has exceeded (not just reached) the budget", async () => {
+    const req = mockReq({
+      _id: "user-1",
+      mode: "MANAGED",
+      costLimits: { monthlyBudget: 10, currentMonthSpent: 15 },
+    });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await rateLimiter(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows the request through when a MANAGED user is still under budget", async () => {
+    const req = mockReq({
+      _id: "user-1",
+      mode: "MANAGED",
+      costLimits: { monthlyBudget: 10, currentMonthSpent: 5 },
+    });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await rateLimiter(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalledWith(402);
+  });
+
+  it("does not apply the budget check to a BYOK user", async () => {
+    const req = mockReq({
+      _id: "user-1",
+      mode: "BYOK",
+      costLimits: { monthlyBudget: 10, currentMonthSpent: 999 },
+    });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await rateLimiter(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalledWith(402);
+  });
+
+  it("returns 401 when there is no authenticated user", async () => {
+    const req = mockReq(undefined);
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await rateLimiter(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/models/__tests__/providerKey.test.ts
+++ b/server/src/models/__tests__/providerKey.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "@jest/globals";
+import { ProviderKey } from "../providerKey";
+
+describe("ProviderKey model (#277)", () => {
+  it("does not define a plaintext apiKey field in the schema", () => {
+    expect(ProviderKey.schema.path("apiKey")).toBeUndefined();
+  });
+
+  it("never exposes apiKeyEncrypted via toJSON", () => {
+    const doc = new ProviderKey({
+      organizationId: "507f1f77bcf86cd799439011",
+      provider: "openai",
+      apiKeyEncrypted: "encrypted-value",
+      keyPrefix: "sk-***",
+    });
+
+    const json = doc.toJSON() as any;
+
+    expect(json.apiKeyEncrypted).toBeUndefined();
+    expect(json.apiKey).toBeUndefined();
+  });
+});

--- a/server/src/models/organization.ts
+++ b/server/src/models/organization.ts
@@ -31,19 +31,20 @@ const OrganizationSchema = new mongoose.Schema(
       default: "pending",
     },
     settings: {
-      // הגדרות ארגוניות כלליות
       maxUsers: {
         type: Number,
         default: 10,
       },
-      allowedDomains: [String], // דומיינים מורשים לרישום אוטומטי
+      allowedDomains: [String],
+      allowedModels: {
+        type: [String],
+        default: [],
+      },
     },
   },
   { timestamps: true }
 );
 
-// Index for faster lookups (name's unique index is already created by
-// `unique: true` on the field above - no need to declare it again here)
 OrganizationSchema.index({ ownerId: 1 });
 
 OrganizationSchema.set("toJSON", {

--- a/server/src/models/providerKey.ts
+++ b/server/src/models/providerKey.ts
@@ -35,8 +35,6 @@ const ProviderKeySchema = new mongoose.Schema(
       type: Boolean,
       default: true,
     },
-
-  apiKey: String
 },
 { timestamps: true }
 );

--- a/server/src/models/providerKey.ts
+++ b/server/src/models/providerKey.ts
@@ -7,6 +7,12 @@ const ProviderKeySchema = new mongoose.Schema(
     ref: "User",
   },
 
+  organizationId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Organization",
+    index: true,
+  },
+
   provider: {
     type: String,
     enum: ["openai","anthropic","google","groq"],

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -5,11 +5,11 @@ const UserSchema = new mongoose.Schema(
     email: { type: String, required: true, unique: true },
     password: { type: String, required: true },
     name: String,
-    organization: String, // Deprecated - kept for backward compatibility
+    organization: String,
     organizationId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "Organization",
-      required: false, // Not required initially to support existing users
+      required: false,
     },
     role: {
       type: String,
@@ -17,7 +17,6 @@ const UserSchema = new mongoose.Schema(
       default: "user",
     },
     
-    // --- Authentication fields ---
     emailVerified: {
       type: Boolean,
       default: false,
@@ -28,14 +27,12 @@ const UserSchema = new mongoose.Schema(
     passwordResetExpires: Date,
     lastLogin: Date,
     
-    // --- Google OAuth fields ---
     googleId: {
       type: String,
       unique: true,
-      sparse: true, // Allows null values while maintaining uniqueness for non-null values
+      sparse: true,
     },
 
-    // --- שדות עבור המפתח שהמשתמש מקבל ממך (App Level) ---
     proxyKeyHash: {
       type: String,
       required: true,
@@ -48,28 +45,26 @@ const UserSchema = new mongoose.Schema(
       index: true,
     },
 
-    // --- שדות עבור התקשורת הפנימית מול LiteLLM (Infrastructure Level) ---
     litellmKeyEncrypted: {
-      type: String, // המפתח הגלוי (sk-safeai-...) אחרי הצפנה ב-userService
+      type: String,
       required: true,
     },
     litellmPrefix: {
-      type: String, // key_name שחזר מ-LiteLLM
+      type: String,
       required: true,
     },
     litellmToken: {
-      type: String, // ה-token (ההאש) שחזר מ-LiteLLM לניהול המפתח
+      type: String,
       required: true,
     },
 
-    // --- הגדרות פרופיל ומודלים ---
     profileId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "AIProfile",
     },
     mode: {
       type: String,
-      enum: ["BYOK", "MANAGED"],
+      enum: ["BYOK", "MANAGED", "MANAGED_ORG"],
       default: "BYOK",
     },
     isActive: {
@@ -77,29 +72,24 @@ const UserSchema = new mongoose.Schema(
       default: true,
     },
     
-    // --- Rate Limits ---
     rateLimits: {
       requestsPerMinute: { type: Number, default: 60 },
       requestsPerDay: { type: Number, default: 10000 },
     },
     
-    // --- Cost Limits (MANAGED mode only) ---
     costLimits: {
-      monthlyBudget: { type: Number, default: 1 },      // $1 free per month
+      monthlyBudget: { type: Number, default: 1 },
       currentMonthSpent: { type: Number, default: 0 },
       lastResetDate: { type: Date, default: Date.now },
     },
     
-    // --- Free Provider Keys (keys that don't cost money) ---
     freeProviderKeys: [String],
     
-    // --- Refresh tokens for JWT ---
     refreshTokens: [String],
   },
   { timestamps: true },
 );
 
-// Index for faster lookups
 UserSchema.index({ verificationToken: 1 });
 UserSchema.index({ passwordResetToken: 1 });
 
@@ -107,7 +97,6 @@ UserSchema.set("toJSON", {
   transform: (_doc, ret) => {
     const obj = ret as any;
 
-    // אנחנו לא רוצים לחשוף מידע רגיש ב-API החיצוני
     delete obj.password;
     delete obj.proxyKeyHash;
     delete obj.litellmKeyEncrypted;
@@ -122,5 +111,4 @@ UserSchema.set("toJSON", {
   },
 });
 
-// שני את השורה הזו בסוף הקובץ server/src/models/User.ts:
 export const User = mongoose.models.User || mongoose.model("User", UserSchema);

--- a/server/src/repositories/providerKeyRepository.ts
+++ b/server/src/repositories/providerKeyRepository.ts
@@ -17,13 +17,28 @@ export async function getProviderKeyByUserAndProvider(
 }
 
 export async function getSystemProviderKey(provider: string) {
-  
-  
+
+
   return ProviderKey.findOne({
     provider,
     isSystem: true,
     isActive: true,
   });
+}
+
+export async function getProviderKeyByOrgAndProvider(
+  organizationId: string,
+  provider: string,
+) {
+  return ProviderKey.findOne({
+    organizationId,
+    provider,
+    isActive: true,
+  });
+}
+
+export async function getProviderKeysByOrganization(organizationId: string) {
+  return ProviderKey.find({ organizationId }).lean();
 }
 
 export async function getProviderKeys() {

--- a/server/src/routes/__tests__/organizationRouter.test.ts
+++ b/server/src/routes/__tests__/organizationRouter.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { Response, NextFunction } from "express";
+import { requireApprovedOrg } from "../organizationRouter";
+import * as organizationService from "../../services/organizationService";
+
+jest.mock("../../services/organizationService", () => ({
+  getOrganizationById: jest.fn(),
+}));
+
+const mockedService = jest.mocked(organizationService);
+
+function mockRes(): Response {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+function mockReq(orgId: string, user: { userId: string; role: string }): any {
+  return { params: { id: orgId }, user };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("organizationRouter.requireApprovedOrg (#217 RBAC-04)", () => {
+  it("blocks an org_owner from a pending organization with 403", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      status: "pending",
+    } as any);
+
+    const req = mockReq("org-A", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await requireApprovedOrg(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows an org_owner through once the organization is approved", async () => {
+    mockedService.getOrganizationById.mockResolvedValue({
+      _id: "org-A",
+      status: "approved",
+    } as any);
+
+    const req = mockReq("org-A", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await requireApprovedOrg(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("lets an admin through regardless of organization status", async () => {
+    const req = mockReq("org-A", { userId: "admin-1", role: "admin" });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await requireApprovedOrg(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(mockedService.getOrganizationById).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the organization does not exist", async () => {
+    mockedService.getOrganizationById.mockResolvedValue(null as any);
+
+    const req = mockReq("missing-org", { userId: "owner-A", role: "org_owner" });
+    const res = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await requireApprovedOrg(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/organizationRouter.ts
+++ b/server/src/routes/organizationRouter.ts
@@ -27,7 +27,7 @@ import { getOrganizationById } from "../services/organizationService";
 const router = express.Router();
 
 // חוסם פעולות ניהול לבעל ארגון כל עוד הארגון אינו מאושר (אדמין עוקף)
-async function requireApprovedOrg(
+export async function requireApprovedOrg(
   req: express.Request<{ id: string }>,
   res: express.Response,
   next: express.NextFunction

--- a/server/src/routes/organizationRouter.ts
+++ b/server/src/routes/organizationRouter.ts
@@ -20,13 +20,15 @@ import {
   approveOrganizationHandler,
   rejectOrganizationHandler,
   getMyOrganizationHandler,
+  addOrganizationProviderKeyHandler,
+  listOrganizationProviderKeysHandler,
+  deleteOrganizationProviderKeyHandler,
 } from "../controllers/organizationController";
 import { authenticateToken, requireAdmin } from "../middleware/auth";
 import { getOrganizationById } from "../services/organizationService";
 
 const router = express.Router();
 
-// חוסם פעולות ניהול לבעל ארגון כל עוד הארגון אינו מאושר (אדמין עוקף)
 export async function requireApprovedOrg(
   req: express.Request<{ id: string }>,
   res: express.Response,
@@ -88,5 +90,10 @@ router.post("/:id/users/by-email", requireApprovedOrg, addUserByEmailToOrganizat
 
 // Wallet Management (Mock) - blocked until org is approved (admins bypass)
 router.post("/:id/top-up", requireApprovedOrg, topUpOrganizationWalletHandler); // Admin or approved Org Owner
+
+// Org-level AI provider keys, used by "MANAGED_ORG" members instead of a personal key
+router.post("/:id/provider-keys", requireApprovedOrg, addOrganizationProviderKeyHandler); // Admin or approved Org Owner
+router.get("/:id/provider-keys", requireApprovedOrg, listOrganizationProviderKeysHandler); // Admin or approved Org Owner
+router.delete("/:id/provider-keys/:keyId", requireApprovedOrg, deleteOrganizationProviderKeyHandler); // Admin or approved Org Owner
 
 export default router;

--- a/server/src/services/__tests__/organizationService.test.ts
+++ b/server/src/services/__tests__/organizationService.test.ts
@@ -18,6 +18,7 @@ jest.mock("../authService", () => ({ register: jest.fn() }));
 jest.mock("../providerKeyService", () => ({
   addProviderKey: jest.fn(),
   listProviderKeysForOrganization: jest.fn(),
+  getProviderKeyById: jest.fn(),
   deleteProviderKey: jest.fn(),
 }));
 jest.mock("../../models", () => ({
@@ -454,12 +455,38 @@ describe("organizationService org-level provider keys (#144 MANAGED_ORG)", () =>
     expect(result).toEqual([{ _id: "key1" }]);
   });
 
-  it("deleteOrganizationProviderKey delegates to providerKeyService", async () => {
+  it("deleteOrganizationProviderKey deletes the key when it belongs to the organization", async () => {
+    mockedProviderKeyService.getProviderKeyById.mockResolvedValue({
+      _id: "key1",
+      organizationId: "org1",
+    } as any);
     mockedProviderKeyService.deleteProviderKey.mockResolvedValue({ _id: "key1" } as any);
 
-    await organizationService.deleteOrganizationProviderKey("key1");
+    const result = await organizationService.deleteOrganizationProviderKey("org1", "key1");
 
     expect(mockedProviderKeyService.deleteProviderKey).toHaveBeenCalledWith("key1");
+    expect(result).toEqual({ _id: "key1" });
+  });
+
+  it("deleteOrganizationProviderKey refuses to delete a key belonging to a different organization (#276 IDOR)", async () => {
+    mockedProviderKeyService.getProviderKeyById.mockResolvedValue({
+      _id: "key1",
+      organizationId: "org-B",
+    } as any);
+
+    const result = await organizationService.deleteOrganizationProviderKey("org-A", "key1");
+
+    expect(result).toBeNull();
+    expect(mockedProviderKeyService.deleteProviderKey).not.toHaveBeenCalled();
+  });
+
+  it("deleteOrganizationProviderKey returns null when the key does not exist", async () => {
+    mockedProviderKeyService.getProviderKeyById.mockResolvedValue(null as any);
+
+    const result = await organizationService.deleteOrganizationProviderKey("org-A", "missing-key");
+
+    expect(result).toBeNull();
+    expect(mockedProviderKeyService.deleteProviderKey).not.toHaveBeenCalled();
   });
 });
 

--- a/server/src/services/__tests__/organizationService.test.ts
+++ b/server/src/services/__tests__/organizationService.test.ts
@@ -8,12 +8,18 @@ import {
   sendOrgApprovalRequestEmail,
 } from "../../utils/email";
 import { register } from "../authService";
+import * as providerKeyService from "../providerKeyService";
 import { UsageLog } from "../../models";
 
 jest.mock("../../repositories/organizationRepository");
 jest.mock("../../repositories/userRepository");
 jest.mock("../../utils/email");
 jest.mock("../authService", () => ({ register: jest.fn() }));
+jest.mock("../providerKeyService", () => ({
+  addProviderKey: jest.fn(),
+  listProviderKeysForOrganization: jest.fn(),
+  deleteProviderKey: jest.fn(),
+}));
 jest.mock("../../models", () => ({
   UsageLog: { aggregate: jest.fn() },
 }));
@@ -21,6 +27,7 @@ jest.mock("../../models", () => ({
 const mockedRepo = jest.mocked(repo);
 const mockedUserRepo = jest.mocked(userRepo);
 const mockedRegister = jest.mocked(register);
+const mockedProviderKeyService = jest.mocked(providerKeyService);
 const mockedUsageLog = jest.mocked(UsageLog);
 
 beforeEach(() => {
@@ -391,6 +398,68 @@ describe("organizationService.createOrganizationMember", () => {
     expect(mockedRegister).toHaveBeenCalledWith(
       expect.objectContaining({ role: "admin" })
     );
+  });
+
+  it("passes mode: MANAGED_ORG through to register (#144)", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({ _id: "org1" } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(0);
+    mockedRegister.mockResolvedValue({ user: { _id: "newUser1" } } as any);
+
+    await organizationService.createOrganizationMember("org1", {
+      ...memberData,
+      mode: "MANAGED_ORG",
+    });
+
+    expect(mockedRegister).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "MANAGED_ORG" })
+    );
+  });
+
+  it("does not pass a mode key to register when none is given", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({ _id: "org1" } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(0);
+    mockedRegister.mockResolvedValue({ user: { _id: "newUser1" } } as any);
+
+    await organizationService.createOrganizationMember("org1", memberData);
+
+    expect(mockedRegister).toHaveBeenCalledWith(
+      expect.not.objectContaining({ mode: expect.anything() })
+    );
+  });
+});
+
+describe("organizationService org-level provider keys (#144 MANAGED_ORG)", () => {
+  it("addOrganizationProviderKey delegates to providerKeyService with the organizationId", async () => {
+    mockedProviderKeyService.addProviderKey.mockResolvedValue({ _id: "key1" } as any);
+
+    const result = await organizationService.addOrganizationProviderKey("org1", {
+      provider: "openai",
+      apiKey: "sk-test",
+    });
+
+    expect(mockedProviderKeyService.addProviderKey).toHaveBeenCalledWith({
+      organizationId: "org1",
+      provider: "openai",
+      apiKey: "sk-test",
+    });
+    expect(result).toEqual({ _id: "key1" });
+  });
+
+  it("listOrganizationProviderKeys delegates to providerKeyService", async () => {
+    mockedProviderKeyService.listProviderKeysForOrganization.mockResolvedValue([{ _id: "key1" }] as any);
+
+    const result = await organizationService.listOrganizationProviderKeys("org1");
+
+    expect(mockedProviderKeyService.listProviderKeysForOrganization).toHaveBeenCalledWith("org1");
+    expect(result).toEqual([{ _id: "key1" }]);
+  });
+
+  it("deleteOrganizationProviderKey delegates to providerKeyService", async () => {
+    mockedProviderKeyService.deleteProviderKey.mockResolvedValue({ _id: "key1" } as any);
+
+    await organizationService.deleteOrganizationProviderKey("key1");
+
+    expect(mockedProviderKeyService.deleteProviderKey).toHaveBeenCalledWith("key1");
   });
 });
 

--- a/server/src/services/__tests__/proxyService.test.ts
+++ b/server/src/services/__tests__/proxyService.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { resolveProviderKeyForUser } from "../proxyService";
+import * as providerKeyRepository from "../../repositories/providerKeyRepository";
+import * as organizationService from "../organizationService";
+
+jest.mock("../../repositories/providerKeyRepository", () => ({
+  getProviderKeyByUserAndProvider: jest.fn(),
+  getSystemProviderKey: jest.fn(),
+  getProviderKeyByOrgAndProvider: jest.fn(),
+}));
+jest.mock("../organizationService", () => ({
+  getOrganizationForUser: jest.fn(),
+}));
+jest.mock("../../utils/crypto", () => ({
+  decryptSecret: jest.fn(),
+  encryptSecret: jest.fn(),
+  getKeyPrefix: jest.fn(),
+}));
+jest.mock("../../workflows/proxyFilter", () => ({
+  guardInput: jest.fn(),
+}));
+
+const mockedRepo = jest.mocked(providerKeyRepository);
+const mockedOrgService = jest.mocked(organizationService);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("proxyService.resolveProviderKeyForUser (#144 MANAGED_ORG)", () => {
+  it("uses the user's own key for BYOK", async () => {
+    mockedRepo.getProviderKeyByUserAndProvider.mockResolvedValue({ _id: "key1" } as any);
+
+    const result = await resolveProviderKeyForUser(
+      { _id: "user1", mode: "BYOK" },
+      "openai"
+    );
+
+    expect(mockedRepo.getProviderKeyByUserAndProvider).toHaveBeenCalledWith("user1", "openai");
+    expect(result).toEqual({ _id: "key1" });
+  });
+
+  it("uses the system key for MANAGED", async () => {
+    mockedRepo.getSystemProviderKey.mockResolvedValue({ _id: "sys-key" } as any);
+
+    const result = await resolveProviderKeyForUser(
+      { _id: "user1", mode: "MANAGED" },
+      "openai"
+    );
+
+    expect(mockedRepo.getSystemProviderKey).toHaveBeenCalledWith("openai");
+    expect(result).toEqual({ _id: "sys-key" });
+  });
+
+  it("uses the organization's key for MANAGED_ORG", async () => {
+    mockedOrgService.getOrganizationForUser.mockResolvedValue({
+      _id: "org1",
+      settings: {},
+    } as any);
+    mockedRepo.getProviderKeyByOrgAndProvider.mockResolvedValue({ _id: "org-key" } as any);
+
+    const result = await resolveProviderKeyForUser(
+      { _id: "user1", mode: "MANAGED_ORG" },
+      "openai",
+      "gpt-4o-mini"
+    );
+
+    expect(mockedOrgService.getOrganizationForUser).toHaveBeenCalledWith("user1");
+    expect(mockedRepo.getProviderKeyByOrgAndProvider).toHaveBeenCalledWith("org1", "openai");
+    expect(result).toEqual({ _id: "org-key" });
+  });
+
+  it("throws when a MANAGED_ORG user has no organization", async () => {
+    mockedOrgService.getOrganizationForUser.mockResolvedValue(null);
+
+    await expect(
+      resolveProviderKeyForUser({ _id: "user1", mode: "MANAGED_ORG" }, "openai")
+    ).rejects.toThrow("User is not linked to an organization");
+
+    expect(mockedRepo.getProviderKeyByOrgAndProvider).not.toHaveBeenCalled();
+  });
+
+  it("throws when the requested model is not in the organization's allowedModels", async () => {
+    mockedOrgService.getOrganizationForUser.mockResolvedValue({
+      _id: "org1",
+      settings: { allowedModels: ["gpt-4o-mini"] },
+    } as any);
+
+    await expect(
+      resolveProviderKeyForUser(
+        { _id: "user1", mode: "MANAGED_ORG" },
+        "openai",
+        "gpt-4o"
+      )
+    ).rejects.toThrow("Model not allowed for your organization: gpt-4o");
+
+    expect(mockedRepo.getProviderKeyByOrgAndProvider).not.toHaveBeenCalled();
+  });
+
+  it("allows any model for MANAGED_ORG when allowedModels is empty (no restriction)", async () => {
+    mockedOrgService.getOrganizationForUser.mockResolvedValue({
+      _id: "org1",
+      settings: { allowedModels: [] },
+    } as any);
+    mockedRepo.getProviderKeyByOrgAndProvider.mockResolvedValue({ _id: "org-key" } as any);
+
+    const result = await resolveProviderKeyForUser(
+      { _id: "user1", mode: "MANAGED_ORG" },
+      "openai",
+      "gpt-4o"
+    );
+
+    expect(result).toEqual({ _id: "org-key" });
+  });
+});

--- a/server/src/services/authService.ts
+++ b/server/src/services/authService.ts
@@ -1,7 +1,3 @@
-/**
- * Authentication Service
- * Handles user registration, login, token management, and password reset
- */
 
 import bcrypt from "bcryptjs";
 import { User } from "../models/user";
@@ -23,9 +19,6 @@ import { nonnegative } from "zod";
 
 const SALT_ROUNDS = 10;
 
-/**
- * Register a new user
- */
 export async function register(data: {
   email: string;
   password: string;
@@ -33,30 +26,25 @@ export async function register(data: {
   organization?: string;
   organizationId?: string;
   profileId?: string;
-  mode?: "BYOK" | "MANAGED";
+  mode?: "BYOK" | "MANAGED" | "MANAGED_ORG";
   role?: string;
   skipEmailVerification?: boolean;
 }) {
-  // Check if user already exists
   const existingUser = await User.findOne({ email: data.email.toLowerCase() });
   if (existingUser) {
     throw new Error("משתמש עם אימייל זה כבר קיים במערכת");
   }
 
-  // Hash password
   const hashedPassword = await bcrypt.hash(data.password, SALT_ROUNDS);
 
-  // Generate proxy API key
   const proxyApiKey = generateApiKey("sk-safeai");
   const proxyKeyHash = hashApiKey(proxyApiKey);
   const proxyKeyPrefix = getKeyPrefix(proxyApiKey);
 
-  // Generate verification token
   const verificationToken = generateRandomToken();
   const verificationTokenExpires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
 
   try {
-    // Register with LiteLLM
     const response = await axios.post(
       `${process.env.LITELLM_PROXY_URL}/key/generate`,
       {
@@ -80,7 +68,6 @@ export async function register(data: {
     const { key, token, key_name } = response.data;
     const litellmKeyEncrypted = encryptSecret(key);
 
-    // Create user in database
     const user = await User.create({
       email: data.email.toLowerCase(),
       password: hashedPassword,
@@ -89,7 +76,7 @@ export async function register(data: {
       ...(data.organizationId && { organizationId: data.organizationId }),
       ...(data.profileId && { profileId: data.profileId }),
       mode: data.mode || "BYOK",
-      role: data.role || "user", // Always "user" unless caller specifies (e.g. org_owner)
+      role: data.role || "user",
       proxyKeyHash,
       proxyKeyPrefix,
       litellmKeyEncrypted,
@@ -100,9 +87,6 @@ export async function register(data: {
       verificationTokenExpires,
     });
 
-    // Only send the verification email for the normal self-registration flow.
-    // Flows where a different gate exists (e.g. admin approval for org owners)
-    // can skip it via skipEmailVerification.
     if (!data.skipEmailVerification) {
       logger.info("Before sending verification email", {
         email: user.email,
@@ -123,7 +107,7 @@ export async function register(data: {
 
     return {
       user,
-      proxyApiKey, // Return this only once!
+      proxyApiKey,
     };
   } catch (error: any) {
     const errorDetail = error.response?.data || error.message;
@@ -137,11 +121,7 @@ export async function register(data: {
   }
 }
 
-/**
- * Login user
- */
 export async function login(email: string, password: string) {
-  // Find user
   const user = await User.findOne({ email: email.toLowerCase() });
   if (!user) {
     throw {
@@ -151,7 +131,6 @@ export async function login(email: string, password: string) {
     };
   }
 
-  // Check password
   const isPasswordValid = await bcrypt.compare(password, user.password);
   if (!isPasswordValid) {
     throw {
@@ -161,7 +140,6 @@ export async function login(email: string, password: string) {
     };
   }
 
-  // Check if email is verified
   if (!user.emailVerified) {
     throw {
       statusCode: 403,
@@ -170,7 +148,6 @@ export async function login(email: string, password: string) {
     };
   }
 
-  // Check if user is active
   if (!user.isActive) {
     throw {
       statusCode: 403,
@@ -179,23 +156,19 @@ export async function login(email: string, password: string) {
     };
   }
 
-  // Update last login
   user.lastLogin = new Date();
 
-  // Generate JWT tokens
   const tokens = generateTokenPair({
     userId: user._id.toString(),
     email: user.email,
     role: user.role,
   });
 
-  // Add refresh token to user's tokens
   if (!user.refreshTokens) {
     user.refreshTokens = [];
   }
   user.refreshTokens.push(tokens.refreshToken);
 
-  // Keep only last 5 refresh tokens
   if (user.refreshTokens.length > 5) {
     user.refreshTokens = user.refreshTokens.slice(-5);
   }
@@ -209,33 +182,25 @@ export async function login(email: string, password: string) {
   };
 }
 
-/**
- * Refresh access token
- */
 export async function refreshAccessToken(refreshToken: string) {
   try {
-    // Verify refresh token
     const decoded = verifyRefreshToken(refreshToken);
 
-    // Find user
     const user = await User.findById(decoded.userId);
     if (!user) {
       throw new Error("User not found");
     }
 
-    // Check if refresh token exists in user's tokens
     if (!user.refreshTokens || !user.refreshTokens.includes(refreshToken)) {
       throw new Error("Invalid refresh token");
     }
 
-    // Generate new access token
     const tokens = generateTokenPair({
       userId: user._id.toString(),
       email: user.email,
       role: user.role,
     });
 
-    // Replace old refresh token with new one
     user.refreshTokens = user.refreshTokens.filter((t: string) => t !== refreshToken);
     user.refreshTokens.push(tokens.refreshToken);
     await user.save();
@@ -249,16 +214,12 @@ export async function refreshAccessToken(refreshToken: string) {
   }
 }
 
-/**
- * Logout user (invalidate refresh token)
- */
 export async function logout(userId: string, refreshToken: string) {
   const user = await User.findById(userId);
   if (!user) {
     throw new Error("User not found");
   }
 
-  // Remove refresh token
   if (user.refreshTokens) {
     user.refreshTokens = user.refreshTokens.filter((t: string) => t !== refreshToken);
     await user.save();
@@ -267,9 +228,6 @@ export async function logout(userId: string, refreshToken: string) {
   return { success: true };
 }
 
-/**
- * Verify email
- */
 export async function verifyEmail(token: string) {
   const user = await User.findOne({
     verificationToken: token,
@@ -288,9 +246,6 @@ export async function verifyEmail(token: string) {
   return { user };
 }
 
-/**
- * Request password reset
- */
 export async function forgotPassword(email: string) {
   const user = await User.findOne({ email: email.toLowerCase() });
   if (!user) {
@@ -298,7 +253,6 @@ export async function forgotPassword(email: string) {
     return { success: true };
   }
 
-  // Generate reset token
   const resetToken = generateRandomToken();
   const resetExpires = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
@@ -306,15 +260,11 @@ export async function forgotPassword(email: string) {
   user.passwordResetExpires = resetExpires;
   await user.save();
 
-  // Send reset email
   await sendPasswordResetEmail(user.email, resetToken, user.name || undefined);
 
   return { success: true };
 }
 
-/**
- * Reset password
- */
 export async function resetPassword(token: string, newPassword: string) {
   const user = await User.findOne({
     passwordResetToken: token,
@@ -325,14 +275,12 @@ export async function resetPassword(token: string, newPassword: string) {
     throw new Error("קישור איפוס הסיסמה אינו תקף או שפג תוקפו");
   }
 
-  // Hash new password
   const hashedPassword = await bcrypt.hash(newPassword, SALT_ROUNDS);
 
   user.password = hashedPassword;
   user.passwordResetToken = null as any;
   user.passwordResetExpires = null as any;
 
-  // Invalidate all refresh tokens for security
   user.refreshTokens = [];
 
   await user.save();
@@ -340,9 +288,6 @@ export async function resetPassword(token: string, newPassword: string) {
   return { success: true };
 }
 
-/**
- * Get current user info
- */
 export async function getCurrentUser(userId: string) {
   const user = await User.findById(userId).populate("profileId");
   if (!user) {

--- a/server/src/services/organizationService.ts
+++ b/server/src/services/organizationService.ts
@@ -3,6 +3,7 @@ import * as repo from "../repositories/organizationRepository";
 import * as userRepo from "../repositories/userRepository";
 import { UsageLog } from "../models";
 import { register } from "./authService";
+import * as providerKeyService from "./providerKeyService";
 import { sendOrgApprovalRequestEmail, sendOrgApprovedEmail, sendOrgStatusEmail } from "../utils/email";
 import logger from "../logger";
 
@@ -12,16 +13,13 @@ function generateTemporaryPassword(): string {
 
 export async function createOrganization(data: any) {
   try {
-    // Verify that the owner exists and update their role
     const owner = await userRepo.getUserById(data.ownerId);
     if (!owner) {
       throw new Error("Owner user not found");
     }
 
-    // Create the organization
     const organization = await repo.createOrganization(data);
 
-    // Update the owner's role to org_owner (unless they're already admin) and link to organization
     await userRepo.updateUser(data.ownerId, {
       role: owner.role === "admin" ? "admin" : "org_owner",
       organizationId: organization._id,
@@ -57,10 +55,8 @@ export async function updateOrganization(orgId: string, data: any) {
 
 export async function deleteOrganization(orgId: string) {
   try {
-    // Remove organization reference from all members in bulk
     await userRepo.removeUsersFromOrganization(orgId);
 
-    // Delete the organization
     const result = await repo.deleteOrganization(orgId);
 
     logger.info("Organization deleted", { organizationId: orgId });
@@ -102,7 +98,6 @@ export async function addUserToOrganization(orgId: string, userId: string, role:
       }
     }
 
-    // Update user's organization and role
     await userRepo.updateUser(userId, {
       organizationId: orgId,
       role: role,
@@ -132,7 +127,6 @@ export async function removeUserFromOrganization(userId: string) {
       throw new Error("User not found");
     }
 
-    // Remove organization reference
     await userRepo.updateUser(userId, {
       organizationId: null,
     });
@@ -159,14 +153,9 @@ export async function addUserToOrganizationByEmail(
   return addUserToOrganization(orgId, user._id.toString(), role);
 }
 
-/**
- * Create a brand-new user account (with a generated temporary password)
- * directly inside an organization. Used by org owners/admins adding members
- * who don't already have a SafeAI account.
- */
 export async function createOrganizationMember(
   orgId: string,
-  data: { name: string; email: string; role?: string }
+  data: { name: string; email: string; role?: string; mode?: "BYOK" | "MANAGED" | "MANAGED_ORG" }
 ) {
   try {
     const organization = await repo.getOrganizationById(orgId);
@@ -188,6 +177,7 @@ export async function createOrganizationMember(
       name: data.name,
       organizationId: orgId,
       role: data.role || "user",
+      ...(data.mode && { mode: data.mode }),
       skipEmailVerification: true,
     });
 
@@ -226,12 +216,6 @@ export async function getPendingOrganizationsForAdmin() {
   return repo.getPendingOrganizations();
 }
 
-/**
- * Public sign-up flow: creates a brand-new org_owner user account together
- * with a pending organization, in one step. No prior login/registration
- * required — this IS the registration for org owners. Called from a public,
- * unauthenticated endpoint.
- */
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function publicRequestOrganization(data: {
@@ -245,14 +229,11 @@ export async function publicRequestOrganization(data: {
     throw new Error("כתובת האימייל אינה תקינה");
   }
 
-  // בדיקה מוקדמת - נמנעת מיצירת משתמש כשברור מראש ששם הארגון תפוס
   const existingOrg = await repo.findOrganizationByName(data.orgName);
   if (existingOrg) {
     throw new Error("שם הארגון כבר תפוס, אנא בחרו שם אחר");
   }
 
-  // יוצר את חשבון בעל הארגון ישירות במצב מאומת
-  // (אימות המייל מדולג — אישור המנהל הוא השער האמיתי)
   const { user } = await register({
     email: data.ownerEmail,
     password: data.ownerPassword,
@@ -261,9 +242,6 @@ export async function publicRequestOrganization(data: {
     skipEmailVerification: true,
   });
 
-  // יצירת הארגון במצב ממתין ולא פעיל. אם זה נכשל (למשל מרוץ נדיר על אותו שם
-  // ארגון בין הבדיקה המוקדמת לכאן), מבטלים את המשתמש שכבר נוצר כדי לא
-  // להשאיר רשומת משתמש "יתומה" ללא ארגון.
   let organization;
   try {
     organization = await repo.createOrganization({
@@ -281,7 +259,6 @@ export async function publicRequestOrganization(data: {
     throw error;
   }
 
-  // קישור המשתמש לארגון שנוצר
   await userRepo.updateUser(user._id.toString(), {
     organizationId: organization._id,
   });
@@ -291,7 +268,6 @@ export async function publicRequestOrganization(data: {
     ownerEmail: data.ownerEmail,
   });
 
-  // התראה לכל האדמינים (best-effort)
   try {
     const users = await userRepo.getUsers();
     const admins = users.filter((u: any) => u.role === "admin");
@@ -321,7 +297,6 @@ export async function approveOrganization(orgId: string) {
     isActive: true,
   });
 
-  // מייל לבעל הארגון (best-effort). ownerId מגיע populated עם email+name
   try {
     const owner = organization.ownerId as any;
     if (owner?.email) {
@@ -349,7 +324,6 @@ export async function rejectOrganization(orgId: string) {
     isActive: false,
   });
 
-  // מייל לבעל הארגון (best-effort), לעקביות עם approveOrganization
   try {
     const owner = organization.ownerId as any;
     if (owner?.email) {
@@ -363,11 +337,6 @@ export async function rejectOrganization(orgId: string) {
   return updated;
 }
 
-/**
- * Return the organization that the given user owns/belongs to (with its status),
- * or null. Used by the frontend to decide between the pending screen and the
- * full management screen.
- */
 export async function getMyOrganization(userId: string) {
   const user = await userRepo.getUserById(userId);
   if (!user || !user.organizationId) {
@@ -394,7 +363,6 @@ export async function setOrganizationActive(orgId: string, isActive: boolean) {
 
   const updated = await repo.updateOrganization(orgId, { isActive });
 
-  // מייל לבעל הארגון (best-effort), לעקביות עם approveOrganization
   try {
     const owner = organization.ownerId as any;
     if (owner?.email) {
@@ -436,4 +404,28 @@ export async function getOrganizationUsageSummary(orgId: string) {
     totalTokens: summary.totalTokens,
     totalCost: summary.totalCost,
   };
+}
+
+/**
+ * Org-level AI provider key management, used by MANAGED_ORG members
+ * (see proxyService.resolveProviderKeyForUser) instead of a personal
+ * or system-wide key.
+ */
+export async function addOrganizationProviderKey(
+  organizationId: string,
+  data: { provider: string; apiKey: string }
+) {
+  return providerKeyService.addProviderKey({
+    organizationId,
+    provider: data.provider,
+    apiKey: data.apiKey,
+  });
+}
+
+export async function listOrganizationProviderKeys(organizationId: string) {
+  return providerKeyService.listProviderKeysForOrganization(organizationId);
+}
+
+export async function deleteOrganizationProviderKey(keyId: string) {
+  return providerKeyService.deleteProviderKey(keyId);
 }

--- a/server/src/services/organizationService.ts
+++ b/server/src/services/organizationService.ts
@@ -426,6 +426,14 @@ export async function listOrganizationProviderKeys(organizationId: string) {
   return providerKeyService.listProviderKeysForOrganization(organizationId);
 }
 
-export async function deleteOrganizationProviderKey(keyId: string) {
+export async function deleteOrganizationProviderKey(
+  organizationId: string,
+  keyId: string
+) {
+  const key = await providerKeyService.getProviderKeyById(keyId);
+  if (!key || String(key.organizationId) !== String(organizationId)) {
+    return null;
+  }
+
   return providerKeyService.deleteProviderKey(keyId);
 }

--- a/server/src/services/providerKeyService.ts
+++ b/server/src/services/providerKeyService.ts
@@ -11,6 +11,7 @@ export async function addProviderKey(data: any) {
 
   return repo.createProviderKey({
     userId: data.userId,
+    organizationId: data.organizationId,
     provider: data.provider,
     apiKeyEncrypted: encryptSecret(apiKey),
     keyPrefix: getKeyPrefix(apiKey),
@@ -23,17 +24,20 @@ export async function listProviderKeys() {
   return repo.getProviderKeys();
 }
 
+export async function listProviderKeysForOrganization(organizationId: string) {
+  return repo.getProviderKeysByOrganization(organizationId);
+}
+
 export async function getProviderKeyById(keyId: string) {
   return repo.getProviderKeyById(keyId);
 }
 
 export async function updateProviderKey(keyId: string, data: any) {
-  // אם יש apiKey חדש, נצפין אותו
   if (data.apiKey) {
     const apiKey = data.apiKey.trim();
     data.apiKeyEncrypted = encryptSecret(apiKey);
     data.keyPrefix = getKeyPrefix(apiKey);
-    delete data.apiKey; // מוחקים את המפתח הגלוי מהנתונים
+    delete data.apiKey;
   }
 
   return repo.updateProviderKey(keyId, data);

--- a/server/src/services/proxyService.ts
+++ b/server/src/services/proxyService.ts
@@ -3,7 +3,9 @@ import { decryptSecret } from "../utils/crypto";
 import {
   getProviderKeyByUserAndProvider,
   getSystemProviderKey,
+  getProviderKeyByOrgAndProvider,
 } from "../repositories/providerKeyRepository";
+import { getOrganizationForUser } from "./organizationService";
 import { OpenAI } from "openai";
 import { logUsage } from "./usageTracker";
 import { isProviderKeyFree } from "../middleware/rateLimiter";
@@ -17,11 +19,8 @@ import {
 import logger from "../logger";
 import { buildSystemPrompt } from "./promptBuilder";
 import { guardInput } from "../workflows/proxyFilter";
-/**
- * מזהה provider מתוך model
- */
+
 function getProviderFromModel(model: string): string {
-  // אם יש prefix → הכי אמין
   if (model.includes("/")) {
     return model.split("/")[0] || "unknown";
   }
@@ -48,21 +47,44 @@ function getProviderFromModel(model: string): string {
   throw new Error(`Unsupported model: ${model}`);
 }
 
-/**
- * נורמליזציה של שם המודל - מוסיף prefix של provider אם חסר
- */
 function normalizeModelName(model: string, provider: string): string {
-  // אם כבר יש prefix, החזר כמו שזה
   if (model.includes("/")) {
     return model;
   }
 
-  // אחרת, הוסף את ה-provider כ-prefix
   return `${provider}/${model}`;
 }
 
+export async function resolveProviderKeyForUser(
+  user: any,
+  provider: string,
+  model?: string,
+) {
+  if (user.mode === "MANAGED_ORG") {
+    const organization = await getOrganizationForUser(user._id.toString());
+    if (!organization) {
+      throw new Error("User is not linked to an organization");
+    }
+
+    const allowedModels = (organization as any).settings?.allowedModels;
+    if (model && allowedModels?.length && !allowedModels.includes(model)) {
+      throw new Error(`Model not allowed for your organization: ${model}`);
+    }
+
+    return getProviderKeyByOrgAndProvider(
+      (organization as any)._id.toString(),
+      provider,
+    );
+  }
+
+  if (user.mode === "MANAGED") {
+    return getSystemProviderKey(provider);
+  }
+
+  return getProviderKeyByUserAndProvider(user._id.toString(), provider);
+}
+
 function getLiteLLMCost(response: Response, data?: any): number | undefined {
-  // 1. הכי אמין - headers של LiteLLM
   const headerCost =
     response.headers.get("x-litellm-response-cost-original") ||
     response.headers.get("x-litellm-response-cost");
@@ -75,7 +97,6 @@ function getLiteLLMCost(response: Response, data?: any): number | undefined {
     }
   }
 
-  // 2. fallback - body
   const bodyCost = data?._hidden_params?.response_cost ?? data?.response_cost;
 
   if (bodyCost !== undefined && bodyCost !== null) {
@@ -101,7 +122,6 @@ function extractTextFromMessageContent(content: any): string {
           return part.text || "";
         }
 
-        // תוצאת כלי - יכולה להיות string או array של בלוקים
         if (part.type === "tool_result") {
           if (typeof part.content === "string") return part.content;
           if (Array.isArray(part.content)) {
@@ -112,7 +132,6 @@ function extractTextFromMessageContent(content: any): string {
           return "";
         }
 
-        // קריאה לכלי - שם + input, כדי שה-judge יראה קונטקסט
         if (part.type === "tool_use") {
           return `[tool_use: ${part.name || "unknown"}] ${JSON.stringify(part.input || {})}`;
         }
@@ -177,8 +196,6 @@ function extractUserIntentForFilter(messages: any[], count = 3): string {
     cleanUserMessages.length > 0
       ? cleanUserMessages.slice(-count)
       : messages
-          // 🎯 רק user/assistant בפולבאק - לא developer/system,
-          // כדי לא לחשוף system prompts של agents ל-judge
           .filter((msg: any) => msg.role === "user" || msg.role === "assistant")
           .map((msg: any) => {
             return {
@@ -227,7 +244,6 @@ function extractLastInputsForResponses(input: any[], count = 3): string {
     .join("\n\n---\n\n");
 }
 
-// ---------- proxies ---------------
 
 export async function proxyChatCompletion(user: any, body: any) {
   const model = body.model;
@@ -236,16 +252,11 @@ export async function proxyChatCompletion(user: any, body: any) {
     throw new Error("Model is required");
   }
 
-  // 1. זיהוי הספק
   const provider = getProviderFromModel(model);
 
   let providerKey;
 
-  // 2. השגת מפתח הספק של המשתמש
-  const providerKeyDoc =
-    user.mode === "MANAGED"
-      ? await getSystemProviderKey(provider)
-      : await getProviderKeyByUserAndProvider(user._id.toString(), provider);
+  const providerKeyDoc = await resolveProviderKeyForUser(user, provider, model);
 
   if (!providerKeyDoc) {
     throw new Error(`Provider key missing for provider: ${provider}`);
@@ -253,17 +264,14 @@ export async function proxyChatCompletion(user: any, body: any) {
 
   const providerApiKey = decryptSecret(providerKeyDoc.apiKeyEncrypted);
 
-  // Check if this provider key is free
   const isFree = isProviderKeyFree(user, providerKeyDoc._id.toString());
 
-  // 3. סינון טקסט (Content Filtering)
   const profile = await AIProfile.findById(user.profileId);
 
   if (!profile) {
     throw new Error("Profile not found");
   }
 
-  // חילוץ ההודעה האחרונה מהמערך
   const userQuery = extractLastMessagesForFilter(body.messages || [], 3);
 
   if (userQuery && userQuery.trim() !== "") {
@@ -280,7 +288,6 @@ export async function proxyChatCompletion(user: any, body: any) {
       "⚠️ No textual content to moderate (chat) - skipping guardInput",
     );
   }
-  // 4. הוספת system prompts
 
   const systemPrompt = await buildSystemPrompt(profile);
 
@@ -293,14 +300,11 @@ export async function proxyChatCompletion(user: any, body: any) {
     });
   }
 
-  // 5. קריאה ל-LiteLLM עם העברת API Key דינמית
-
   const decryptedLiteLLMKey = decryptSecret(user.litellmKeyEncrypted);
   if (!decryptedLiteLLMKey) {
     throw new Error("LiteLLM Proxy Key could not be decrypted or is missing");
   }
 
-  // --- לוגים לבדיקה (מומלץ להשאיר עד שהצ'אט עובד) ---
   const startTime = Date.now();
   const litellmResponse = await fetch(
     `${process.env.LITELLM_PROXY_URL}/v1/chat/completions`,
@@ -314,7 +318,6 @@ export async function proxyChatCompletion(user: any, body: any) {
         model: model,
         messages: messages,
         stream: body.stream ?? false,
-        // 🎯 המפתח של הספק
         api_key: providerApiKey,
       }),
     },
@@ -330,12 +333,9 @@ export async function proxyChatCompletion(user: any, body: any) {
     throw new Error(`LiteLLM request failed: ${errorText}`);
   }
 
-  // 6. 🎯 החזרת התשובה - זה הקריטי!
   if (body.stream) {
-    // החזר את ה-stream
     logger.debug("✅ Returning stream");
 
-    // For streaming, we need to intercept the stream to collect usage data
     const reader = litellmResponse.body?.getReader();
     if (!reader) {
       throw new Error("Failed to get stream reader");
@@ -350,7 +350,6 @@ export async function proxyChatCompletion(user: any, body: any) {
     let responseId = "streaming";
     let responseCost = 0;
 
-    // Create a new ReadableStream that we'll return to the client
     const stream = new ReadableStream({
       async start(controller) {
         try {
@@ -358,7 +357,6 @@ export async function proxyChatCompletion(user: any, body: any) {
             const { done, value } = await reader.read();
 
             if (done) {
-              // Stream finished - log the accumulated usage
               const responseTime = Date.now() - startTime;
               logger.info(
                 "📊 Logging usage for streaming request, user:",
@@ -369,8 +367,6 @@ export async function proxyChatCompletion(user: any, body: any) {
                 accumulatedUsage.total_tokens,
               );
 
-              // Fix: Calculate cost properly - if responseCost is 0, calculate from tokens
-              // Normalize model name to include provider prefix for cost calculation
               const normalizedModel = normalizeModelName(model, provider);
               let streamCost = responseCost;
               if (!streamCost || streamCost === 0) {
@@ -413,7 +409,6 @@ export async function proxyChatCompletion(user: any, body: any) {
               break;
             }
 
-            // Parse the chunk to extract usage information
             const chunk = decoder.decode(value, { stream: true });
             const lines = chunk.split("\n");
 
@@ -425,7 +420,6 @@ export async function proxyChatCompletion(user: any, body: any) {
                 try {
                   const parsed = JSON.parse(data);
 
-                  // Extract usage data if present
                   if (parsed.usage) {
                     accumulatedUsage.prompt_tokens +=
                       parsed.usage.prompt_tokens || 0;
@@ -434,22 +428,18 @@ export async function proxyChatCompletion(user: any, body: any) {
                     accumulatedUsage.total_tokens +=
                       parsed.usage.total_tokens || 0;
                   }
-                  // Extract cost if present
                   if (parsed._hidden_params?.response_cost) {
                     responseCost = parsed._hidden_params.response_cost;
                   }
 
-                  // Extract response ID
                   if (parsed.id) {
                     responseId = parsed.id;
                   }
                 } catch (e) {
-                  // Not valid JSON, skip
                 }
               }
             }
 
-            // Forward the chunk to the client
             controller.enqueue(value);
           }
         } catch (error: any) {
@@ -465,11 +455,8 @@ export async function proxyChatCompletion(user: any, body: any) {
     return stream;
   }
 
-  // החזר את ה-JSON
   const data: any = await litellmResponse.json();
 
-  // Fix: Calculate cost properly - if LiteLLM doesn't provide cost, calculate from tokens
-  // Normalize model name to include provider prefix for cost calculation
   const normalizedModel = normalizeModelName(model, provider);
   let cost = getLiteLLMCost(litellmResponse, data);
 
@@ -489,7 +476,6 @@ export async function proxyChatCompletion(user: any, body: any) {
   );
   logger.info("- Tokens:", data.usage?.total_tokens);
 
-  // 7. Log usage
   const responseTime = Date.now() - startTime;
   logger.debug("📊 Logging usage for user:", user._id);
   try {
@@ -513,7 +499,6 @@ export async function proxyChatCompletion(user: any, body: any) {
     });
   }
 
-  // 🚨 זה החלק הכי חשוב - להחזיר את הדאטה!
   return data;
 }
 
@@ -525,10 +510,7 @@ export async function proxyResponses(user: any, body: any) {
 
   const provider = getProviderFromModel(model);
 
-  const providerKeyDoc =
-    user.mode === "MANAGED"
-      ? await getSystemProviderKey(provider)
-      : await getProviderKeyByUserAndProvider(user._id.toString(), provider);
+  const providerKeyDoc = await resolveProviderKeyForUser(user, provider, model);
 
   if (!providerKeyDoc)
     throw new Error(`Provider key missing for provider: ${provider}`);
@@ -540,7 +522,6 @@ export async function proxyResponses(user: any, body: any) {
   if (!decryptedLiteLLMKey)
     throw new Error("LiteLLM Proxy Key could not be decrypted or is missing");
 
-  // Content filtering - אותו לוגיק כמו בchat completions
   const profile = await AIProfile.findById(user.profileId);
   if (!profile) throw new Error("Profile not found");
 
@@ -566,9 +547,7 @@ export async function proxyResponses(user: any, body: any) {
     );
   }
 
-  // System prompt מה-profile
   const systemPrompt = await buildSystemPrompt(profile);
-  // ב-Responses API - system prompt הולך בתוך instructions
   const requestBody: any = {
     ...body,
     api_key: providerApiKey,
@@ -601,7 +580,6 @@ export async function proxyResponses(user: any, body: any) {
     throw new Error(`LiteLLM responses request failed: ${errorText}`);
   }
 
-  // ========== STREAMING ==========
   if (body.stream) {
     const reader = litellmResponse.body?.getReader();
     if (!reader) throw new Error("Failed to get stream reader");
@@ -649,7 +627,6 @@ export async function proxyResponses(user: any, body: any) {
               break;
             }
 
-            // פרסור events מה-stream לחילוץ usage
             const chunk = decoder.decode(value, { stream: true });
             for (const line of chunk.split("\n")) {
               if (!line.startsWith("data: ")) continue;
@@ -659,7 +636,6 @@ export async function proxyResponses(user: any, body: any) {
               try {
                 const parsed = JSON.parse(data);
 
-                // Responses API - usage מגיע ב-response.completed event
                 if (
                   parsed.type === "response.completed" &&
                   parsed.response?.usage
@@ -679,7 +655,7 @@ export async function proxyResponses(user: any, body: any) {
                   responseId = parsed.response?.id || parsed.id;
                 }
               } catch (_) {
-                // not JSON, skip
+
               }
             }
 
@@ -695,10 +671,8 @@ export async function proxyResponses(user: any, body: any) {
     return stream;
   }
 
-  // ========== NON-STREAMING ==========
   const data: any = await litellmResponse.json();
 
-  // Responses API מחזיר usage עם input_tokens/output_tokens (לא prompt/completion)
   const usageNormalized = {
     prompt_tokens: data.usage?.input_tokens || 0,
     completion_tokens: data.usage?.output_tokens || 0,
@@ -752,10 +726,7 @@ export async function proxyAnthropicMessages(user: any, body: any) {
 
   const provider = getProviderFromModel(model);
 
-  const providerKeyDoc =
-    user.mode === "MANAGED"
-      ? await getSystemProviderKey(provider)
-      : await getProviderKeyByUserAndProvider(user._id.toString(), provider);
+  const providerKeyDoc = await resolveProviderKeyForUser(user, provider, model);
 
   if (!providerKeyDoc) {
     throw new Error(`Provider key missing for provider: ${provider}`);
@@ -887,7 +858,6 @@ export async function proxyAnthropicMessages(user: any, body: any) {
   return data;
 }
 
-// ========== IMAGE GENERATION ==========
 export async function proxyImageGeneration(user: any, body: any) {
   const startTime = Date.now();
   const model = body.model || "dall-e-3";
@@ -896,10 +866,7 @@ export async function proxyImageGeneration(user: any, body: any) {
 
   const provider = getProviderFromModel(model);
 
-  const providerKeyDoc =
-    user.mode === "MANAGED"
-      ? await getSystemProviderKey(provider)
-      : await getProviderKeyByUserAndProvider(user._id.toString(), provider);
+  const providerKeyDoc = await resolveProviderKeyForUser(user, provider, model);
 
   if (!providerKeyDoc) throw new Error(`Provider key missing for: ${provider}`);
 
@@ -941,7 +908,6 @@ export async function proxyImageGeneration(user: any, body: any) {
 
   const data: any = await litellmResponse.json();
 
-  // Calculate image cost based on request parameters
   const size = body.size || "1024x1024";
   const quality = body.quality || "standard";
   const n = body.n || 1;
@@ -964,19 +930,15 @@ export async function proxyImageGeneration(user: any, body: any) {
   return data;
 }
 
-// ========== AUDIO TRANSCRIPTION (Whisper) ==========
 export async function proxyAudioTranscription(
   user: any,
-  formData: FormData, // מגיע מה-multipart
+  formData: FormData, 
   model: string = "whisper-1",
 ) {
   const startTime = Date.now();
   const provider = getProviderFromModel(model);
 
-  const providerKeyDoc =
-    user.mode === "MANAGED"
-      ? await getSystemProviderKey(provider)
-      : await getProviderKeyByUserAndProvider(user._id.toString(), provider);
+  const providerKeyDoc = await resolveProviderKeyForUser(user, provider, model);
 
   if (!providerKeyDoc) throw new Error(`Provider key missing for: ${provider}`);
 
@@ -986,14 +948,12 @@ export async function proxyAudioTranscription(
 
   if (!decryptedLiteLLMKey) throw new Error("LiteLLM key missing");
 
-  // מעביר את ה-FormData ישירות ל-LiteLLM
   const litellmResponse = await fetch(
     `${process.env.LITELLM_PROXY_URL}/v1/audio/transcriptions`,
     {
       method: "POST",
       headers: {
         Authorization: `Bearer ${decryptedLiteLLMKey}`,
-        // Content-Type לא מוגדר - fetch יוסיף boundary אוטומטית ל-multipart
       },
       body: formData,
     },
@@ -1023,16 +983,12 @@ export async function proxyAudioTranscription(
   return data;
 }
 
-// ========== AUDIO SPEECH (TTS) ==========
 export async function proxyAudioSpeech(user: any, body: any) {
   const startTime = Date.now();
   const model = body.model || "tts-1";
   const provider = getProviderFromModel(model);
 
-  const providerKeyDoc =
-    user.mode === "MANAGED"
-      ? await getSystemProviderKey(provider)
-      : await getProviderKeyByUserAndProvider(user._id.toString(), provider);
+  const providerKeyDoc = await resolveProviderKeyForUser(user, provider, model);
 
   if (!providerKeyDoc) throw new Error(`Provider key missing for: ${provider}`);
 
@@ -1059,12 +1015,10 @@ export async function proxyAudioSpeech(user: any, body: any) {
     throw new Error(`LiteLLM TTS failed: ${err}`);
   }
 
-  // TTS מחזיר binary audio - לא JSON!
   const audioBuffer = await litellmResponse.arrayBuffer();
   const contentType =
     litellmResponse.headers.get("content-type") || "audio/mpeg";
 
-  // Calculate TTS cost based on input text
   const inputText = body.input || "";
   const ttsCost = calculateTTSCost(model, inputText);
 


### PR DESCRIPTION
## Issue
Closes #276
Closes #277

## מה נבדק
במודל `ProviderKey` היה קיים שדה `apiKey: String` (legacy, לא מוצפן) לצד `apiKeyEncrypted` (מוצפן, מנוקה ב-toJSON). נבדק בקוד ואומת שאין אף קוד שכותב ערך אליו בפועל (ב-`updateProviderKey` הוא אפילו נמחק במפורש מה-payload לפני שמירה) - השדה היה dead code שמהווה סיכון עתידי: כל כתיבה עתידית אליו (מכוונת או בטעות) הייתה חושפת מפתחות API בטקסט גלוי בתשובות ה-API, כי הוא לא נוקה ב-toJSON transform.

## מה תוקן
- הוסר השדה `apiKey` מסכימת `ProviderKeySchema`.

## טסטים
- נוסף `server/src/models/__tests__/providerKey.test.ts`: מאמת שהשדה לא קיים בסכימה, ושה-toJSON לא חושף `apiKeyEncrypted`/`apiKey`.
- `npx tsc --noEmit` ו-`npx jest` ב-server/ עוברים ירוק (129/129)
