### PR TITLE
Fix server MongoDB Atlas SRV DNS resolution in Docker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -59,6 +59,13 @@ services:
     restart: unless-stopped
     logging: *default-logging
     mem_limit: 512m
+    # Docker's embedded DNS resolver (127.0.0.11) failed to resolve the
+    # mongodb+srv:// SRV record against MongoDB Atlas ("querySrv ECONNREFUSED"),
+    # a known issue with SRV lookups through Docker's default DNS forwarding.
+    # Public DNS resolves it directly.
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     depends_on:
       litellm:
         condition: service_healthy


### PR DESCRIPTION
## Summary

The staging deploy pipeline itself finally went green, but the `server` container was crash-looping in a `Restarting` state — confirmed via `docker compose logs server`:

```
querySrv ECONNREFUSED _mongodb._tcp.<cluster>.mongodb.net
```

This is a known Docker issue: the embedded DNS resolver (127.0.0.11) doesn't reliably forward SRV record queries, which `mongodb+srv://` connection strings depend on. Pointing the `server` container at public DNS (8.8.8.8 / 8.8.4.4) resolves it directly instead of going through Docker's forwarder.

This is what was causing the `502 Bad Gateway` on `/api/auth/register` in the browser — nginx had nothing to proxy to since `server` never stayed up.

## Test plan

- [x] `docker-compose.prod.yml` validates as YAML
- [ ] Re-run `cd-staging.yml` after merge and confirm `server` reports healthy (not restarting) and registration/login works end-to-end in the browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_