### PR TITLE
SCRUM-219: show invite-email success/failure notice when adding a member

### DIFF
--- a/apps/client/src/features/organizations/api/organizationApi.ts
+++ b/apps/client/src/features/organizations/api/organizationApi.ts
@@ -106,6 +106,7 @@ export const createOrganizationMember = async (
   success: boolean;
   user: { _id: string; name: string; email: string };
   temporaryPassword: string;
+  emailSent: boolean;
 }> => {
   return apiCall(API_ENDPOINTS.adminOrganizations.members(orgId), {
     method: "POST",

--- a/apps/client/src/features/organizations/components/OrganizationDetail.tsx
+++ b/apps/client/src/features/organizations/components/OrganizationDetail.tsx
@@ -28,6 +28,10 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
   const [memberEmail, setMemberEmail] = useState("");
   const [addingMember, setAddingMember] = useState(false);
   const [addMemberError, setAddMemberError] = useState<string | null>(null);
+  const [addMemberNotice, setAddMemberNotice] = useState<{
+    type: "success" | "warning";
+    text: string;
+  } | null>(null);
   const [createdMembers, setCreatedMembers] = useState<
     { name: string; email: string; password: string }[]
   >([]);
@@ -46,6 +50,7 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
     try {
       setAddingMember(true);
       setAddMemberError(null);
+      setAddMemberNotice(null);
       const result = await createOrganizationMember(orgId, {
         name: memberName.trim(),
         email: memberEmail.trim(),
@@ -58,6 +63,14 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
           password: result.temporaryPassword,
         },
       ]);
+      setAddMemberNotice(
+        result.emailSent
+          ? { type: "success", text: `נשלח מייל הזמנה ל-${result.user.email}` }
+          : {
+              type: "warning",
+              text: "המשתמש נוצר אך שליחת מייל ההזמנה נכשלה — יש לשתף את הפרטים ידנית",
+            }
+      );
       setMemberName("");
       setMemberEmail("");
       await reloadUsers();
@@ -169,6 +182,11 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
           placeholder="כתובת אימייל"
         />
         {addMemberError && <div className="orgs-error">{addMemberError}</div>}
+        {addMemberNotice && (
+          <div className={addMemberNotice.type === "success" ? "orgs-success" : "orgs-warning"}>
+            {addMemberNotice.text}
+          </div>
+        )}
         <button type="submit" className="orgs-btn orgs-btn-activate" disabled={addingMember}>
           {addingMember ? "מוסיף..." : "הוסף משתמש"}
         </button>

--- a/apps/client/src/styles/organizations-admin.css
+++ b/apps/client/src/styles/organizations-admin.css
@@ -38,6 +38,8 @@
 .orgs-empty { padding: 16px; background: #f5f5f5; border-radius: 6px; text-align: center; color: #666; }
 .orgs-loading { padding: 20px; text-align: center; }
 .orgs-error { padding: 20px; color: #dc3545; }
+.orgs-success { padding: 8px 0; color: #16a34a; }
+.orgs-warning { padding: 8px 0; color: #b45309; }
 
 /* Internal sub-toggle (all / pending) */
 .orgs-subtoggle { display: flex; gap: 8px; margin: 12px 0 20px; border-bottom: 1px solid #e5e7eb; }


### PR DESCRIPTION
## Summary
- `createOrganizationMember` API type now includes `emailSent`
- `OrganizationDetail.tsx` shows a success or warning message after adding a member, based on `emailSent`
- Existing password/Excel-export fallback is unchanged (still shown as backup for the failure case)

Jira: SCRUM-219 (subtask of SCRUM-218)
Depends on: SCRUM-221 backend PR (for the `emailSent` field to actually be returned by the API)

## Test plan
- [x] `npx tsc -b` passes
- [ ] Manual verification in the browser once merged alongside the backend PR