### PR TITLE
SCRUM-221: send invite email when a new org member is created

### DIFF
--- a/apps/server/src/controllers/organizationController.ts
+++ b/apps/server/src/controllers/organizationController.ts
@@ -284,7 +284,7 @@ export async function createOrganizationMemberHandler(
       return res.status(403).json({ error: "Access denied" });
     }
 
-    const { user: newUser, temporaryPassword } = await createOrganizationMember(orgId, {
+    const { user: newUser, temporaryPassword, emailSent } = await createOrganizationMember(orgId, {
       name: name.trim(),
       email: email.trim(),
       role,
@@ -294,6 +294,7 @@ export async function createOrganizationMemberHandler(
       success: true,
       user: { _id: newUser._id, name: newUser.name, email: newUser.email },
       temporaryPassword,
+      emailSent,
     });
   } catch (error: any) {
     logger.error("Failed to create organization member", {

--- a/apps/server/src/services/__tests__/organizationService.test.ts
+++ b/apps/server/src/services/__tests__/organizationService.test.ts
@@ -6,6 +6,7 @@ import {
   sendOrgApprovedEmail,
   sendOrgStatusEmail,
   sendOrgApprovalRequestEmail,
+  sendInviteEmail,
 } from "../../utils/email";
 import { register } from "../authService";
 import { UsageLog } from "../../models";
@@ -22,6 +23,7 @@ const mockedRepo = jest.mocked(repo);
 const mockedUserRepo = jest.mocked(userRepo);
 const mockedRegister = jest.mocked(register);
 const mockedUsageLog = jest.mocked(UsageLog);
+const mockedSendInviteEmail = jest.mocked(sendInviteEmail);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -379,6 +381,42 @@ describe("organizationService.createOrganizationMember", () => {
     });
     expect(typeof result.temporaryPassword).toBe("string");
     expect(result.temporaryPassword.length).toBeGreaterThan(0);
+  });
+
+  it("sends an invite email with the generated temporary password and reports success", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({ _id: "org1" } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(0);
+    mockedRegister.mockResolvedValue({
+      user: { _id: "newUser1", name: "New Member", email: "member@example.com" },
+    } as any);
+    mockedSendInviteEmail.mockResolvedValue(true);
+
+    const result = await organizationService.createOrganizationMember("org1", memberData);
+
+    expect(mockedSendInviteEmail).toHaveBeenCalledWith(
+      "member@example.com",
+      "New Member",
+      result.temporaryPassword
+    );
+    expect(result.emailSent).toBe(true);
+  });
+
+  it("still creates the user and reports emailSent=false when the invite email fails", async () => {
+    mockedRepo.getOrganizationById.mockResolvedValue({ _id: "org1" } as any);
+    mockedUserRepo.countUsersByOrganization.mockResolvedValue(0);
+    mockedRegister.mockResolvedValue({
+      user: { _id: "newUser1", name: "New Member", email: "member@example.com" },
+    } as any);
+    mockedSendInviteEmail.mockResolvedValue(false);
+
+    const result = await organizationService.createOrganizationMember("org1", memberData);
+
+    expect(result.user).toEqual({
+      _id: "newUser1",
+      name: "New Member",
+      email: "member@example.com",
+    });
+    expect(result.emailSent).toBe(false);
   });
 
   it("uses the given role instead of the default", async () => {

--- a/apps/server/src/services/organizationService.ts
+++ b/apps/server/src/services/organizationService.ts
@@ -3,7 +3,7 @@ import * as repo from "../repositories/organizationRepository";
 import * as userRepo from "../repositories/userRepository";
 import { UsageLog } from "../models";
 import { register } from "./authService";
-import { sendOrgApprovalRequestEmail, sendOrgApprovedEmail, sendOrgStatusEmail } from "../utils/email";
+import { sendOrgApprovalRequestEmail, sendOrgApprovedEmail, sendOrgStatusEmail, sendInviteEmail } from "../utils/email";
 import logger from "../logger";
 
 function generateTemporaryPassword(): string {
@@ -213,7 +213,9 @@ export async function createOrganizationMember(
 
     logger.info("Organization member created", { organizationId: orgId, userId: user._id });
 
-    return { user, temporaryPassword };
+    const emailSent = await sendInviteEmail(data.email, data.name, temporaryPassword);
+
+    return { user, temporaryPassword, emailSent };
   } catch (error: any) {
     logger.error("Failed to create organization member", {
       error: error.message,

--- a/apps/server/src/utils/email.ts
+++ b/apps/server/src/utils/email.ts
@@ -412,6 +412,83 @@ export async function sendWelcomeEmail(
 }
 
 /**
+ * Send invite email to a user newly added to an organization by an
+ * admin/org owner, containing their temporary password and a link to the
+ * site. Best-effort: failures are logged and swallowed, never block the
+ * underlying user-creation flow (same convention as sendWelcomeEmail).
+ */
+export async function sendInviteEmail(
+  email: string,
+  name: string,
+  temporaryPassword: string,
+): Promise<boolean> {
+  const safeName = escapeHtml(name);
+  const safeTemporaryPassword = escapeHtml(temporaryPassword);
+  const safeEmail = escapeHtml(email);
+
+  const mailOptions = {
+    from: EMAIL_FROM,
+    to: email,
+    subject: "הוזמנת להצטרף ל-SafeAI 🎉",
+    html: `
+      <!DOCTYPE html>
+      <html dir="rtl" lang="he">
+      <head>
+        <meta charset="UTF-8">
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+          .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+          .header { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0; }
+          .content { background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px; }
+          .credentials { background: white; padding: 15px; border-radius: 5px; border: 2px solid #667eea; }
+          .credentials p { margin: 5px 0; }
+          .password { font-family: monospace; font-weight: bold; }
+          .button { display: inline-block; margin-top: 20px; padding: 12px 24px; background: #667eea; color: white; text-decoration: none; border-radius: 5px; }
+          .footer { text-align: center; margin-top: 20px; color: #666; font-size: 12px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header">
+            <h1>🎉 הוזמנת ל-SafeAI!</h1>
+          </div>
+          <div class="content">
+            <p>שלום ${safeName},</p>
+            <p>נוצר עבורך חשבון ב-SafeAI. הפרטים להתחברות:</p>
+            <div class="credentials">
+              <p><strong>אימייל:</strong> ${safeEmail}</p>
+              <p><strong>סיסמה זמנית:</strong> <span class="password">${safeTemporaryPassword}</span></p>
+            </div>
+            <p style="text-align: center;">
+              <a class="button" href="${FRONTEND_URL}">כניסה למערכת</a>
+            </p>
+          </div>
+          <div class="footer">
+            <p>© 2026 SafeAI. כל הזכויות שמורות.</p>
+          </div>
+        </div>
+      </body>
+      </html>
+    `,
+  };
+
+  try {
+    await withRetry(async () => {
+      const transporter = await createTransporter();
+      return transporter.sendMail(mailOptions);
+    });
+    return true;
+  } catch (error) {
+    logger.error("Failed to send invite email:", {
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    // Don't throw - invite email failure must not block user creation
+    return false;
+  }
+}
+
+/**
  * Send contact form email to support
  */
 export async function sendContactEmail(data: {


### PR DESCRIPTION
## Summary
- Adds `sendInviteEmail()` to `utils/email.ts` (nodemailer, best-effort, mirrors `sendWelcomeEmail`'s error convention)
- Wires it into `createOrganizationMember` so a new org member receives their temporary password + a link to the site by email
- Returns `emailSent` in the create-member API response
- Adds unit tests for the success and failure paths (46/46 tests passing)

Jira: SCRUM-221 (subtask of SCRUM-218)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx jest src/services/__tests__/organizationService.test.ts` — 46/46 passing
- [ ] Manual E2E with a real SMTP server (not covered here — see SCRUM-220 QA notes)