### PR TITLE
Fix CD: restore internal Docker DNS on server (broke litellm calls)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,8 +62,12 @@ services:
     # Docker's embedded DNS resolver (127.0.0.11) failed to resolve the
     # mongodb+srv:// SRV record against MongoDB Atlas ("querySrv ECONNREFUSED"),
     # a known issue with SRV lookups through Docker's default DNS forwarding.
-    # Public DNS resolves it directly.
+    # Listing 127.0.0.11 FIRST keeps resolving other containers by name on
+    # this compose network (e.g. "litellm", needed for the in-app LiteLLM
+    # key-generation call on registration — omitting it broke that with a
+    # 5s timeout instead). Public DNS is the fallback for the SRV lookup.
     dns:
+      - 127.0.0.11
       - 8.8.8.8
       - 8.8.4.4
     depends_on:


### PR DESCRIPTION
## Summary

Registration on the deployed staging site now hits the right URL (`/api/auth/register`, fixed in #313) but failed with a 400 — real server logs showed the actual cause:

```
Registration failed: ... timeout of 5000ms exceeded
at Object.register (/app/dist/services/authService.js:106)
```

`authService.ts` calls `${LITELLM_PROXY_URL}/key/generate` (`http://litellm:4000`) with a 5s timeout to provision the new user's LiteLLM key. This is a side effect of #312: setting `dns: [8.8.8.8, 8.8.4.4]` on `server` to fix MongoDB's SRV lookup replaced Docker's embedded DNS resolver (127.0.0.11) entirely instead of adding to it — so `server` could no longer resolve `litellm` by its container name on the compose network.

Fix: list `127.0.0.11` first (handles container-name resolution and most lookups), with public DNS as fallback specifically for the SRV query type Docker's forwarder refuses.

## Test plan

- [x] `docker-compose.prod.yml` validates as YAML
- [ ] Re-deploy staging and confirm registration succeeds end-to-end (Mongo connects AND the LiteLLM key-generation call succeeds)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_