### PR TITLE
Rewrite deployment docs with real staging/production topology and gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 Quick Agent Summary
 -------------------
-- **Purpose:** Rapid orientation for AI coding agents working in this monorepo (client + server).
+- **Purpose:** Rapid orientation for AI coding agents working in this monorepo (client + server + agent, under `apps/`).
 - **Key files:** See [.github/copilot-instructions.md](.github/copilot-instructions.md) for developer workflows and [README.md](README.md) for setup.
-- **Where to look first:** `client/src/config/api.ts`, `server/src/index.ts`, and `docs/` for domain-specific guides.
+- **Where to look first:** `apps/client/src/config/api.ts`, `apps/server/src/index.ts`, [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for anything CD/AWS-related, and `docs/` for other domain-specific guides.
 
 This file defines the roles, responsibilities, and communication protocols for AI coding agents working on SafeAI-613. Use this to coordinate multi-agent work and ensure agents understand their boundaries and quality expectations.
 
@@ -194,3 +194,4 @@ When a task touches multiple layers (e.g., "add user management" spans backend C
 - [docs/CLIENT_ROUTING_STRUCTURE.md](docs/CLIENT_ROUTING_STRUCTURE.md) — Frontend routes and guards
 - [docs/CODE_DOCUMENTATION_GUIDE.md](docs/CODE_DOCUMENTATION_GUIDE.md) — Documentation standards
 - [docs/CLIENT_URGENT_TASKS.md](docs/CLIENT_URGENT_TASKS.md) — Backlog of outstanding work
+- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) — CI/CD, the real staging/production AWS topology, and every deploy bug hit so far with its fix. Read this before touching `.github/workflows/cd-*.yml` or `docker-compose.prod.yml`.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,41 +1,59 @@
 # פריסה ו-DevOps — SafeAI-613
 
-מסמך זה מתאר את מבנה המונו-ריפו, את שכבת הדוקר, ואת תהליכי ה-CI/CD — כולל הפריסה בפועל ל-AWS.
+מסמך זה מתאר את מבנה המונו-ריפו, את תהליכי ה-CI/CD, ואת **המציאות בפועל** של שתי הסביבות ב-AWS — כולל כל התקלות שנתקלנו בהן בפריסה הראשונה שעבדה בפועל (חשוב לקרוא את סעיף 10 לפני שמנסים שוב).
 
 ## 1. מבנה הריפו
 
 ```
 /
 ├─ apps/
-│  ├─ client/   React + Vite + TS
+│  ├─ client/   React + Vite + TS — נבנה כקבצים סטטיים, לא רץ בדוקר ב-staging/production
 │  ├─ server/   Node.js + Express + TS
-│  └─ agent/    Python + FastAPI (שלד בלבד כרגע — לא היה קיים קוד פייתון בריפו)
+│  └─ agent/    Python + FastAPI
 ├─ infra/
-│  ├─ docker/nginx/     Dockerfile + nginx.conf.template — מגישים את ה-client תחת VITE_BASE_PATH (prod/staging: "/console/") ומעבירים "<base>api/" לשרת
-│  ├─ litellm/          litellm_config.yaml (ללא סודות — ראו סעיף 4)
+│  ├─ docker/nginx/     Dockerfile + nginx.conf.template — בשימוש רק לפיתוח מקומי (docker-compose.yml). ב-staging/production אין nginx בדוקר בכלל, ראו סעיף 8.
+│  ├─ litellm/          litellm_config.yaml (ללא סודות — ראו סעיף 5)
 │  └─ legacy/           ecosystem.config.js (הגדרת PM2 ישנה, נשמרה להיסטוריה)
-├─ docker-compose.yml       סביבת פיתוח מקומית — כולל mongo+postgres מקומיים
-├─ docker-compose.prod.yml  סביבת production — מריץ רק images מוכנים, ללא build
+├─ docker-compose.yml       סביבת פיתוח מקומית — כולל mongo+postgres מקומיים ו-nginx בדוקר
+├─ docker-compose.prod.yml  רץ על ה-EC2 (staging ו-production) — litellm+server+agent בלבד, ללא nginx
 └─ .github/workflows/
-   ├─ ci.yml              בדיקות איכות (lint/typecheck/test/build) לכל אפליקציה + build של כל תמונות הדוקר
-   ├─ cd-staging.yml       פריסה בעת push ל-develop
-   └─ cd-production.yml    פריסה בעת push ל-main
+   ├─ ci.yml              בדיקות איכות (lint/typecheck/test/build) לכל אפליקציה + build של תמונות הדוקר
+   ├─ cd-staging.yml       פריסה בעת push ל-develop — **פעיל ונבדק בפועל**
+   └─ cd-production.yml    פריסה בעת push ל-main — **עדיין לא נבדק בפועל**, ראו סעיף 2
 ```
 
-## 2. טופולוגיית הדוקר
+## 2. שתי סביבות נפרדות לגמרי — אל תתבלבלו ביניהן
 
-| שירות | Local dev (`docker-compose.yml`) | Production (`docker-compose.prod.yml`) |
+זו הטעות היקרה ביותר שאפשר לעשות כאן: **staging ו-production הן שתי מכונות EC2 נפרדות לחלוטין**, עם topology שונה. תמיד לוודא `hostname`/`curl -s ifconfig.me` לפני שמריצים משהו.
+
+| | **Staging** | **Production** |
 |---|---|---|
-| `nginx` | בונה מהריפו, מגיש client מהשורש (`/`) + מעביר `/api/*` לשרת | image מוכן מהרג'יסטרי, מגיש תחת `/console/` (ראו סעיף 7), פורט נקשר ל-`127.0.0.1` בלבד |
-| `server` | build מ-`Dockerfile.dev` (hot reload) | image מוכן, `Dockerfile` (multi-stage, `node:20-alpine`) |
-| `agent` | build מקומי | image מוכן |
-| `litellm` | image רשמי + Postgres מקומי | image רשמי + Postgres מנוהל (Neon/אחר) |
-| `mongo` | קונטיינר מקומי | **לא רץ** — מתחברים ל-MongoDB Atlas דרך `MONGO_URI` |
-| `postgres` | קונטיינר מקומי (בסיס הנתונים הפנימי של LiteLLM) | **לא רץ** — מתחברים ל-Postgres מנוהל דרך `DATABASE_URL` |
+| דומיין | `dev.safeai613.com` | `safeai613.com` |
+| Hostname | `ip-172-31-4-7` | `ip-172-31-65-222` (שונה!) |
+| IP | `98.89.219.65` | (לא תועד כאן בכוונה — לבדוק ב-AWS Console) |
+| מוצרים על אותה מכונה | רק SafeAI-613 | SafeAI-613 **+ LibreChat** |
+| נתיב URL | שורש (`/`) | תת-נתיב (`/console/`) — כי LibreChat תופס את השורש |
+| קבצים סטטיים | `/var/www/safeai` | `/var/www/ai613/console/client/dist/` |
+| repo checkout | `~/SafeAI-613` (בית של `ubuntu`) | `/opt/safeai/SafeAI-613` (לפי תיעוד ההקמה המקורי) |
+| TLS | **אין** — HTTP בלבד (סביבת בדיקות) | יש, Let's Encrypt/certbot |
+| CD פעיל | כן — `cd-staging.yml`, SSH | לא עדיין — `cd-production.yml` כתוב (OIDC+SSM) אבל **מעולם לא הופעל בפועל** |
 
-**למה אין Mongo/Postgres בפרודקשן בדוקר?** כרגע יש לכם שירותים מנוהלים (Atlas, וכן Postgres חיצוני עבור LiteLLM כשתרצו) — אלה כוללים גיבויים, ניטור ו-HA "בחינם". להריץ מסדי נתונים סטייטפוליים בקונטיינר יחיד על EC2 בודד זה בדיוק המקום שבו קורות תקלות פריסה (איבוד וולום, אין גיבוי, ריסטארט מוחק דאטה אם שוכחים volume). אם תרצו להריץ Postgres עצמאית על ה-EC2 — אפשר, אבל כדאי להחליט את זה יחד עם תוכנית גיבוי (`pg_dump` מתוזמן + שמירה מחוץ למכונה, למשל ל-S3).
+**עד כה, כל העבודה בסעיף הזה בוצעה ואומתה רק על staging.** production לא נגעה בכלל בתהליך הזה — היא ממשיכה לרוץ איך שהוקמה במקור (ראו `infra/legacy/ecosystem.config.js` ותיעוד ההקמה החיצוני, אם קיים).
 
-## 3. איך מריצים
+## 3. טופולוגיית הדוקר
+
+| שירות | Local dev (`docker-compose.yml`) | Staging/Production (`docker-compose.prod.yml`) |
+|---|---|---|
+| `nginx` | בדוקר, בונה מהריפו, מגיש client + מעביר `/api/*` לשרת | **לא קיים בקובץ הזה בכלל** — ה-nginx **של המערכת** (מחוץ לדוקר, כבר קיים על כל מכונה) מגיש את ה-client כקבצים סטטיים ומעביר `/api/` ל-`server` דרך `http://localhost:3001` |
+| `server` | build מ-`Dockerfile.dev` (hot reload) | image מוכן מ-GHCR, פורט מפורסם ל-`127.0.0.1:3001` כדי שה-nginx החיצוני יגיע אליו |
+| `agent` | build מקומי | image מוכן מ-GHCR |
+| `litellm` | image רשמי + Postgres מקומי | image רשמי + Postgres מנוהל (Neon) |
+| `mongo` | קונטיינר מקומי | **לא רץ** — MongoDB Atlas דרך `MONGO_URI` |
+| `postgres` | קונטיינר מקומי | **לא רץ** — Postgres מנוהל (Neon) דרך `DATABASE_URL` |
+
+ה-client **נבנה ישירות על ה-host** (לא בדוקר) כחלק מסקריפט ה-deploy עצמו — ראו סעיף 6.
+
+## 4. איך מריצים
 
 **פיתוח מקומי (הכל בדוקר, כולל DB-ים מקומיים):**
 ```bash
@@ -46,104 +64,85 @@ docker compose up --build
 # client: http://localhost:8080  |  server ישיר: http://localhost:3001  |  litellm: http://localhost:4000
 ```
 
-**Production (על ה-EC2, אחרי שהתמונות כבר נבנו ונדחפו ע"י ה-CD):**
+**ידנית על ה-EC2 (staging/production), בלי CD:**
 ```bash
-cp .env.example .env   # למלא ערכי אמת (כולל את כל המשתנים מ-apps/server/.env.example), ואז: chmod 600 .env
+cd ~/SafeAI-613   # staging. ב-production: /opt/safeai/SafeAI-613
+git pull
 docker compose -f docker-compose.prod.yml pull
 docker compose -f docker-compose.prod.yml up -d
+cd apps/client && npm ci && VITE_API_URL=/api VITE_BASE_PATH=/ npm run build   # /console/ ו-/console/api ב-production
+sudo cp -r dist/. /var/www/safeai/   # /var/www/ai613/console/client/dist/ ב-production
 ```
 
-## 4. ניהול סודות (Secrets)
+## 5. ניהול סודות (Secrets)
 
-**מה תוקן כחלק מהעבודה הזו:** בקובץ ה-config של LiteLLM (כיום `infra/litellm/litellm_config.yaml`) ה-`master_key` וה-`database_url` היו כתובים ישירות בקובץ (hardcoded), למרות שכבר לא הצביעו על סוד חי אמיתי בפועל ב-`develop` (את תקלת הסיסמה שדלפה בעבר כבר טיפלת). בכל זאת, כתובת ה-config עצמה עברה להפניה למשתני סביבה (`os.environ/LITELLM_MASTER_KEY`, `os.environ/DATABASE_URL`) כהרגל עבודה נכון — כך שאותו קובץ בטוח להישאר בריפו לכל סביבה, וה-master key האמיתי (שעדיין מופיע היום כערך קבוע `sk-safe-ai-master-123` בכמה מקומות ב-`develop`) כדאי גם הוא להתחלף לערך אקראי (`openssl rand -hex 32` או דומה) בהזדמנות, פשוט כי הוא חשוף היום בקוד.
+**שני קבצי `.env` שונים לגמרי — קלות טעות אמיתית שקרתה בפועל:**
+- `apps/server/.env` — רלוונטי רק אם מריצים את השרת **ישירות** (לא בדוקר), למשל תחת PM2 הישן.
+- `.env` **בשורש** ה-repo — זה מה ש-`docker compose` קורא בפועל (גם ל-`${VAR}` substitution בתוך `docker-compose.prod.yml`, וגם דרך `env_file: .env` לתוך containers של `server`/`agent`). **אם הוא חסר, `docker compose up` נכשל על `.env not found` בלי הסבר ברור.**
 
-**איך מנהלים סודות מעכשיו:**
-1. **מקומי**: קובצי `.env` (לא נכנסים לגיט — מכוסה ב-`.gitignore`).
-2. **CI/CD**: GitHub Environments — `staging` ו-`production` (ב-Settings → Environments של הריפו). כל סוד (מפתחות API, `MONGO_URI`, `DATABASE_URL`, `AWS_DEPLOY_ROLE_ARN` וכו' — ראו סעיף 5) מוגדר בנפרד לכל Environment, כך שסוד של production לא נגיש לפריסת staging. אין מפתחות SSH בכלל — הפריסה עצמה עוברת דרך AWS OIDC + SSM (סעיף 5, 8), בלי שום credential ארוך-טווח.
-3. **על ה-EC2**: קובץ `.env` יחיד עם הרשאות `chmod 600`, לא בבעלות משתמש שאינו נחוץ.
-4. **שדרוג עתידי (מומלץ, לא הוקם עדיין)**: מכיוון שאתם כבר על AWS — כדאי לשקול **AWS Secrets Manager** או **SSM Parameter Store** במקום קובץ `.env` על הדיסק, כדי שסודות לא יישבו כטקסט גלוי על המכונה. זה משהו שכדאי לדבר עליו כשנשב על הפרטים.
+ודאו ששני הקבצים תואמים כשמעדכנים ערך (למשל `MONGO_URI`) — ותוך שימת לב ל-**וודאות ש-`DATABASE_URL` הוא Postgres (Neon), לא Mongo!** זו טעות אמיתית שקרתה — `litellm` דורש `postgresql://`, לא `mongodb+srv://`; אם הערך הלא-נכון מגיע ל-`DATABASE_URL`, litellm יכתוב ללוג `unsupported scheme 'mongodb+srv'` בבירור.
 
-## 5. CI/CD
+1. **מקומי**: קובצי `.env` (מכוסה ב-`.gitignore`).
+2. **CI/CD**: GitHub Environment בשם `staging` (Settings → Environments) עם 3 Secrets: `STAGING_HOST`, `STAGING_SSH_USER`, `STAGING_SSH_KEY` (מפתח SSH **ייעודי** לדיפלוי, לא אישי — ראו סעיף 6).
+3. **על ה-EC2**: קובץ `.env` יחיד בשורש עם הרשאות `chmod 600`.
+4. **שדרוג עתידי (מומלץ, לא הוקם עדיין)**: AWS Secrets Manager / SSM Parameter Store במקום `.env` על הדיסק.
 
-- **`ci.yml`**: רץ על כל PR ועל push ל-`main`/`develop`. בודק lint/typecheck/build לכל אחת משלוש האפליקציות, ובסוף מנסה לבנות את כל תמונות הדוקר (בלי לדחוף) כדי לתפוס שבירות Docker מוקדם.
-- **`cd-staging.yml`**: רץ על push ל-`develop`. בונה ודוחף images אמיתיים ל-GitHub Container Registry (`ghcr.io`), עם תיוג לפי git sha וגם `staging`, ואז **פורס בפועל** ל-EC2 של סביבת הבדיקות (`dev.safeai613.com`).
-- **`cd-production.yml`**: אותו דבר עבור push ל-`main`, עם תיוג `latest`, פורס בפועל ל-EC2 של production (`safeai613.com`).
+## 6. CI/CD
 
-**איך הפריסה בפועל עובדת (שני הקבצים, אותו מנגנון):**
-1. GitHub Actions מתחבר ל-AWS דרך **OIDC** — לא שומרים שום מפתח AWS קבוע כ-Secret. ה-workflow "מתחזה" זמנית לתפקיד IAM ומקבל טוקן שתקף לדקות בודדות בלבד.
-2. הפריסה עצמה רצה דרך **AWS SSM Run Command** — לא SSH. אין צורך לפתוח פורט 22 לאינטרנט בכלל; SSM עובד על תעבורה יוצאת (outbound) מה-EC2 בלבד.
-3. הפקודה שרצה בפועל על המכונה: `cd /opt/safeai-613 && docker compose -f docker-compose.prod.yml pull && docker compose -f docker-compose.prod.yml up -d && docker image prune -f`.
+- **`ci.yml`**: רץ על כל PR ועל push ל-`main`/`develop`. lint/typecheck/build לכל אפליקציה + build של תמונות הדוקר (בלי push).
+- **`cd-staging.yml`**: רץ על push ל-`develop`. **נבדק ועובד בפועל.** בונה ודוחף `server`+`agent` ל-GHCR (`ghcr.io/safeai613/safeai-613` — **hardcoded lowercase**, ראו סעיף 10), ואז פורס דרך **SSH** (`appleboy/ssh-action`) עם Secrets `STAGING_HOST`/`STAGING_SSH_USER`/`STAGING_SSH_KEY`. הסקריפט: `git reset --hard origin/develop` (במתכוון, לא `pull` — זה יעד deploy, לא מכונת עבודה) → `docker compose -f docker-compose.prod.yml pull && up -d` → בניית ה-client ישירות על ה-host והעתקה ל-`/var/www/safeai`.
+- **`cd-production.yml`**: אותו רעיון עבור push ל-`main`, אבל דרך **AWS OIDC + SSM** (לא SSH — ראו סעיף 9) — **עדיין לא הופעל בפועל אף פעם**, רק כתוב. יתכן שיתגלו בו תקלות דומות לאלה שבסעיף 10 ברגע שיופעל לראשונה.
 
-זה משמעותית יותר בטוח מ-SSH עם מפתח קבוע ב-Secret: אין credential ארוך-טווח שיכול לדלוף, ואין משטח תקיפה של פורט 22 פתוח.
+**למה SSH ב-staging ו-OIDC+SSM ב-production?** SSH עם מפתח ייעודי הוא מהיר להקים ומספיק בטוח לסביבת בדיקות; OIDC+SSM (בלי מפתחות קבועים, בלי פורט 22 פתוח) הוא הסטנדרט הגבוה יותר ששמור ל-production. אפשר לשקול לשדרג את staging לאותו מנגנון בהמשך.
 
-**Secrets נדרשים (מוגדרים בנפרד לכל GitHub Environment — `staging`/`production`, ראו סעיף 4):**
-| Secret | ערך |
-|---|---|
-| `AWS_DEPLOY_ROLE_ARN` | ARN של ה-IAM Role שה-workflow מתחזה אליו (ראו סעיף 8) |
-| `AWS_REGION` | האזור של ה-EC2 (למשל `il-central-1` / `eu-central-1`) |
-| `EC2_INSTANCE_ID` | ה-instance ID של המכונה (`i-...`) — שונה בין staging ל-production |
+**מומלץ להגדיר (לא ניתן דרך קוד):** ל-Environment `production` להוסיף **Required reviewers**.
 
-**מומלץ להגדיר (לא ניתן דרך קוד, רק ב-Settings של הריפו):** ל-Environment בשם `production` להוסיף **Required reviewers**, כך שכל פריסה ל-production תדרוש אישור ידני של מישהו לפני שהיא רצה בפועל — רשת ביטחון פשוטה וזולה נגד "לחיצה בטעות".
+## 7. נקודות DevOps חשובות
 
-## 6. נקודות DevOps חשובות שכיסינו
-
-- **Healthchecks**: לכל שירות (server, agent, litellm, nginx) יש `HEALTHCHECK`/`healthcheck` ברמת הדוקר, ו-`depends_on: condition: service_healthy` כך שהשרת לא יעלה לפני ש-LiteLLM מוכן.
-- **הגבלת לוגים**: ב-`docker-compose.prod.yml` הוגדר `max-size`/`max-file` לכל שירות — בלי זה, לוגים לא מוגבלים יכולים למלא את הדיסק של ה-EC2 עם הזמן (תקלה נפוצה מאוד בשרת יחיד).
-- **הגבלת זיכרון** (`mem_limit`) לכל שירות, כדי שקונטיינר "משתולל" לא יפיל את כל המכונה.
-- **`restart: unless-stopped`** בכל מקום, כדי ששירותים יעלו מחדש אחרי קריסה או ריבוט של המכונה.
-- **גרסת Node אחידה**: ה-Dockerfile הישן של השרת השתמש ב-`node:14` (מיושן משמעותית), עודכן ל-`node:20-alpine` עם build רב-שלבי (multi-stage) — התמונה הסופית לא מכילה devDependencies או קוד TypeScript גולמי.
+- **Healthchecks**: לכל שירות (`server`, `agent`, `litellm`) יש `healthcheck`, ו-`depends_on: condition: service_healthy`.
+- **הגבלת לוגים/זיכרון**: `max-size`/`max-file` ו-`mem_limit` לכל שירות.
+- **`restart: unless-stopped`** בכל מקום.
 - **משתמש לא-root** בתוך קונטיינר השרת והסוכן.
-- **`.dockerignore`** בכל אפליקציה כדי ש-`.env`, `node_modules` וכו' לא ייכנסו בטעות להקשר הבנייה.
+- **`.dockerignore`** בכל אפליקציה.
 
-## 7. טופולוגיית הרשת: nginx של המערכת מול nginx של הדוקר
+## 8. nginx: המערכת מגישה הכל, אין nginx בדוקר
 
-לשתי הסביבות יש כבר nginx **ברמת המערכת** (מחוץ לדוקר) שמחזיק את הדומיין:
-- **production** (`safeai613.com`) — משרת גם מוצר נוסף (LibreChat) בשורש (`/`); SafeAI-613 מוגש תחת `/console/`. יש תעודת Let's Encrypt קיימת.
-- **staging** (`dev.safeai613.com/console/`) — HTTP בלבד כרגע (בלי תעודה — זו סביבת בדיקות).
-
-בגלל זה, ה-`nginx` container של הדוקר (`infra/docker/nginx/`) **לא יכול לתפוס בעצמו את פורט 80/443**. הוא נבנה עכשיו כך שהוא:
-1. מגיש את ה-client ומעביר `/api` **תחת `/console/`** (`VITE_BASE_PATH=/console/`, `VITE_API_URL=/console/api` — נקבעים ב-build args של ה-CD, ראו `cd-staging.yml`/`cd-production.yml`).
-2. ב-`docker-compose.prod.yml` הפורט שלו נקשר ל-`127.0.0.1:${NGINX_HOST_PORT:-8091}` בלבד — לא לכתובת הציבורית.
-
-**הצעד שנדרש עלייך, פעם אחת בכל מכונה:** להוסיף ל-nginx **הקיים** (ברמת המערכת) בלוק location שמעביר `/console/` ל-container:
+לשתי הסביבות יש nginx **ברמת המערכת** (מחוץ לדוקר לגמרי) שמחזיק את הדומיין, מגיש את קבצי ה-client הסטטיים ישירות, ומעביר `/api/` ל-`server`:
 
 ```nginx
-# production — בתוך ה-server block הקיים שמחזיק את התעודה של safeai613.com
-location /console/ {
-    proxy_pass http://127.0.0.1:8091;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-}
-```
-
-```nginx
-# staging — server block נפרד/קיים תחת dev.safeai613.com, HTTP בלבד (בלי ssl_certificate)
+# staging בפועל (HTTP בלבד) — /etc/nginx/sites-available/ במכונת staging
 server {
     listen 80;
     server_name dev.safeai613.com;
 
-    location /console/ {
-        proxy_pass http://127.0.0.1:8091;
+    root /var/www/safeai;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://localhost:3001/;
         proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
     }
 }
 ```
 
-לאחר עריכה: `nginx -t && systemctl reload nginx`. שימו לב ל-`proxy_pass http://127.0.0.1:8091;` **בלי** `/` בסוף — כך ה-nginx החיצוני מעביר את ה-path המלא (`/console/...`) הלאה, וזה תואם למה שה-`nginx` הפנימי בדוקר מצפה לו (הוא כבר מוגדר לשרת בדיוק תחת `/console/`, לא תחת שורש).
+ב-**production** ההגיון זהה, רק תחת `/console/` (כי `/` שמור ל-LibreChat) עם `root /var/www/ai613/console/client/dist/`, ועם `ssl_certificate` (Let's Encrypt/certbot). לא ראינו את קובץ ה-nginx האמיתי של production בשיחה הזו — יש לאתר אותו על אותה מכונה (`sudo nginx -T | grep -B1 server_name` אם שם הקובץ לא ידוע מראש).
 
-## 8. הקמה חד-פעמית ב-AWS: OIDC + SSM (ל-CD האמיתי)
+**המשמעות ל-Docker:** ה-`server` container חייב לפרסם את הפורט שלו ל-host (`ports: 127.0.0.1:3001:3001` ב-`docker-compose.prod.yml`) כדי שה-nginx החיצוני יוכל להגיע אליו — אין רשת דוקר משותפת בין השניים.
 
-כדי ש-GitHub Actions יוכל לפרוס בפועל בלי SSH ובלי סודות ארוכי-טווח, נדרשת הקמה חד-פעמית בקונסולת AWS (או ב-CLI) — זה לא משהו שניתן לבצע מתוך הריפו:
+## 9. הקמה חד-פעמית ב-AWS: OIDC + SSM (ל-`cd-production.yml` בלבד)
 
-1. **OIDC Identity Provider**: IAM → Identity providers → Add provider → OpenID Connect, עם URL `https://token.actions.githubusercontent.com` ו-audience `sts.amazonaws.com`.
-2. **IAM Role** (למשל `github-actions-deploy`) עם Trust policy שמתירה **רק** לריפו הזה להתחזות:
+זה עדיין רלוונטי רק ל-production (staging משתמש ב-SSH, ראו סעיף 6) — ולא נבדק בפועל:
+
+1. **OIDC Identity Provider**: IAM → Identity providers → Add provider → OpenID Connect, URL `https://token.actions.githubusercontent.com`, audience `sts.amazonaws.com`.
+2. **IAM Role** עם Trust policy שמתירה רק לריפו הזה:
    ```json
    {
      "Version": "2012-10-17",
@@ -158,7 +157,7 @@ server {
      }]
    }
    ```
-3. **Permissions policy** על התפקיד — מצומצם רק ל-SSM ורק על מכונות ה-EC2 הרלוונטיות (מומלץ שני roles נפרדים, אחד ל-staging ואחד ל-production, עם `Resource` שמצביע רק על ה-instance המתאים):
+3. **Permissions policy** מצומצם ל-SSM על ה-instance הרלוונטי בלבד:
    ```json
    {
      "Version": "2012-10-17",
@@ -172,14 +171,36 @@ server {
      }]
    }
    ```
-4. **על כל EC2 עצמה**: לוודא ש-**SSM Agent** רץ (ברוב ה-AMI המודרניים כבר מותקן) ושיש למכונה **IAM instance profile** עם המדיניות המנוהלת `AmazonSSMManagedInstanceCore` — בלי זה המכונה לא "נראית" ל-SSM בכלל, גם אם ה-Role של ה-CD תקין.
-5. **ב-GitHub**: להוסיף את ה-Secrets שבטבלה בסעיף 5 (`AWS_DEPLOY_ROLE_ARN`, `AWS_REGION`, `EC2_INSTANCE_ID`) לכל אחד מה-Environments (`staging`/`production`) בנפרד.
-6. **על כל EC2**: `docker login ghcr.io` פעם אחת עם token עם הרשאת `read:packages` (כדי שה-`docker compose pull` יצליח למשוך images פרטיים) — לא עובר דרך ה-CD בכלל, כדי לא לחשוף טוקן נוסף בלוגים.
+4. **על ה-EC2**: SSM Agent רץ + IAM instance profile עם `AmazonSSMManagedInstanceCore`.
+5. **ב-GitHub**: Secrets `AWS_DEPLOY_ROLE_ARN`, `AWS_REGION`, `EC2_INSTANCE_ID` ב-Environment `production`.
+6. **על ה-EC2**: `docker login ghcr.io` פעם אחת (טוקן עם `read:packages`).
 
-## 9. מה עוד לא מכוסה — לשבת עליו יחד
+## 10. תקלות אמיתיות שנתקלנו בהן — ותיקונים (מהפריסה הראשונה שעבדה בפועל)
 
-- **מוניטורינג והתראות**: אין היום שום דבר שיתריע אם השירות נופל (רק `restart: unless-stopped` שמנסה להעלות מחדש). כדאי בדיקת "חיים" חיצונית פשוטה (Uptime check) כצעד ראשון.
-- **גיבויים ל-Postgres** אם בעתיד יוחלט להריץ אותו עצמאית במקום Neon/מנוהל.
-- **HTTPS ל-staging**: כרגע `dev.safeai613.com` נשאר HTTP בכוונה (סביבת בדיקות) — קל להוסיף Let's Encrypt בהמשך אם ירצו.
-- **שדרוג ניהול סודות**: מעבר מ-`.env` על הדיסק ל-AWS Secrets Manager/SSM Parameter Store (ראו סעיף 4).
-- **תיקון ל-`apps/server/package-lock.json`**: בזמן הבדיקה גילינו ש-`npm ci` (המצב הקפדני שמשתמשים בו ב-Dockerfile וב-CI, בניגוד ל-`npm install` הסלחני) נכשל על השרת עם שגיאת "lockfile out of sync" (חסרים בו שני רשומות תלות פנימיות אופציונליות — `zod` עבור החבילה `litellm`, ו-`gcp-metadata` עבור mongoose). בנוסף, כל עוד השורש (`package.json`) הכריז על npm workspaces שכללו את `apps/server`, ה-hoisting של npm שינה את עץ התלויות בפועל של השרת מספיק כדי לגרום לכשלי build מוזרים ב-TypeScript מול Mongoose (שגיאות "no overload matches"/"signatures incompatible"). **הפתרון**: הסרנו את ה-`workspaces` מה-`package.json` בשורש (כל אפליקציה מותקנת ונבנית באופן עצמאי לגמרי — בדיוק כמו שכל Dockerfile כבר עושה), ויצרנו מחדש את `apps/server/package-lock.json` כך שיהיה עקבי. אחרי התיקון: `npm ci && npm run build` על השרת עובר נקי (0 שגיאות), וכך גם lint (0 שגיאות) ו-68 הטסטים.
+זו הרשימה החשובה ביותר במסמך — כל אחת מהן עצרה את ה-CD בפועל, לא תיאורטית:
+
+1. **תגי Docker חייבים lowercase.** `IMAGE_BASE: ghcr.io/${{ github.repository }}` נכשל מיד (`repository name must be lowercase`) כי `github.repository` מחזיר `SafeAI613/SafeAI-613` (אותיות גדולות). **תיקון**: hardcode ל-`ghcr.io/safeai613/safeai-613`.
+2. **אין nginx בדוקר ב-staging בכלל** — ראו סעיף 8. גרסה מוקדמת של הקוד הזה ניסתה להריץ nginx בדוקר עם bind ל-`/console/`, שלא תואם למה שבאמת רץ על אף אחת מהמכונות.
+3. **תהליך PM2 ישן תפס את פורט 3001.** לפני המעבר לדוקר, `safeai-server` רץ תחת PM2 (`pm2 list`) במשך 29 יום, מחזיק את פורט 3001 — וה-container `server` נכשל לעלות עם `address already in use`. **תיקון**: `pm2 stop safeai-server && pm2 delete safeai-server && pm2 save` פעם אחת בכל מכונה שעוברת לדוקר.
+4. **`wget` לא קיים ב-image של litellm** (`ghcr.io/berriai/litellm:main-latest`). ה-healthcheck (`wget -q -O- .../health/liveliness`) נכשל **לנצח**, לא בגלל זמן — בדיקה עם `docker exec ... which wget` הראתה `not found`. זה בלבל אותנו לחשוב שזו בעיית תזמון (הגדלנו `start_period` מ-180 ל-300 שניות בלי תועלת) לפני שגילינו את השורש האמיתי. **תיקון**: healthcheck עם `python3 -c "import urllib.request; urllib.request.urlopen(...)"` (מאומת: `python3` כן קיים ב-PATH של ה-image הזה).
+5. **`mongodb+srv://` נכשל לפענח DNS בתוך דוקר** (`querySrv ECONNREFUSED`) — bug ידוע: ה-DNS resolver המובנה של דוקר (`127.0.0.11`) לא מטפל טוב תמיד ב-SRV records. **תיקון ראשוני** (חלקי מדי): `dns: [8.8.8.8, 8.8.4.4]` על השירות `server` — זה פתר את ה-Mongo אבל **שבר** את הרזולוציה הפנימית של דוקר לשמות containers אחרים (`litellm`), כי זה **מחליף** את ה-resolver המובנה במקום להוסיף עליו. גילינו את זה כי הקריאה הפנימית ל-litellm (`/key/generate`, בהרשמה) התחילה ליפול ב-timeout של 5 שניות. **תיקון סופי**: `dns: [127.0.0.11, 8.8.8.8, 8.8.4.4]` — resolver של דוקר קודם (שמות containers פנימיים), ציבורי כ-fallback ל-SRV.
+6. **`apiCall()` בקוד ה-client הכפיל את `/api`.** `API_ENDPOINTS.*` (ב-`apps/client/src/config/api.ts`) כבר בנוי עם `API_BASE_URL` אפוי בפנים (למשל `/api/auth/register`), אבל `apiCall()`'s `resolveUrl()` הוסיף את `API_BASE_URL` **שוב** לכל דבר שלא מתחיל ב-`http` — וב-`/api` (יחסי) זה תפס גם endpoints שכבר היו מוכנים. זה **בלתי נראה בפיתוח מקומי**, כי שם `VITE_API_URL` הוא כתובת מלאה (`http://localhost:3001`) שכבר עוברת את בדיקת ה-`starts with http`. מתבטא כ-`404` על `/api/api/auth/register`. **תיקון**: `resolveUrl()` מדלג על ההוספה אם ה-endpoint כבר מתחיל ב-`API_BASE_URL`.
+7. **הגנת הענף (`develop`) איפשרה עקיפה בטעות.** "Do not allow bypassing" היה מסומן, אבל סעיף נפרד — "Restrict who can push to matching branches" — כלל כברירת מחדל את "Organization administrators, repository administrators, and users with the Maintain role" ברשימת המורשים ל-push ישיר, מה שעקף בפועל את דרישת ה-PR. **תיקון**: הסרת התפקידים האלה מרשימת ה-push access.
+8. **סקריפט ה-seed לא רץ מתוך קונטיינר ה-production.** ה-image של `server` נבנה עם `npm ci --omit=dev` ומעתיק רק `dist/` — אין שם `ts-node` ואין `src/`. חייבים להריץ אותו **ישירות על ה-host**, מתוך ה-git checkout, עם משתני הסביבה של `.env` בשורש טעונים ידנית (הסקריפט קורא `process.env` ישירות, בלי dotenv):
+   ```bash
+   cd ~/SafeAI-613/apps/server
+   npm ci
+   set -a; source ~/SafeAI-613/.env; set +a
+   npx ts-node --transpile-only src/seedDevData.ts
+   ```
+   ה-`--transpile-only` נדרש כי `ts-node` (עם type-checking מלא) נכשל על שגיאת TS לא-קשורה ב-`seedDevData.ts` (`User.findOne({ email })`, TS2353) שלא מופיעה ב-`npm run build` הרגיל (`tsc`) שמשמש את ה-Dockerfile — ככל הנראה הבדל בהתנהגות type-checking בין השניים. הסקריפט עצמו בטוח להרצה חוזרת (idempotent, בודק לפי מפתח ייחודי).
+9. **403 מהסביבה של Claude עצמה, לא מהשרת.** בדיקת `curl` לדומיין ה-staging מתוך sandbox של Claude Code החזירה `403` עם `x-deny-reason: host_not_allowed` — זה ה-proxy של סביבת ה-agent (allowlist דומיינים), **לא** אינדיקציה לתקלה אמיתית באתר. תמיד לוודא זמינות אמיתית מדפדפן/מכונה רגילה, לא מתוך session של Claude.
+
+## 11. מה עוד לא מכוסה
+
+- **מוניטורינג והתראות**: אין היום כלום שמתריע אם שירות נופל.
+- **גיבויים ל-Postgres** אם בעתיד יריצו אותו עצמאית במקום Neon.
+- **HTTPS ל-staging**: HTTP בכוונה כרגע.
+- **שדרוג ניהול סודות**: מעבר מ-`.env` ל-AWS Secrets Manager/SSM Parameter Store.
+- **`cd-production.yml` מעולם לא הופעל בפועל** — צפויות כנראה תקלות דומות לסעיף 10 בהפעלה הראשונה שלו (טופולוגיית production שונה: `/console/`, `/opt/safeai/SafeAI-613`, LibreChat על אותה מכונה).
+- **תיקון היסטורי ל-`apps/server/package-lock.json`**: `npm ci` נכשל בעבר עם "lockfile out of sync" (חסרו `zod`/`gcp-metadata`) בגלל npm workspaces שהשפיעו על ה-hoisting; workspaces הוסרו והלוקפייל נבנה מחדש.


### PR DESCRIPTION
## Summary

`docs/DEPLOYMENT.md` described a theoretical setup that turned out to be wrong once we actually deployed to staging (dockerized nginx under `/console/` for both environments, OIDC+SSM for both). Rewrote it to match reality, so the next Claude session (or teammate) starts with this knowledge instead of rediscovering it the hard way:

- Staging and production are two separate EC2 boxes with different topology — a table with hostnames, static-file paths, and what's actually verified vs. still just written but never run.
- No dockerized nginx in either environment — the system's own nginx serves static files directly and proxies `/api` to the server container's published port.
- `cd-staging.yml` (SSH) is tested and working; `cd-production.yml`'s OIDC+SSM plan has never actually been executed.
- A dedicated "real bugs hit and their fixes" section covering everything found getting the first real staging deploy green: lowercase GHCR tags, an old PM2 process holding port 3001, `wget` missing from the litellm image (misdiagnosed as a timing issue at first), the Docker-DNS-vs-Mongo-SRV-vs-container-name-resolution conflict, the client's double `/api` prefix bug, the branch-protection push-access gap, how to run the dev seed script against a deployed container, and the sandbox-proxy 403 false alarm.

Also fixed `CLAUDE.md`'s quick-orientation paths (still pointed at pre-restructure `client/src`/`server/src`) and added `docs/DEPLOYMENT.md` to its references list so it's discoverable.

## Test plan

- Documentation only — no code paths affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_