### PR TITLE
Fix litellm healthcheck: wget isn't in the image, use python3

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,15 +41,18 @@ services:
       GROQ_API_KEY: ${GROQ_API_KEY:-}
     command: ["--config", "/app/config.yaml", "--port", "4000"]
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O-", "http://localhost:4000/health/liveliness"]
+      # `wget` doesn't exist in this image (confirmed via `docker exec ... which
+      # wget` -> not found) — the healthcheck was failing forever regardless of
+      # timing, which is why bumping start_period kept "almost" working. python3
+      # is what's actually on PATH here.
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness', timeout=5)"]
       interval: 15s
-      timeout: 5s
+      timeout: 10s
       retries: 5
-      # litellm runs Prisma DB migrations on every startup. Neon Postgres is
-      # serverless and can be suspended, so first-connect latency varies a
-      # lot (observed 100s once, 245s another time) — 180s wasn't enough.
-      # Failing checks during start_period don't count against retries.
-      start_period: 300s
+      # Real logs show Prisma migrate + app startup completing in ~100-190s
+      # against Neon; this leaves real margin without the excess left over
+      # from chasing the wrong root cause.
+      start_period: 180s
 
   server:
     image: ${IMAGE_REGISTRY}/server:${IMAGE_TAG:-latest}


### PR DESCRIPTION
## Summary

Found the real root cause via `docker exec safeai-613-litellm-1 which wget` on the staging box: `wget` doesn't exist in `ghcr.io/berriai/litellm:main-latest`. The healthcheck was failing forever regardless of timing — the app was actually up and serving the whole time (`docker compose ps` showed `Up 21 minutes (unhealthy)`, and the container logs showed `Uvicorn running on http://0.0.0.0:4000` within ~3 minutes of start). The last two commits widening `start_period` (180s → 300s) were chasing the wrong problem.

- Healthcheck now uses `python3` (confirmed present on `PATH` in the image) via `urllib.request` instead of `wget`.
- `start_period` back down to 180s, matching the actual observed startup time now that timing was never the real issue.

## Test plan

- [x] `docker-compose.prod.yml` validates as YAML
- [x] Confirmed via `docker exec` that `wget` is absent and `python3`/`python` are present in the running container
- [ ] Re-run `cd-staging.yml` after merge to confirm `litellm` reports healthy and the full deploy goes green


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_