### PR TITLE
Improve request detail page UX for closing inquiries

### DIFF
--- a/apps/client/src/features/safeai-ui/RequestDetails.tsx
+++ b/apps/client/src/features/safeai-ui/RequestDetails.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { apiCall } from "../../config/api";
+import "../../styles/safeai-ui.css";
 
 interface RequestData {
     title?: unknown; requestType?: unknown; description?: unknown; createdAt?: unknown; replies?: unknown[]; status?: unknown;
@@ -13,6 +14,8 @@ export default function RequestDetails() {
     const navigate = useNavigate();
     const [replyText, setReplyText] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+    const [isClosing, setIsClosing] = useState(false);
 
         useEffect(() => {
         apiCall(`/contact/my-requests/${id}`, { method: "GET" })
@@ -26,17 +29,20 @@ export default function RequestDetails() {
 
     if (!request) return <div>טוען פרטי פנייה...</div>;
 
-    const handleCloseRequest = async () => {
+    const confirmCloseRequest = async () => {
+        setIsClosing(true);
         try {
             await apiCall(`/contact/my-requests/${id}/close`, { method: "PATCH" });
 
             // עדכון ה-State של ה-request כדי שהסטטוס ישתנה ב-UI באופן מיידי
             setRequest({ ...request, status: 'closed' });
-            alert("הפנייה נסגרה בהצלחה!");
             navigate(-1); // נווט חזרה לרשימת הפניות לאחר סגירה
         } catch (error) {
             console.error("שגיאה בסגירת הפנייה:", error);
             alert("שגיאה בסגירת הפנייה. נסי שוב מאוחר יותר.");
+        } finally {
+            setIsClosing(false);
+            setShowCloseConfirm(false);
         }
     };
 
@@ -60,13 +66,33 @@ export default function RequestDetails() {
 
         return (
         <div className="request-details-container">
+            <button className="back-btn" onClick={() => navigate(-1)}>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M15 6L9 12L15 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+                חזרה לרשימת הפניות
+            </button>
             <h2>פרטי הפנייה</h2>
             <div className="request-card">
                 <h3>{String(request.title || "")}</h3>
                 <p><strong>סוג:</strong> {String(request.requestType || "")}</p>
                 <p><strong>תוכן:</strong> {String(request.description || "")}</p>
                 <p><strong>תאריך שליחה:</strong> {request.createdAt ? new Date(request.createdAt as string | number | Date).toLocaleDateString("he-IL") : ""}</p>
-                <button onClick={handleCloseRequest}>סגור פנייה</button>
+                {String(request.status) === "closed" ? (
+                    <button className="close-btn close-btn-disabled" disabled title="לא ניתן לסגור פנייה שכבר נסגרה">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M5 13L9 17L19 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                        </svg>
+                        הפנייה סגורה
+                    </button>
+                ) : (
+                    <button className="close-btn" onClick={() => setShowCloseConfirm(true)}>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M6 6L18 18M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                        </svg>
+                        סגור פנייה
+                    </button>
+                )}
 
                 <div className="replies-list">
                     {(request.replies || []).map((replyItem, index: number) => {
@@ -91,6 +117,28 @@ export default function RequestDetails() {
                     </button>
                 </div>
             </div>
+
+            {showCloseConfirm && (
+                <div className="modal-overlay" onClick={() => !isClosing && setShowCloseConfirm(false)}>
+                    <div className="modal confirm-modal" onClick={(e) => e.stopPropagation()}>
+                        <div className="confirm-modal-icon">
+                            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M12 9V13M12 17H12.01M10.29 3.86L1.82 18A2 2 0 0 0 3.55 21H20.45A2 2 0 0 0 22.18 18L13.71 3.86A2 2 0 0 0 10.29 3.86Z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                            </svg>
+                        </div>
+                        <h2 className="confirm-modal-title">סגירת פנייה</h2>
+                        <p className="confirm-modal-text">האם את/ה בטוח/ה שברצונך לסגור את הפנייה? לא ניתן לשלוח תגובות נוספות לאחר הסגירה.</p>
+                        <div className="modal-footer confirm-modal-footer">
+                            <button className="btn btn-secondary" onClick={() => setShowCloseConfirm(false)} disabled={isClosing}>
+                                ביטול
+                            </button>
+                            <button className="btn btn-danger" onClick={confirmCloseRequest} disabled={isClosing}>
+                                {isClosing ? "סוגר..." : "כן, סגור פנייה"}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 

--- a/apps/client/src/styles/safeai-ui.css
+++ b/apps/client/src/styles/safeai-ui.css
@@ -594,18 +594,71 @@
   color: #24343a;
 }
 
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 16px;
+  padding: 8px 14px;
+  background: transparent;
+  color: #0b6b5b;
+  border: 1px solid #d5eae6;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, transform 0.2s;
+}
+
+.back-btn:hover {
+  background: #f1f8f7;
+  border-color: #0b6b5b;
+  transform: translateX(2px);
+}
+
+.back-btn svg {
+  transform: scaleX(-1);
+}
+
 .close-btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   margin-top: 12px;
-  padding: 8px 12px;
+  padding: 10px 16px;
   background: #0b6b5b;
   color: #fff;
   border-radius: 8px;
   border: none;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 6px 16px rgba(11, 107, 91, 0.25);
+  transition: background 0.2s, box-shadow 0.2s, transform 0.2s;
 }
-.close-btn:hover { background: #095a4d; }
+
+.close-btn:hover {
+  background: #095a4d;
+  box-shadow: 0 8px 20px rgba(11, 107, 91, 0.3);
+  transform: translateY(-1px);
+}
+
+.close-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 10px rgba(11, 107, 91, 0.25);
+}
+
+.close-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.close-btn-disabled {
+  background: #eef2f1;
+  color: #5b6b67;
+  opacity: 1;
+}
 
 .replies-list { margin-top: 18px; display:flex; flex-direction:column; gap:12px; }
 .reply-bubble {
@@ -641,5 +694,47 @@
 @media (max-width: 720px) {
   .request-details-container { padding: 12px; }
   .reply-bubble { max-width: 100%; }
+}
+
+/* Close-request confirmation modal */
+.confirm-modal {
+  max-width: 420px;
+  width: 90%;
+  text-align: center;
+  padding: 28px 24px 24px;
+}
+
+.confirm-modal-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.confirm-modal-title {
+  margin: 0 0 8px;
+  font-size: 1.2rem;
+  color: #111827;
+}
+
+.confirm-modal-text {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+.confirm-modal-footer {
+  justify-content: center;
+  margin-top: 22px;
+}
+
+.confirm-modal-footer .btn {
+  min-width: 110px;
+  justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- Add a styled back button on the request detail page to return to the inquiries list
- Replace the "close request" button's browser `confirm`/`alert` with a centered, styled confirmation modal
- Disable the close action and show a "closed" state once an inquiry is already closed, preventing re-closing

## Test plan
- [x] `npm run typecheck` passes in `apps/client`
- [ ] Manually verify: open a request as a user/admin, confirm the back button returns to the previous list, confirm closing shows the modal, confirm a closed request shows the disabled "closed" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)