### PR TITLE
fix(org): consistent error logging for organization endpoints

### DIFF
--- a/server/src/controllers/organizationController.ts
+++ b/server/src/controllers/organizationController.ts
@@ -34,8 +34,12 @@ export async function createOrganizationHandler(req: Request, res: Response) {
     }
     const organization = await createOrganization(req.body);
     res.status(201).json({ success: true, organization });
-  } catch (error) {
-    logger.error("Failed to create organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to create organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+    });
     res.status(500).json({ error: "Failed to create organization" });
   }
 }
@@ -67,7 +71,11 @@ export async function listOrganizationsHandler(req: Request, res: Response) {
 
     return res.status(200).json(userOrganizations);
   } catch (error: any) {
-    logger.error("Failed to list organizations", { error });
+    logger.error("Failed to list organizations", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+    });
     return res.status(500).json({ error: "Failed to fetch organizations", details: error.message });
   }
 }
@@ -95,8 +103,13 @@ export async function getOrganizationHandler(
     }
 
     res.json(organization);
-  } catch (error) {
-    logger.error("Failed to get organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to get organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(500).json({ error: "Failed to get organization" });
   }
 }
@@ -133,8 +146,13 @@ export async function updateOrganizationHandler(
 
     const updatedOrg = await updateOrganization(orgId, updateData);
     res.json({ success: true, organization: updatedOrg });
-  } catch (error) {
-    logger.error("Failed to update organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to update organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(500).json({ error: "Failed to update organization" });
   }
 }
@@ -154,8 +172,13 @@ export async function deleteOrganizationHandler(
 
     await deleteOrganization(req.params.id);
     res.json({ success: true, message: "Organization deleted successfully" });
-  } catch (error) {
-    logger.error("Failed to delete organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to delete organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(500).json({ error: "Failed to delete organization" });
   }
 }
@@ -186,8 +209,13 @@ export async function getOrganizationUsersHandler(
 
     const users = await getOrganizationUsers(orgId);
     res.json(users);
-  } catch (error) {
-    logger.error("Failed to get organization users", { error });
+  } catch (error: any) {
+    logger.error("Failed to get organization users", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(500).json({ error: "Failed to get organization users" });
   }
 }
@@ -218,7 +246,12 @@ export async function addUserToOrganizationHandler(
     await addUserToOrganization(orgId, userId, role || "user");
     res.json({ success: true, message: "User added to organization" });
   } catch (error: any) {
-    logger.error("Failed to add user to organization", { error });
+    logger.error("Failed to add user to organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(400).json({ error: error.message || "Failed to add user" });
   }
 }
@@ -263,7 +296,12 @@ export async function createOrganizationMemberHandler(
       temporaryPassword,
     });
   } catch (error: any) {
-    logger.error("Failed to create organization member", { error });
+    logger.error("Failed to create organization member", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(400).json({ error: error.message || "Failed to create organization member" });
   }
 }
@@ -306,7 +344,12 @@ export async function addUserByEmailToOrganizationHandler(
       organization: updatedOrg,
     });
   } catch (error: any) {
-    logger.error("Failed to add user by email to organization", { error });
+    logger.error("Failed to add user by email to organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res
       .status(400)
       .json({ error: error.message || "Failed to add user by email" });
@@ -341,7 +384,12 @@ export async function removeUserFromOrganizationHandler(
       message: "User removed from organization successfully",
     });
   } catch (error: any) {
-    logger.error("Failed to remove user from organization", { error });
+    logger.error("Failed to remove user from organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      targetUserId: req.params.userId,
+    });
     res.status(400).json({ error: error.message || "Failed to remove user" });
   }
 }
@@ -361,6 +409,11 @@ export async function getPendingOrganizationsHandler(
       data: pendingOrganizations,
     });
   } catch (error: any) {
+    logger.error("Failed to get pending organizations", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+    });
     res.status(500).json({
       success: false,
       message: "שגיאה בשרת בעת שליפת ארגונים ממתינים",
@@ -403,7 +456,12 @@ export async function topUpOrganizationWalletHandler(
       organization: updatedOrg,
     });
   } catch (error: any) {
-    logger.error("Failed to top up organization wallet", { error });
+    logger.error("Failed to top up organization wallet", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(500).json({ error: "Failed to top up wallet", details: error.message });
   }
 }
@@ -411,12 +469,16 @@ export async function topUpOrganizationWalletHandler(
 /**
  * List ALL organizations with user counts + wallet balance (Admin only)
  */
-export async function getAllOrganizationsHandler(_req: Request, res: Response) {
+export async function getAllOrganizationsHandler(req: Request, res: Response) {
   try {
     const organizations = await listAllOrganizationsWithStats();
     res.status(200).json(organizations);
   } catch (error: any) {
-    logger.error("Failed to list all organizations", { error });
+    logger.error("Failed to list all organizations", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+    });
     res.status(500).json({ error: "Failed to fetch organizations" });
   }
 }
@@ -432,7 +494,12 @@ export async function suspendOrganizationHandler(
     const updated = await setOrganizationActive(req.params.id, false);
     res.json({ success: true, message: "Organization suspended", organization: updated });
   } catch (error: any) {
-    logger.error("Failed to suspend organization", { error });
+    logger.error("Failed to suspend organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(400).json({ error: error.message || "Failed to suspend organization" });
   }
 }
@@ -448,7 +515,12 @@ export async function activateOrganizationHandler(
     const updated = await setOrganizationActive(req.params.id, true);
     res.json({ success: true, message: "Organization reactivated", organization: updated });
   } catch (error: any) {
-    logger.error("Failed to reactivate organization", { error });
+    logger.error("Failed to reactivate organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(400).json({ error: error.message || "Failed to reactivate organization" });
   }
 }
@@ -480,7 +552,12 @@ export async function getOrganizationStatsHandler(
     const summary = await getOrganizationUsageSummary(orgId);
     res.json({ ...summary, walletBalance: (organization as any).walletBalance || 0 });
   } catch (error: any) {
-    logger.error("Failed to get organization stats", { error });
+    logger.error("Failed to get organization stats", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(500).json({ error: "Failed to fetch organization stats" });
   }
 }
@@ -514,7 +591,10 @@ export async function publicRequestOrganizationHandler(req: Request, res: Respon
       organization,
     });
   } catch (error: any) {
-    logger.error("Failed public organization request", { error });
+    logger.error("Failed public organization request", {
+      error: error.message,
+      stack: error.stack,
+    });
     // register() ו-publicRequestOrganization() כבר זורקים הודעות עבריות ברורות
     // ומובחנות עבור התנגשות אימייל לעומת התנגשות שם ארגון - מציגים אותן כמו
     // שהן במקום למפות כל שגיאה גורפת ל"אימייל כבר רשום".
@@ -535,7 +615,11 @@ export async function getMyOrganizationHandler(req: Request, res: Response) {
     const organization = await getMyOrganization(user.userId);
     res.json({ organization: organization || null });
   } catch (error: any) {
-    logger.error("Failed to get user's organization", { error });
+    logger.error("Failed to get user's organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+    });
     res.status(500).json({ error: "Failed to fetch organization" });
   }
 }
@@ -551,7 +635,12 @@ export async function approveOrganizationHandler(
     const updated = await approveOrganization(req.params.id);
     res.json({ success: true, message: "Organization approved", organization: updated });
   } catch (error: any) {
-    logger.error("Failed to approve organization", { error });
+    logger.error("Failed to approve organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(400).json({ error: error.message || "Failed to approve organization" });
   }
 }
@@ -567,7 +656,12 @@ export async function rejectOrganizationHandler(
     const updated = await rejectOrganization(req.params.id);
     res.json({ success: true, message: "Organization rejected", organization: updated });
   } catch (error: any) {
-    logger.error("Failed to reject organization", { error });
+    logger.error("Failed to reject organization", {
+      error: error.message,
+      stack: error.stack,
+      userId: (req as any).user?.userId,
+      organizationId: req.params.id,
+    });
     res.status(400).json({ error: error.message || "Failed to reject organization" });
   }
 }

--- a/server/src/repositories/organizationRepository.ts
+++ b/server/src/repositories/organizationRepository.ts
@@ -6,8 +6,12 @@ export async function createOrganization(data: any) {
     const organization = await Organization.create(data);
     logger.info("Organization created in DB", { organizationId: organization._id });
     return organization;
-  } catch (error) {
-    logger.error("Failed to create organization in DB", { error, data });
+  } catch (error: any) {
+    logger.error("Failed to create organization in DB", {
+      error: error.message,
+      stack: error.stack,
+      data,
+    });
     throw error;
   }
 }
@@ -34,10 +38,14 @@ export async function updateOrganization(orgId: string, data: any) {
       new: true,
       runValidators: true,
     }).lean();
-    logger.info("Organization updated in DB", { orgId, data });
+    logger.info("Organization updated in DB", { organizationId: orgId, data });
     return organization;
-  } catch (error) {
-    logger.error("Failed to update organization in DB", { error, orgId });
+  } catch (error: any) {
+    logger.error("Failed to update organization in DB", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
     throw error;
   }
 }
@@ -49,10 +57,15 @@ export async function incrementWalletBalance(orgId: string, amount: number) {
       { $inc: { walletBalance: amount } },
       { new: true, runValidators: true }
     ).lean();
-    logger.info("Organization wallet balance incremented in DB", { orgId, amount });
+    logger.info("Organization wallet balance incremented in DB", { organizationId: orgId, amount });
     return organization;
-  } catch (error) {
-    logger.error("Failed to increment organization wallet balance in DB", { error, orgId, amount });
+  } catch (error: any) {
+    logger.error("Failed to increment organization wallet balance in DB", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+      amount,
+    });
     throw error;
   }
 }
@@ -60,10 +73,14 @@ export async function incrementWalletBalance(orgId: string, amount: number) {
 export async function deleteOrganization(orgId: string) {
   try {
     const organization = await Organization.findByIdAndDelete(orgId).lean();
-    logger.info("Organization deleted in DB", { orgId });
+    logger.info("Organization deleted in DB", { organizationId: orgId });
     return organization;
-  } catch (error) {
-    logger.error("Failed to delete organization in DB", { error, orgId });
+  } catch (error: any) {
+    logger.error("Failed to delete organization in DB", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
     throw error;
   }
 }

--- a/server/src/services/organizationService.ts
+++ b/server/src/services/organizationService.ts
@@ -33,8 +33,11 @@ export async function createOrganization(data: any) {
     });
 
     return organization;
-  } catch (error) {
-    logger.error("Failed to create organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to create organization", {
+      error: error.message,
+      stack: error.stack,
+    });
     throw error;
   }
 }
@@ -66,8 +69,12 @@ export async function deleteOrganization(orgId: string) {
     logger.info("Organization deleted", { organizationId: orgId });
 
     return result;
-  } catch (error) {
-    logger.error("Failed to delete organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to delete organization", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
     throw error;
   }
 }
@@ -75,8 +82,12 @@ export async function deleteOrganization(orgId: string) {
 export async function getOrganizationUsers(orgId: string) {
   try {
     return await userRepo.getUsersByOrganization(orgId);
-  } catch (error) {
-    logger.error("Failed to get organization users", { error });
+  } catch (error: any) {
+    logger.error("Failed to get organization users", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
     throw error;
   }
 }
@@ -108,11 +119,16 @@ export async function addUserToOrganization(orgId: string, userId: string, role:
       role: role,
     });
 
-    logger.info("User added to organization", { userId, orgId, role });
+    logger.info("User added to organization", { userId, organizationId: orgId, role });
 
     return user;
-  } catch (error) {
-    logger.error("Failed to add user to organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to add user to organization", {
+      error: error.message,
+      stack: error.stack,
+      userId,
+      organizationId: orgId,
+    });
     throw error;
   }
 }
@@ -140,8 +156,12 @@ export async function removeUserFromOrganization(userId: string) {
     logger.info("User removed from organization", { userId });
 
     return user;
-  } catch (error) {
-    logger.error("Failed to remove user from organization", { error });
+  } catch (error: any) {
+    logger.error("Failed to remove user from organization", {
+      error: error.message,
+      stack: error.stack,
+      userId,
+    });
     throw error;
   }
 }
@@ -191,11 +211,15 @@ export async function createOrganizationMember(
       skipEmailVerification: true,
     });
 
-    logger.info("Organization member created", { orgId, userId: user._id });
+    logger.info("Organization member created", { organizationId: orgId, userId: user._id });
 
     return { user, temporaryPassword };
-  } catch (error) {
-    logger.error("Failed to create organization member", { error, orgId });
+  } catch (error: any) {
+    logger.error("Failed to create organization member", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
     throw error;
   }
 }
@@ -210,14 +234,19 @@ export async function topUpOrganizationWallet(orgId: string, amount: number) {
     const updateOrg = await repo.incrementWalletBalance(orgId, amount);
 
     logger.info("Organization wallet topped up successfully (Mock)", {
-      orgId,
+      organizationId: orgId,
       amount,
       newBalance: (updateOrg as any)?.walletBalance,
     });
 
     return updateOrg;
-  } catch (error) {
-    logger.error("Failed to top up organization wallet", { error });
+  } catch (error: any) {
+    logger.error("Failed to top up organization wallet", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+      amount,
+    });
     throw error;
   }
 }
@@ -300,8 +329,12 @@ export async function publicRequestOrganization(data: {
         sendOrgApprovalRequestEmail(admin.email, data.orgName, data.ownerEmail)
       )
     );
-  } catch (error) {
-    logger.error("Failed to notify admins about org request", { error });
+  } catch (error: any) {
+    logger.error("Failed to notify admins about org request", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: organization._id,
+    });
   }
 
   return organization;
@@ -327,11 +360,15 @@ export async function approveOrganization(orgId: string) {
     if (owner?.email) {
       await sendOrgApprovedEmail(owner.email, (organization as any).name, owner.name);
     }
-  } catch (error) {
-    logger.error("Failed to send org approved email", { error });
+  } catch (error: any) {
+    logger.error("Failed to send org approved email", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
   }
 
-  logger.info("Organization approved", { orgId });
+  logger.info("Organization approved", { organizationId: orgId });
   return updated;
 }
 
@@ -355,11 +392,15 @@ export async function rejectOrganization(orgId: string) {
     if (owner?.email) {
       await sendOrgStatusEmail("rejected", owner.email, (organization as any).name, owner.name);
     }
-  } catch (error) {
-    logger.error("Failed to send org rejected email", { error });
+  } catch (error: any) {
+    logger.error("Failed to send org rejected email", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
   }
 
-  logger.info("Organization rejected", { orgId });
+  logger.info("Organization rejected", { organizationId: orgId });
   return updated;
 }
 
@@ -405,11 +446,15 @@ export async function setOrganizationActive(orgId: string, isActive: boolean) {
         owner.name
       );
     }
-  } catch (error) {
-    logger.error("Failed to send org active-state email", { error });
+  } catch (error: any) {
+    logger.error("Failed to send org active-state email", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: orgId,
+    });
   }
 
-  logger.info("Organization active state changed", { orgId, isActive });
+  logger.info("Organization active state changed", { organizationId: orgId, isActive });
   return updated;
 }
 


### PR DESCRIPTION
## Summary
- Replaced raw `{ error }` (Error object) logging with explicit `error.message` + `error.stack` across all organization-related logger calls — raw Error objects serialize to `{}` in MongoDB and were losing all diagnostic info.
- Added `userId`/`organizationId` to error logs in `organizationController.ts` for traceability (pulled from `req`, since local `user`/`orgId` vars are out of scope inside `catch`).
- Standardized on `organizationId` instead of the inconsistent `orgId` key across `organizationService.ts` and `organizationRepository.ts` log context.
- Added a missing `logger.error` call in `getPendingOrganizationsHandler`, which previously logged nothing on failure.

Scope is intentionally limited to organization-related files only (`organizationController.ts`, `organizationService.ts`, `organizationRepository.ts`).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `organizationService.test.ts` — 44/44 passing, log output verified to contain readable `error` string, full `stack`, and consistent `organizationId`
- [x] Manually exercised several endpoints against a local server + MongoDB (register/login/org create/org suspend/etc.) and confirmed `context.error`/`stack`/`userId` are now populated correctly in stored log documents