### PR TITLE
Widen litellm healthcheck start_period (Neon cold-start varies)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -45,11 +45,11 @@ services:
       interval: 15s
       timeout: 5s
       retries: 5
-      # litellm runs Prisma DB migrations on every startup, which took ~100s
-      # against the real Postgres (Neon) — well past interval*retries (75s)
-      # with no grace period, so Docker gave up before it ever got healthy.
+      # litellm runs Prisma DB migrations on every startup. Neon Postgres is
+      # serverless and can be suspended, so first-connect latency varies a
+      # lot (observed 100s once, 245s another time) — 180s wasn't enough.
       # Failing checks during start_period don't count against retries.
-      start_period: 180s
+      start_period: 300s
 
   server:
     image: ${IMAGE_REGISTRY}/server:${IMAGE_TAG:-latest}


### PR DESCRIPTION
## Summary

- The real staging deploy showed `litellm`'s startup time (Prisma migrations against Neon Postgres) varies a lot — 100s once, 245s another time, likely due to Neon's serverless cold-start latency.
- `docker-compose.prod.yml`'s `litellm` healthcheck `start_period` was 180s, which wasn't a safe enough margin (a real deploy run took ~245s and still failed).
- Widening `start_period` to 300s to give real headroom instead of chasing the exact observed number.

## Test plan

- [x] `docker-compose.prod.yml` validates as YAML
- [ ] Re-run `cd-staging.yml` after merge to confirm the staging deploy goes green end-to-end


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_