### PR TITLE
Fix apiCall() double-prepending API_BASE_URL (broke register on staging)

### DIFF
--- a/apps/client/src/config/api.ts
+++ b/apps/client/src/config/api.ts
@@ -94,9 +94,15 @@ export async function apiCall<T>(
   // Get access token from localStorage
   const accessToken = localStorage.getItem("accessToken");
 
-  // If a relative endpoint is provided (starts with '/'), prepend the API base URL
-  const resolveUrl = (ep: string) =>
-    ep.startsWith("http") ? ep : `${API_BASE_URL}${ep}`;
+  // Most callers pass an API_ENDPOINTS.* value, which already has API_BASE_URL
+  // baked in (e.g. "/api/auth/register") — prepending it again here would
+  // double it up. Only bare relative paths that don't already carry the base
+  // (e.g. "/contact/my-requests/123") need it added.
+  const resolveUrl = (ep: string) => {
+    if (ep.startsWith("http")) return ep;
+    if (API_BASE_URL && ep.startsWith(API_BASE_URL)) return ep;
+    return `${API_BASE_URL}${ep}`;
+  };
 
   const makeRequest = async (token: string | null) => {
     const url = resolveUrl(endpoint);


### PR DESCRIPTION
## Summary

With the deploy pipeline itself finally green and `server` staying up, registration on the deployed staging site failed with `404` on `POST /api/api/auth/register` (doubled `/api`).

Root cause: `API_ENDPOINTS.auth.register` (and nearly every other `API_ENDPOINTS.*` entry) already has `API_BASE_URL` baked in — e.g. `/api/auth/register`. `apiCall()`'s `resolveUrl()` then unconditionally prepended `API_BASE_URL` again for anything not starting with `http`, doubling it. This was invisible in local dev, where `VITE_API_URL` is an absolute URL (`http://localhost:3001`) and already satisfied the `starts with http` check — it only shows up once `VITE_API_URL` is a relative path, which every staging/production deploy uses. Nearly every `apiCall(API_ENDPOINTS.*)` call site in the app was affected, not just registration.

Fix: skip the prepend when the endpoint already starts with `API_BASE_URL`. Both existing calling conventions keep working — passing an already-resolved `API_ENDPOINTS.*` value, and passing a bare relative path directly (e.g. `RequestDetails.tsx`'s `/contact/my-requests/:id`).

## Test plan

- [x] `npm run typecheck` passes
- [ ] Re-deploy staging and confirm registration succeeds end-to-end in the browser


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_