### PR TITLE
Replace hardcoded localhost URLs with configurable API_BASE_URL

### DIFF
--- a/apps/client/src/features/forum/AddPostModal.tsx
+++ b/apps/client/src/features/forum/AddPostModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import CreatableSelect from 'react-select/creatable';
+import { API_BASE_URL } from '../../config/api';
 
 interface AddPostModalProps {
   isOpen: boolean;
@@ -22,7 +23,7 @@ export const AddPostModal: React.FC<AddPostModalProps> = ({ isOpen, onClose, onP
   const [validationError, setValidationError] = useState<string | null>(null);
 
   const loadTagsFromServer = () => {
-    fetch('http://localhost:5000/api/tags')
+    fetch(`${API_BASE_URL}/api/tags`)
       .then((res) => res.json())
       .then((data) => {
         const formatted = Array.isArray(data) ? data.map((tag: { _id?: string; name: string }) => ({
@@ -37,7 +38,7 @@ export const AddPostModal: React.FC<AddPostModalProps> = ({ isOpen, onClose, onP
   useEffect(() => {
     if (formData.title.length >= 3) {
       const timer = setTimeout(() => {
-        fetch(`http://localhost:5000/api/posts/search-similar?title=${formData.title}`)
+        fetch(`${API_BASE_URL}/api/posts/search-similar?title=${formData.title}`)
           .then((res) => res.json())
           .then((data) => setSimilarPosts(data))
           .catch((err) => console.error('Error fetching similar posts:', err));
@@ -71,7 +72,7 @@ const handleSubmit = async (e: React.FormEvent) => {
   // --- שלב א': העלאת הקובץ ל-S3 ---
   if (selectedFile) {
     try {
-      const urlResponse = await fetch('http://localhost:5000/api/upload/get-url', {
+      const urlResponse = await fetch(`${API_BASE_URL}/api/upload/get-url`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -114,7 +115,7 @@ const handleSubmit = async (e: React.FormEvent) => {
   try {
 const token = localStorage.getItem('token') || localStorage.getItem('accessToken'); 
 
-const response = await fetch('http://localhost:5000/api/posts', {
+const response = await fetch(`${API_BASE_URL}/api/posts`, {
   method: 'POST',
   headers: { 
     'Content-Type': 'application/json',

--- a/apps/client/src/features/forum/ForumPage.tsx
+++ b/apps/client/src/features/forum/ForumPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AddPostModal } from './AddPostModal';
+import { API_BASE_URL } from '../../config/api';
 
 interface Post {
   _id: string;
@@ -45,8 +46,8 @@ export const ForumPage: React.FC = () => {
     const userRole = currentUser?.role || 'user';
 
     const baseUrl = search.trim() 
-      ? `http://localhost:5000/api/posts/search?query=${search}`
-      : `http://localhost:5000/api/posts?page=${page}`;
+      ? `${API_BASE_URL}/api/posts/search?query=${search}`
+      : `${API_BASE_URL}/api/posts?page=${page}`;
     
     const url = baseUrl.includes('?') 
       ? `${baseUrl}&userRole=${userRole}${!search.trim() ? '' : `&page=${page}`}` 
@@ -106,7 +107,7 @@ export const ForumPage: React.FC = () => {
     }
 
     if (queryParam) {
-      fetch(`http://localhost:5000/api/posts/search-similar?${queryParam}`)
+      fetch(`${API_BASE_URL}/api/posts/search-similar?${queryParam}`)
         .then((res) => res.json())
         .then((data) => {
           if (Array.isArray(data)) {
@@ -168,7 +169,7 @@ export const ForumPage: React.FC = () => {
     if (!currentUser?._id) return alert('משתמש לא מחובר');
 
     try {
-      const response = await fetch(`http://localhost:5000/api/posts/${postId}/moderation`, {
+      const response = await fetch(`${API_BASE_URL}/api/posts/${postId}/moderation`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/apps/client/src/features/forum/PostThreadPage.tsx
+++ b/apps/client/src/features/forum/PostThreadPage.tsx
@@ -8,6 +8,7 @@ import { Highlight } from '@tiptap/extension-highlight';
 import { FontFamily } from '@tiptap/extension-font-family';
 import { TextAlign } from '@tiptap/extension-text-align';
 import Placeholder from '@tiptap/extension-placeholder';
+import { API_BASE_URL } from '../../config/api';
 
 interface Comment {
   _id: string;
@@ -72,7 +73,7 @@ export const PostThreadPage: React.FC = () => {
 
   const loadPostAndComments = () => {
     if (!id) return;
-    fetch(`http://localhost:5000/api/posts/${id}`)
+    fetch(`${API_BASE_URL}/api/posts/${id}`)
       .then((res) => res.json())
       .then((data) => {
         setPost(data.post);
@@ -89,7 +90,7 @@ export const PostThreadPage: React.FC = () => {
           localStorage.setItem('viewed_titles', JSON.stringify(updatedHistory));
 
           // שימוש בפרמטר postId המהיר ב-100% מול ה-Backend
-          fetch(`http://localhost:5000/api/posts/search-similar?postId=${data.post._id}`)
+          fetch(`${API_BASE_URL}/api/posts/search-similar?postId=${data.post._id}`)
             .then((res) => res.json())
             .then((similarData) => {
               if (Array.isArray(similarData)) {
@@ -140,7 +141,7 @@ export const PostThreadPage: React.FC = () => {
     const user = userStr ? JSON.parse(userStr) : null;
 
     if (user) {
-      fetch(`http://localhost:5000/api/posts/${id}/view`, {
+      fetch(`${API_BASE_URL}/api/posts/${id}/view`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId: user._id })
@@ -159,7 +160,7 @@ export const PostThreadPage: React.FC = () => {
     if (!window.confirm('האם את בטוחה שברצונך למחוק תגובה זו לצמיתות?')) return;
 
     try {
-      const response = await fetch(`http://localhost:5000/api/posts/comment/${commentId}`, {
+      const response = await fetch(`${API_BASE_URL}/api/posts/comment/${commentId}`, {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userId: currentUser?._id })
@@ -189,7 +190,7 @@ export const PostThreadPage: React.FC = () => {
 
     if (selectedFile) {
       try {
-        const urlResponse = await fetch('http://localhost:5000/api/upload/get-url', {
+        const urlResponse = await fetch(`${API_BASE_URL}/api/upload/get-url`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -226,7 +227,7 @@ export const PostThreadPage: React.FC = () => {
     };
 
     try {
-      const response = await fetch(`http://localhost:5000/api/posts/${id}/comment`, {
+      const response = await fetch(`${API_BASE_URL}/api/posts/${id}/comment`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(commentPayload)
@@ -254,7 +255,7 @@ export const PostThreadPage: React.FC = () => {
     setUserRating(selectedRating);
 
     try {
-      const response = await fetch(`http://localhost:5000/api/posts/${post._id}/rate`, {
+      const response = await fetch(`${API_BASE_URL}/api/posts/${post._id}/rate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
@@ -402,7 +403,7 @@ export const PostThreadPage: React.FC = () => {
             {post.attachments && post.attachments.length > 0 && (
               <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
                 {post.attachments.map((file, index) => {
-                  const fileUrl = file.startsWith('http') ? file : `http://localhost:5000/uploads/${file}`;
+                  const fileUrl = file.startsWith('http') ? file : `${API_BASE_URL}/uploads/${file}`;
                   return (
                     <a 
                       key={index}
@@ -504,7 +505,7 @@ export const PostThreadPage: React.FC = () => {
                   {comment.attachments && comment.attachments.length > 0 && (
                     <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap', marginTop: '10px' }}>
                       {comment.attachments.map((file, idx) => {
-                        const fileUrl = file.startsWith('http') ? file : `http://localhost:5000/uploads/${file}`;
+                        const fileUrl = file.startsWith('http') ? file : `${API_BASE_URL}/uploads/${file}`;
                         const isImage = /\.(jpg|jpeg|png|gif|webp)$/i.test(file);
 
                         if (isImage) {


### PR DESCRIPTION
## Summary
Refactored all hardcoded API endpoint URLs from `http://localhost:5000` to use a centralized `API_BASE_URL` configuration constant. This enables environment-specific API endpoint configuration without code changes.

## Key Changes
- Imported `API_BASE_URL` from `../../config/api` in three forum feature files:
  - `PostThreadPage.tsx`
  - `AddPostModal.tsx`
  - `ForumPage.tsx`

- Replaced all hardcoded `http://localhost:5000` URLs with `${API_BASE_URL}` template literals across:
  - Post fetching and creation endpoints
  - Comment operations (create, delete)
  - Post rating endpoints
  - File upload endpoints
  - Tag fetching
  - Similar posts search
  - Post moderation
  - File URL construction for attachments

## Implementation Details
- Total of 15 URL replacements across the three files
- Maintains backward compatibility with existing API contract
- Enables seamless environment switching (development, staging, production) through configuration
- File URLs for attachments now properly use the configurable base URL instead of hardcoded localhost

https://claude.ai/code/session_01G7JjtZjooKc1xwotL8zebQ