### PR TITLE
Fix 404 on Google login redirect caused by double slash

### DIFF
--- a/apps/server/src/controllers/googleAuthController.ts
+++ b/apps/server/src/controllers/googleAuthController.ts
@@ -12,7 +12,7 @@ import logger from "../logger";
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "";
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || "";
 const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI || "http://localhost:3001/api/auth/google/callback";
-const CLIENT_URL = process.env.CLIENT_URL || "http://localhost:5173";
+const CLIENT_URL = (process.env.CLIENT_URL || "http://localhost:5173").replace(/\/+$/, "");
 
 const oauth2Client = new OAuth2Client(
   GOOGLE_CLIENT_ID,

--- a/apps/server/src/utils/email.ts
+++ b/apps/server/src/utils/email.ts
@@ -5,7 +5,7 @@
 import nodemailer from "nodemailer";
 import logger from "../logger";
 
-const FRONTEND_URL = process.env.FRONTEND_URL || "http://localhost:5173";
+const FRONTEND_URL = (process.env.FRONTEND_URL || "http://localhost:5173").replace(/\/+$/, "");
 const EMAIL_FROM = process.env.EMAIL_FROM || "SafeAI <noreply@safeai.com>";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Google OAuth login redirected to `${CLIENT_URL}/login?...`. When `CLIENT_URL` (or `FRONTEND_URL` for email links) has a trailing slash, this produced a doubled slash (e.g. `.../login`), which the client-side router does not match, so it fell through to the 404 page.
- Strip trailing slashes from `CLIENT_URL` and `FRONTEND_URL` before concatenating paths, so this class of bug can't recur regardless of how the env var is set.

## Changes
- `apps/server/src/controllers/googleAuthController.ts`: normalize `CLIENT_URL`
- `apps/server/src/utils/email.ts`: normalize `FRONTEND_URL` (verification/reset links have the same issue)

## Test plan
- [ ] Set `CLIENT_URL`/`FRONTEND_URL` with a trailing slash in a dev environment and confirm the Google login redirect and email links no longer produce a doubled slash
https://claude.ai/code/session_016LbnQvWfPniYHiEWrr8XpJ