### PR TITLE
fix: remove unused plaintext apiKey field from ProviderKey model

### DIFF
--- a/apps/server/src/models/providerKey.ts
+++ b/apps/server/src/models/providerKey.ts
@@ -29,8 +29,6 @@ const ProviderKeySchema = new mongoose.Schema(
       type: Boolean,
       default: true,
     },
-
-  apiKey: String
 },
 { timestamps: true }
 );


### PR DESCRIPTION
The schema had a leftover apiKey: String field alongside the real apiKeyEncrypted one. No code path ever wrote to it (create/update only ever set apiKeyEncrypted), and unlike apiKeyEncrypted it wasn't stripped by the toJSON transform - so if it were ever populated, a provider's raw API key would have been returned in plain text from any endpoint that serializes a ProviderKey document.