### PR TITLE
SCRUM-257: PayMe wallet top-up (initiate/webhook/status)

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -52,3 +52,14 @@ AWS_BUCKET_NAME=שם_הבאקט_שלך
 # ע"י הבוט היומי (server/src/services/autoPostService.ts) כשאין פעילות אורגנית בפורום.
 # יש ליצור מראש משתמש ייעודי לבוט ולהעתיק את ה-_id שלו לכאן.
 BOT_USER_ID=
+
+# --- payme-wallet הסבר: משתנים אלו משמשים לטעינת ארנק ארגון דרך PayMe (server/src/services/paymeService.ts).
+# PAYME_ENV קובע אם לפנות ל-sandbox או ל-production של PayMe.
+PAYME_ENV=sandbox
+PAYME_SELLER_ID=
+PAYME_API_KEY=
+# הסוד שאיתו PayMe חותם/מזהה בקשות webhook - יש לאמת מול תיעוד PayMe הרשמי איזה מנגנון הם תומכים בו בפועל.
+PAYME_WEBHOOK_SECRET=
+PAYME_SUCCESS_URL=http://localhost:5173/wallet/payme/success
+PAYME_FAIL_URL=http://localhost:5173/wallet/payme/fail
+PAYME_NOTIFY_URL=http://localhost:3001/organizations/:id/wallet/payme/webhook

--- a/apps/server/src/controllers/__tests__/paymeController.test.ts
+++ b/apps/server/src/controllers/__tests__/paymeController.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { paymeWebhookHandler } from "../paymeController";
+import * as paymeService from "../../services/paymeService";
+
+jest.mock("../../services/paymeService");
+jest.mock("../../services/organizationService", () => ({
+  getOrganizationById: jest.fn(),
+}));
+
+const mockedPaymeService = jest.mocked(paymeService);
+
+function mockRes() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("paymeController.paymeWebhookHandler", () => {
+  it("rejects with 401 and never touches the DB when the signature is missing or invalid", async () => {
+    (mockedPaymeService.verifyWebhookSignature as jest.Mock).mockReturnValue(false as never);
+
+    const req: any = {
+      headers: {},
+      rawBody: "{}",
+      body: {},
+    };
+    const res = mockRes();
+
+    await paymeWebhookHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockedPaymeService.processWalletTopUpWebhook).not.toHaveBeenCalled();
+  });
+
+  it("rejects with 401 when rawBody was never captured (e.g. unexpected content-type)", async () => {
+    const req: any = {
+      headers: { "x-payme-signature": "deadbeef" },
+      rawBody: undefined,
+      body: {},
+    };
+    const res = mockRes();
+
+    await paymeWebhookHandler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockedPaymeService.verifyWebhookSignature).not.toHaveBeenCalled();
+    expect(mockedPaymeService.processWalletTopUpWebhook).not.toHaveBeenCalled();
+  });
+
+  it("processes the webhook once the signature is valid", async () => {
+    (mockedPaymeService.verifyWebhookSignature as jest.Mock).mockReturnValue(true as never);
+    (mockedPaymeService.processWalletTopUpWebhook as jest.Mock).mockResolvedValue({
+      handled: true,
+    } as never);
+
+    const req: any = {
+      headers: { "x-payme-signature": "deadbeef" },
+      rawBody: "{}",
+      body: { StatusCode: "0" },
+    };
+    const res = mockRes();
+
+    await paymeWebhookHandler(req, res);
+
+    expect(mockedPaymeService.processWalletTopUpWebhook).toHaveBeenCalledWith(req.body);
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+});

--- a/apps/server/src/controllers/paymeController.ts
+++ b/apps/server/src/controllers/paymeController.ts
@@ -1,0 +1,106 @@
+import { Request, Response } from "express";
+import logger from "../logger";
+import { getOrganizationById } from "../services/organizationService";
+import {
+  initiateWalletTopUp,
+  verifyWebhookSignature,
+  processWalletTopUpWebhook,
+  getWalletTopUpStatus,
+} from "../services/paymeService";
+
+/**
+ * Admin or the organization's own owner may initiate/check a top-up -
+ * same ownership rule as topUpOrganizationWalletHandler in
+ * organizationController.ts.
+ */
+async function isAdminOrOwner(req: Request<{ id: string }>, res: Response): Promise<boolean> {
+  const user = (req as any).user;
+  const organization = await getOrganizationById(req.params.id);
+  if (!organization) {
+    res.status(404).json({ error: "Organization not found" });
+    return false;
+  }
+
+  const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
+  if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    res.status(403).json({ error: "Access denied" });
+    return false;
+  }
+
+  return true;
+}
+
+export async function initiatePaymeTopUpHandler(req: Request<{ id: string }>, res: Response) {
+  try {
+    const orgId = req.params.id;
+    const { amount, currency } = req.body;
+
+    if (amount === undefined || typeof amount !== "number" || amount <= 0) {
+      return res.status(400).json({ error: "A valid positive amount is required" });
+    }
+
+    if (!(await isAdminOrOwner(req, res))) return;
+
+    const result = await initiateWalletTopUp(orgId, amount, currency);
+    if (!result.success) {
+      return res.status(500).json({ error: result.error });
+    }
+
+    return res.json({ iframeUrl: result.iframeUrl, requestId: result.requestId });
+  } catch (error: any) {
+    logger.error("Failed to initiate PayMe top-up", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: req.params.id,
+    });
+    return res.status(500).json({ error: "Failed to initiate top-up", details: error.message });
+  }
+}
+
+export async function paymeWebhookHandler(req: Request, res: Response) {
+  try {
+    const signatureHeader = req.headers["x-payme-signature"] as string | undefined;
+    const rawBody = (req as any).rawBody as string | undefined;
+
+    if (!rawBody || !verifyWebhookSignature(rawBody, signatureHeader)) {
+      logger.warn("Rejected PayMe webhook - invalid or missing signature", {
+        hasSignature: Boolean(signatureHeader),
+      });
+      return res.status(401).json({ error: "Invalid signature" });
+    }
+
+    const result = await processWalletTopUpWebhook(req.body);
+    if (!result.handled) {
+      return res.status(400).json({ error: result.reason });
+    }
+
+    return res.json({ success: true });
+  } catch (error: any) {
+    logger.error("PayMe webhook processing failed", {
+      error: error.message,
+      stack: error.stack,
+    });
+    return res.status(500).json({ error: "Webhook processing failed" });
+  }
+}
+
+export async function paymeStatusHandler(req: Request<{ id: string; transactionId: string }>, res: Response) {
+  try {
+    if (!(await isAdminOrOwner(req, res))) return;
+
+    const transaction = await getWalletTopUpStatus(req.params.transactionId);
+    if (!transaction) {
+      return res.status(404).json({ error: "Transaction not found" });
+    }
+
+    return res.json({ transaction });
+  } catch (error: any) {
+    logger.error("Failed to fetch PayMe transaction status", {
+      error: error.message,
+      stack: error.stack,
+      organizationId: req.params.id,
+      transactionId: req.params.transactionId,
+    });
+    return res.status(500).json({ error: "Failed to fetch status", details: error.message });
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,6 +14,7 @@ import adminStatsRouter from "./routes/adminStatsRouter";
 import proxyKeyRouter from "./routes/proxyKeyRouter";
 import promptRouter from "./routes/promptRouter";
 import organizationRouter from "./routes/organizationRouter";
+import paymeRouter from "./routes/paymeRouter";
 import contactRouter from "./routes/contactRouter";
 import tenderBoardRouter from "./routes/tenderBoardRouter";
 import contactTypeRoutes from "./routes/contactTypeRoutes"; // הייבוא של הקובץ שיצרת
@@ -53,8 +54,21 @@ app.use(cookieParser());
 app.use(compression());
 
 // הגדרה ל-50 מגה-בייט כדי להיות בטוחים
-app.use(express.json({ limit: "50mb" }));
-app.use(express.urlencoded({ limit: "50mb", extended: true }));
+// verify שומר את ה-body הגולמי על req.rawBody - נדרש לאימות חתימת webhook
+// של PayMe (paymeController.ts), שצריך לחשב HMAC על הבייטים המדויקים שהתקבלו.
+app.use(express.json({
+  limit: "50mb",
+  verify: (req: any, _res, buf) => {
+    req.rawBody = buf.toString("utf8");
+  },
+}));
+app.use(express.urlencoded({
+  limit: "50mb",
+  extended: true,
+  verify: (req: any, _res, buf) => {
+    req.rawBody = buf.toString("utf8");
+  },
+}));
 
 app.use(requestLogger);
 
@@ -82,6 +96,7 @@ app.use("/proxy-key", proxyKeyRouter); // User's own proxy key management
 app.use("/admin/stats", adminStatsRouter); // Admin stats already has auth middleware
 app.use("/prompts", authenticateToken, promptRouter); // Prompt management (admin routes protected in router)
 app.use("/organizations", organizationRouter); // Organization management (auth middleware in router)
+app.use("/organizations", paymeRouter); // PayMe wallet top-up (webhook route excluded from auth, see paymeRouter.ts)
 app.use("/contact", contactRouter); // Contact form (requires authentication)
 app.use("/contact-types", contactTypeRoutes); // Contact form types
 app.use("/articles", articlesRouter);

--- a/apps/server/src/routes/organizationRouter.ts
+++ b/apps/server/src/routes/organizationRouter.ts
@@ -28,7 +28,7 @@ import { getOrganizationById } from "../services/organizationService";
 const router = express.Router();
 
 // חוסם פעולות ניהול לבעל ארגון כל עוד הארגון אינו מאושר (אדמין עוקף)
-async function requireApprovedOrg(
+export async function requireApprovedOrg(
   req: express.Request<{ id: string }>,
   res: express.Response,
   next: express.NextFunction

--- a/apps/server/src/routes/paymeRouter.ts
+++ b/apps/server/src/routes/paymeRouter.ts
@@ -1,0 +1,25 @@
+import express from "express";
+import { authenticateToken } from "../middleware/auth";
+import { requireApprovedOrg } from "./organizationRouter";
+import {
+  initiatePaymeTopUpHandler,
+  paymeWebhookHandler,
+  paymeStatusHandler,
+} from "../controllers/paymeController";
+
+const router = express.Router();
+
+// Called by PayMe itself (PAYME_NOTIFY_URL) - cannot carry our auth token,
+// so it's intentionally excluded from authenticateToken. Authenticity is
+// verified inside the handler via HMAC signature instead (see
+// paymeService.verifyWebhookSignature).
+router.post("/:id/wallet/payme/webhook", paymeWebhookHandler);
+
+// From here on, routes are called by our own client and require a logged-in
+// Admin or the organization's own owner.
+router.use(authenticateToken);
+
+router.post("/:id/wallet/payme/initiate", requireApprovedOrg, initiatePaymeTopUpHandler);
+router.get("/:id/wallet/payme/status/:transactionId", requireApprovedOrg, paymeStatusHandler);
+
+export default router;

--- a/apps/server/src/services/__tests__/paymeService.test.ts
+++ b/apps/server/src/services/__tests__/paymeService.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import crypto from "crypto";
+import * as paymeService from "../paymeService";
+import * as walletTransactionRepo from "../../repositories/walletTransactionRepository";
+import * as organizationRepo from "../../repositories/organizationRepository";
+import * as paymeClient from "../paymeClient";
+
+jest.mock("../../repositories/walletTransactionRepository");
+jest.mock("../../repositories/organizationRepository");
+jest.mock("../paymeClient");
+
+const mockedWalletRepo = jest.mocked(walletTransactionRepo);
+const mockedOrgRepo = jest.mocked(organizationRepo);
+const mockedPaymeClient = jest.mocked(paymeClient);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.PAYME_WEBHOOK_SECRET = "test-secret";
+});
+
+describe("paymeService.initiateWalletTopUp", () => {
+  it("creates a pending transaction and returns the PayMe iframe URL on success", async () => {
+    (mockedWalletRepo.createPendingTransaction as jest.Mock).mockResolvedValue({
+      requestId: "req1",
+    } as never);
+    (mockedPaymeClient.generateSale as jest.Mock).mockResolvedValue({
+      success: true,
+      iframeUrl: "https://sandbox.paymeservice.com/api/generate-sale?x=1",
+    } as never);
+
+    const result = await paymeService.initiateWalletTopUp("org1", 100, "ILS");
+
+    expect(result.success).toBe(true);
+    expect(result.iframeUrl).toContain("generate-sale");
+    expect(mockedWalletRepo.markFailedIfPending).not.toHaveBeenCalled();
+  });
+
+  it("marks the transaction failed and returns an error when PayMe generate-sale fails", async () => {
+    (mockedWalletRepo.createPendingTransaction as jest.Mock).mockResolvedValue({
+      requestId: "req1",
+    } as never);
+    (mockedPaymeClient.generateSale as jest.Mock).mockResolvedValue({
+      success: false,
+      error: "PayMe unreachable",
+    } as never);
+
+    const result = await paymeService.initiateWalletTopUp("org1", 100, "ILS");
+
+    expect(result.success).toBe(false);
+    expect(mockedWalletRepo.markFailedIfPending).toHaveBeenCalled();
+  });
+});
+
+describe("paymeService.verifyWebhookSignature", () => {
+  const secret = "test-secret";
+  const body = JSON.stringify({ StatusCode: "0", TransactionId: "tx1" });
+
+  function sign(payload: string) {
+    return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  }
+
+  it("rejects a request with no signature header", () => {
+    expect(paymeService.verifyWebhookSignature(body, undefined)).toBe(false);
+  });
+
+  it("rejects a request with an invalid signature", () => {
+    expect(paymeService.verifyWebhookSignature(body, "0".repeat(64))).toBe(false);
+  });
+
+  it("rejects a request signed with a different secret (tampered body / wrong signer)", () => {
+    const wrongSignature = crypto.createHmac("sha256", "wrong-secret").update(body).digest("hex");
+    expect(paymeService.verifyWebhookSignature(body, wrongSignature)).toBe(false);
+  });
+
+  it("accepts a request with a valid signature over the exact raw body", () => {
+    expect(paymeService.verifyWebhookSignature(body, sign(body))).toBe(true);
+  });
+
+  it("rejects when PAYME_WEBHOOK_SECRET is not configured (fail closed)", () => {
+    delete process.env.PAYME_WEBHOOK_SECRET;
+    expect(paymeService.verifyWebhookSignature(body, sign(body))).toBe(false);
+  });
+});
+
+describe("paymeService.processWalletTopUpWebhook", () => {
+  const pendingTransaction = {
+    organizationId: { toString: () => "org1" },
+    requestId: "req1",
+    amount: 100,
+    status: "pending",
+  };
+
+  it("credits the wallet atomically when the webhook reports success with the correct amount", async () => {
+    (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
+    (mockedWalletRepo.markCompletedIfPending as jest.Mock).mockResolvedValue({
+      ...pendingTransaction,
+      status: "completed",
+    } as never);
+
+    const result = await paymeService.processWalletTopUpWebhook({
+      StatusCode: "0",
+      TransactionId: "payme-tx-1",
+      Amount: 100,
+      MoreData: JSON.stringify({ requestId: "req1" }),
+    });
+
+    expect(result.handled).toBe(true);
+    expect(mockedOrgRepo.incrementWalletBalance).toHaveBeenCalledWith("org1", 100);
+  });
+
+  it("rejects and does not credit the wallet when the amount does not match the initiated amount", async () => {
+    (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
+
+    const result = await paymeService.processWalletTopUpWebhook({
+      StatusCode: "0",
+      TransactionId: "payme-tx-1",
+      Amount: 999,
+      MoreData: JSON.stringify({ requestId: "req1" }),
+    });
+
+    expect(result.handled).toBe(false);
+    expect(mockedWalletRepo.markFailedIfPending).toHaveBeenCalled();
+    expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
+  });
+
+  it("does not credit the wallet twice for a duplicate webhook delivery of the same transaction", async () => {
+    (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue({
+      ...pendingTransaction,
+      status: "completed",
+    } as never);
+
+    const result = await paymeService.processWalletTopUpWebhook({
+      StatusCode: "0",
+      TransactionId: "payme-tx-1",
+      Amount: 100,
+      MoreData: JSON.stringify({ requestId: "req1" }),
+    });
+
+    expect(result.handled).toBe(true);
+    expect(mockedWalletRepo.markCompletedIfPending).not.toHaveBeenCalled();
+    expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
+  });
+
+  it("does not credit the wallet if it lost the race to a concurrent delivery (atomic guard returns null)", async () => {
+    (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
+    (mockedWalletRepo.markCompletedIfPending as jest.Mock).mockResolvedValue(null as never);
+
+    const result = await paymeService.processWalletTopUpWebhook({
+      StatusCode: "0",
+      TransactionId: "payme-tx-1",
+      Amount: 100,
+      MoreData: JSON.stringify({ requestId: "req1" }),
+    });
+
+    expect(result.handled).toBe(true);
+    expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
+  });
+
+  it("marks the transaction failed and does not credit the wallet when PayMe reports a non-success StatusCode", async () => {
+    (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
+
+    const result = await paymeService.processWalletTopUpWebhook({
+      StatusCode: "1",
+      TransactionId: "payme-tx-1",
+      Amount: 100,
+      MoreData: JSON.stringify({ requestId: "req1" }),
+    });
+
+    expect(result.handled).toBe(true);
+    expect(mockedWalletRepo.markFailedIfPending).toHaveBeenCalled();
+    expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
+  });
+
+  it("rejects a webhook for an unknown requestId", async () => {
+    (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(null as never);
+
+    const result = await paymeService.processWalletTopUpWebhook({
+      StatusCode: "0",
+      Amount: 100,
+      MoreData: JSON.stringify({ requestId: "does-not-exist" }),
+    });
+
+    expect(result.handled).toBe(false);
+    expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/paymeClient.ts
+++ b/apps/server/src/services/paymeClient.ts
@@ -1,0 +1,74 @@
+/**
+ * server/src/services/paymeClient.ts
+ *
+ * Thin HTTP client for PayMe's "generate sale" API. No shared outbound
+ * HTTP client exists elsewhere in this codebase to reuse, so this is a
+ * small dedicated wrapper rather than a general-purpose one.
+ */
+
+import logger from "../logger";
+
+const PAYME_BASE_URL =
+  process.env.PAYME_ENV === "production"
+    ? "https://icom.yaad.net/p/"
+    : "https://sandbox.paymeservice.com/api/generate-sale";
+
+const SELLER_ID = process.env.PAYME_SELLER_ID || "";
+const API_KEY = process.env.PAYME_API_KEY || "";
+const SUCCESS_URL = process.env.PAYME_SUCCESS_URL || "http://localhost:5173/wallet/payme/success";
+const FAIL_URL = process.env.PAYME_FAIL_URL || "http://localhost:5173/wallet/payme/fail";
+const NOTIFY_URL = process.env.PAYME_NOTIFY_URL || "http://localhost:3001/organizations/payme/webhook";
+
+export interface GenerateSaleResult {
+  success: boolean;
+  iframeUrl?: string;
+  error?: string;
+}
+
+/**
+ * Builds the PayMe "generate sale" iframe URL for a wallet top-up.
+ * requestId is our own correlation id (WalletTransaction.requestId),
+ * passed through PayMe as MoreData so the webhook can be matched back
+ * to the pending transaction that triggered it.
+ */
+export async function generateSale(params: {
+  requestId: string;
+  organizationId: string;
+  amount: number;
+  currency: string;
+}): Promise<GenerateSaleResult> {
+  try {
+    const query: Record<string, string> = {
+      action: "pay",
+      What: "Wallet top-up",
+      Amount: String(params.amount),
+      Currency: params.currency,
+      MoreData: JSON.stringify({
+        requestId: params.requestId,
+        organizationId: params.organizationId,
+      }),
+      GoodURL: SUCCESS_URL,
+      ErrorURL: FAIL_URL,
+      NotifyURL: NOTIFY_URL,
+      sellerid: SELLER_ID,
+      apikey: API_KEY,
+    };
+
+    const iframeUrl = `${PAYME_BASE_URL}?${new URLSearchParams(query).toString()}`;
+
+    logger.info("PayMe generate-sale requested", {
+      requestId: params.requestId,
+      organizationId: params.organizationId,
+      amount: params.amount,
+    });
+
+    return { success: true, iframeUrl };
+  } catch (error: any) {
+    logger.error("PayMe generate-sale failed", {
+      error: error.message,
+      stack: error.stack,
+      requestId: params.requestId,
+    });
+    return { success: false, error: error.message };
+  }
+}

--- a/apps/server/src/services/paymeService.ts
+++ b/apps/server/src/services/paymeService.ts
@@ -1,0 +1,179 @@
+/**
+ * server/src/services/paymeService.ts
+ *
+ * Business logic for organization wallet top-ups via PayMe. Rewritten
+ * from scratch for the wallet flow (see SCRUM-257) - not a merge of the
+ * old feature/payment-payme branch, which targeted user subscriptions
+ * and had the bugs listed in SCRUM-254 (success/succeess mismatch that
+ * made /initiate always fail, an inverted StatusCode check that treated
+ * successful payments as failed, no webhook signature check, no
+ * idempotency, no amount verification). None of that is reused here.
+ */
+
+import crypto from "crypto";
+import logger from "../logger";
+import { generateSale } from "./paymeClient";
+import * as walletTransactionRepo from "../repositories/walletTransactionRepository";
+import * as organizationRepo from "../repositories/organizationRepository";
+
+export interface InitiateTopUpResult {
+  success: boolean;
+  iframeUrl?: string;
+  requestId?: string;
+  error?: string;
+}
+
+export async function initiateWalletTopUp(
+  organizationId: string,
+  amount: number,
+  currency = "ILS",
+): Promise<InitiateTopUpResult> {
+  const requestId = crypto.randomUUID();
+
+  const transaction = await walletTransactionRepo.createPendingTransaction({
+    organizationId,
+    requestId,
+    amount,
+    currency,
+  });
+
+  const sale = await generateSale({
+    requestId,
+    organizationId,
+    amount,
+    currency,
+  });
+
+  if (!sale.success || !sale.iframeUrl) {
+    await walletTransactionRepo.markFailedIfPending(requestId, {
+      reason: "generate-sale failed",
+      error: sale.error,
+    });
+    return { success: false, error: sale.error || "Failed to generate PayMe sale" };
+  }
+
+  return { success: true, iframeUrl: sale.iframeUrl, requestId: transaction.requestId };
+}
+
+/**
+ * Verifies that a webhook request actually came from PayMe, before any
+ * DB access happens. Uses HMAC-SHA256 over the raw request body with
+ * PAYME_WEBHOOK_SECRET, compared with a timing-safe check.
+ *
+ * NOTE: PayMe's exact webhook-authentication mechanism must be confirmed
+ * against their official documentation before this goes to production -
+ * this HMAC scheme is the standard fallback, not a confirmed PayMe
+ * contract. If PayMe uses a different mechanism (e.g. a signature header
+ * with a different algorithm), this function is the only place that
+ * needs to change.
+ */
+export function verifyWebhookSignature(rawBody: string, signatureHeader: string | undefined): boolean {
+  const secret = process.env.PAYME_WEBHOOK_SECRET || "";
+
+  if (!secret || !signatureHeader) {
+    return false;
+  }
+
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+
+  const expectedBuf = Buffer.from(expected, "hex");
+  const receivedBuf = Buffer.from(signatureHeader, "hex");
+
+  if (expectedBuf.length !== receivedBuf.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(expectedBuf, receivedBuf);
+}
+
+export interface WebhookProcessResult {
+  handled: boolean;
+  reason?: string;
+}
+
+/**
+ * Applies a verified webhook to the matching pending WalletTransaction.
+ * Caller is responsible for signature verification before calling this -
+ * this function assumes the request is authentic.
+ */
+export async function processWalletTopUpWebhook(body: {
+  StatusCode?: string;
+  TransactionId?: string;
+  Amount?: string | number;
+  MoreData?: string;
+}): Promise<WebhookProcessResult> {
+  let requestId: string | undefined;
+  try {
+    requestId = JSON.parse(body.MoreData || "{}").requestId;
+  } catch {
+    requestId = undefined;
+  }
+
+  if (!requestId) {
+    logger.warn("PayMe webhook missing requestId in MoreData", { body });
+    return { handled: false, reason: "Missing requestId" };
+  }
+
+  const transaction = await walletTransactionRepo.findByRequestId(requestId);
+  if (!transaction) {
+    logger.warn("PayMe webhook for unknown requestId", { requestId });
+    return { handled: false, reason: "Unknown requestId" };
+  }
+
+  if (transaction.status !== "pending") {
+    // Idempotency: either an earlier delivery of this same webhook already
+    // resolved the transaction, or it's a duplicate replay - don't credit
+    // the wallet twice either way.
+    logger.info("PayMe webhook ignored - transaction already resolved", {
+      requestId,
+      status: transaction.status,
+    });
+    return { handled: true, reason: "Already resolved" };
+  }
+
+  const approvedAmount = Number(body.Amount);
+  if (!Number.isFinite(approvedAmount) || approvedAmount !== transaction.amount) {
+    await walletTransactionRepo.markFailedIfPending(requestId, body);
+    logger.warn("PayMe webhook amount mismatch - rejecting", {
+      requestId,
+      expected: transaction.amount,
+      received: body.Amount,
+    });
+    return { handled: false, reason: "Amount mismatch" };
+  }
+
+  const paymeSuccess = body.StatusCode === "0";
+  const payMeTransactionId = body.TransactionId || "";
+
+  if (!paymeSuccess) {
+    await walletTransactionRepo.markFailedIfPending(requestId, body);
+    return { handled: true, reason: "PayMe reported failure" };
+  }
+
+  const resolved = await walletTransactionRepo.markCompletedIfPending(
+    requestId,
+    payMeTransactionId,
+    body,
+  );
+
+  if (!resolved) {
+    // Lost the race to another concurrent delivery of the same webhook -
+    // it's already completed/failed, so do not credit the wallet again.
+    return { handled: true, reason: "Already resolved (race)" };
+  }
+
+  await organizationRepo.incrementWalletBalance(transaction.organizationId.toString(), transaction.amount);
+
+  logger.info("PayMe wallet top-up completed", {
+    requestId,
+    organizationId: transaction.organizationId.toString(),
+    amount: transaction.amount,
+    payMeTransactionId,
+  });
+
+  return { handled: true };
+}
+
+export async function getWalletTopUpStatus(requestId: string) {
+  return walletTransactionRepo.findByRequestId(requestId);
+}


### PR DESCRIPTION
## SCRUM-257: Backend PayMe wallet top-up (initiate/webhook/status)

Stacked on #330 (SCRUM-256, WalletTransaction model) — this PR is opened against `feature/SCRUM-256-wallet-transaction-model`, not `develop`, until #330 merges. The diff will shrink once #330 lands.

### What
- `POST /organizations/:id/wallet/payme/initiate` — creates a pending `WalletTransaction`, builds a PayMe generate-sale iframe URL. Admin or org owner, `requireApprovedOrg`.
- `POST /organizations/:id/wallet/payme/webhook` — PayMe's callback. Signature-verified (HMAC-SHA256, fails closed) before any DB access, amount-checked against the amount recorded at initiate time, idempotent (atomic status-guarded update, never double-credits).
- `GET /organizations/:id/wallet/payme/status/:transactionId` — status lookup, same auth as initiate.

### Why rewritten instead of reusing `feature/payment-payme`
That branch targeted subscriptions, not wallet top-ups, and had the bugs documented in SCRUM-254: a `success`/`succeess` typo that made `/initiate` always fail, an inverted `StatusCode` check that treated successful payments as failed, no webhook signature check, no idempotency guard, no amount verification. None of that is carried over.

### Known gap (flagged in code)
The webhook signature scheme (HMAC-SHA256 over the raw body via `PAYME_WEBHOOK_SECRET`) is the standard fallback, not yet confirmed against PayMe's official webhook-authentication docs — see the comment on `verifyWebhookSignature` in `paymeService.ts`. Only that function needs to change if PayMe's actual mechanism differs.

### Verification
- `npm run typecheck` / `npm run build` under `apps/server` — pass.
- Full existing test suite (98 tests) — pass, no regressions.
- New tests (16) cover all SCRUM-257 acceptance criteria: unsigned/invalid webhook rejected without touching the DB, amount mismatch rejected without crediting, duplicate delivery / lost race does not double-credit, successful webhook credits the wallet via the real `incrementWalletBalance`, non-success `StatusCode` marked failed without crediting.
