### PR TITLE
Skip CD on docs-only pushes to develop/main

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -16,6 +16,9 @@ on:
     paths-ignore:
       - "**.md"
       - "docs/**"
+      - "claude-knowledge/**"
+      - ".claude/**"
+      - ".gitignore"
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -13,6 +13,9 @@ name: CD - Production
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -16,6 +16,9 @@ name: CD - Staging
 on:
   push:
     branches: [develop]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -19,6 +19,9 @@ on:
     paths-ignore:
       - "**.md"
       - "docs/**"
+      - "claude-knowledge/**"
+      - ".claude/**"
+      - ".gitignore"
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## Summary

This commit was pushed to the feature branch after PR #317 had already been merged, so it never actually landed on `develop`. Re-opening it standalone.

`cd-staging.yml`/`cd-production.yml` triggered on every push with no path filter, so a docs-only change (like #317 itself) would still rebuild images and redeploy for nothing. Adds `paths-ignore` for `*.md` and `docs/**`.

## Test plan

- [x] Both workflow files validate as YAML


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhzoWjzr2ZF9zpYMDuf4X)_