### PR TITLE
SCRUM-258: real PayMe wallet top-up flow (frontend)

### DIFF
--- a/apps/client/src/config/api.ts
+++ b/apps/client/src/config/api.ts
@@ -85,6 +85,13 @@ export const API_ENDPOINTS = {
     all: `${API_BASE_URL}/articles/all`,
     bySlug: (slug: string) => `${API_BASE_URL}/articles/${slug}`,
   },
+  // PayMe wallet top-up endpoints
+  payme: {
+    initiate: (organizationId: string) =>
+      `${API_BASE_URL}/organizations/${organizationId}/wallet/payme/initiate`,
+    status: (organizationId: string, transactionId: string) =>
+      `${API_BASE_URL}/organizations/${organizationId}/wallet/payme/status/${transactionId}`,
+  },
 } as const;
 
 // Helper function for API calls

--- a/apps/client/src/features/organizations/PaymeResultPage.tsx
+++ b/apps/client/src/features/organizations/PaymeResultPage.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { apiCall, API_ENDPOINTS } from "../../config/api";
+
+interface WalletTransactionStatus {
+  status: "pending" | "completed" | "failed";
+  amount: number;
+  currency: string;
+}
+
+interface OrganizationDetail {
+  walletBalance?: number;
+}
+
+type ViewState =
+  | { phase: "loading" }
+  | { phase: "success"; walletBalance: number }
+  | { phase: "failed" }
+  | { phase: "error"; message: string };
+
+/**
+ * Landing page PayMe redirects the browser to after a wallet top-up
+ * attempt (GoodURL/ErrorURL, built per-request in paymeClient.ts). The
+ * transaction's real status (from our own DB, not just which URL PayMe
+ * happened to redirect to) decides what's shown - PayMe's redirect
+ * choice is a hint, not the source of truth.
+ */
+export default function PaymeResultPage() {
+  const { id: organizationId } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const requestId = searchParams.get("requestId");
+
+  const [view, setView] = useState<ViewState>(() =>
+    organizationId && requestId
+      ? { phase: "loading" }
+      : { phase: "error", message: "חסרים פרטי עסקה" }
+  );
+
+  useEffect(() => {
+    if (!organizationId || !requestId) {
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const { transaction } = await apiCall<{ transaction: WalletTransactionStatus }>(
+          API_ENDPOINTS.payme.status(organizationId, requestId)
+        );
+
+        if (cancelled) return;
+
+        if (transaction.status === "completed") {
+          const organization = await apiCall<OrganizationDetail>(
+            API_ENDPOINTS.adminOrganizations.detail(organizationId)
+          );
+          if (cancelled) return;
+          setView({ phase: "success", walletBalance: organization.walletBalance ?? 0 });
+        } else if (transaction.status === "failed") {
+          setView({ phase: "failed" });
+        } else {
+          // Still pending - webhook hasn't landed yet. Rare in practice
+          // since PayMe redirects the browser after the webhook fires,
+          // but treat it as a failure to be safe rather than claim success.
+          setView({ phase: "failed" });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setView({
+            phase: "error",
+            message: err instanceof Error ? err.message : "שגיאה בבדיקת סטטוס התשלום",
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [organizationId, requestId]);
+
+  if (view.phase === "loading") {
+    return (
+      <div className="auth-form-container">
+        <div className="auth-form-wrapper">
+          <div style={{ textAlign: "center", padding: "40px" }}>
+            <div className="spinner" style={{ margin: "0 auto 20px" }}></div>
+            <h2>בודק את סטטוס התשלום...</h2>
+            <p style={{ color: "#666" }}>אנא המתן</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (view.phase === "success") {
+    return (
+      <div className="auth-form-container">
+        <div className="auth-form-wrapper">
+          <div style={{ textAlign: "center", padding: "40px" }}>
+            <h2>הטעינה הצליחה!</h2>
+            <p>יתרת הארנק המעודכנת: <strong>{view.walletBalance.toFixed(2)}</strong></p>
+            <button className="btn-primary" onClick={() => navigate("/organization/users")}>
+              חזרה לניהול הארגון
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="auth-form-container">
+      <div className="auth-form-wrapper">
+        <div style={{ textAlign: "center", padding: "40px" }}>
+          <h2>הטעינה נכשלה</h2>
+          <p style={{ color: "#666" }}>
+            {view.phase === "error" ? view.message : "התשלום לא הושלם או בוטל."}
+          </p>
+          <button className="btn-primary" onClick={() => navigate("/organization/users")}>
+            נסה שוב
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/pages/OrganizationUsersPage.tsx
+++ b/apps/client/src/pages/OrganizationUsersPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import axios from "axios";
 import * as XLSX from "xlsx";
 import { createOrganizationMember, getMyOrganization } from "../features/organizations/api/organizationApi";
+import { apiCall, API_ENDPOINTS } from "../config/api";
 import "../styles/organization-wallet.css";
 
 interface User {
@@ -124,38 +125,20 @@ export default function OrganizationUsersPage() {
     try {
       setIsSubmitting(true);
 
-      const token = localStorage.getItem("accessToken");
-
-      const response = await axios.post(
-        `${import.meta.env.VITE_API_URL}/organizations/${organization._id}/top-up`,
-        { amount: Number(topUpAmount) },
+      const { iframeUrl } = await apiCall<{ iframeUrl: string; requestId: string }>(
+        API_ENDPOINTS.payme.initiate(organization._id),
         {
-          headers: { Authorization: `Bearer ${token}` },
+          method: "POST",
+          body: JSON.stringify({ amount: Number(topUpAmount) }),
         }
       );
 
-      alert(
-        `הארנק נטען בהצלחה! יתרה חדשה: $${response.data.organization.walletBalance}`
-      );
-
-      setOrganization(response.data.organization);
-      setTopUpAmount("");
+      // Hand off to PayMe - it redirects back to our success/fail page
+      // (see PaymeResultPage.tsx) once the payment is done.
+      window.location.href = iframeUrl;
     } catch (err: unknown) {
-      console.error("Error topping up wallet:", err);
-
-      if (axios.isAxiosError(err)) {
-        const errorMsg =
-          err.response?.data?.error ||
-          err.response?.data?.message ||
-          "נכשל הטעינה לארנק";
-
-        alert(errorMsg);
-      } else if (err instanceof Error) {
-        alert(err.message);
-      } else {
-        alert("נכשל הטעינה לארנק");
-      }
-    } finally {
+      console.error("Error initiating wallet top-up:", err);
+      alert(err instanceof Error ? err.message : "נכשלה יצירת בקשת התשלום");
       setIsSubmitting(false);
     }
   };

--- a/apps/client/src/router/AppRouter.tsx
+++ b/apps/client/src/router/AppRouter.tsx
@@ -33,6 +33,7 @@ import AiNewsDetailsPage from "../pages/AiNewsDetailsPage";
 import ErrorBoundary from "../components/ErrorBoundary";
 import ForumPage from '../features/forum/ForumPage';
 import { PostThreadPage } from '../features/forum/PostThreadPage';
+import PaymeResultPage from '../features/organizations/PaymeResultPage';
 
 // Protected Route Component
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -197,6 +198,28 @@ export default function AppRouter() {
         />
 
         <Route path="/admin/organizations" element={<Navigate to="/safeai-ui" replace />} />
+
+        {/* PayMe wallet top-up result pages (PayMe redirects the browser here) */}
+        <Route
+          path="/organizations/:id/wallet/payme/success"
+          element={
+            <ProtectedRoute>
+              <ErrorBoundary>
+                <PaymeResultPage />
+              </ErrorBoundary>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/organizations/:id/wallet/payme/fail"
+          element={
+            <ProtectedRoute>
+              <ErrorBoundary>
+                <PaymeResultPage />
+              </ErrorBoundary>
+            </ProtectedRoute>
+          }
+        />
 
         <Route
           path="/admin/articles"

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -60,6 +60,8 @@ PAYME_SELLER_ID=
 PAYME_API_KEY=
 # הסוד שאיתו PayMe חותם/מזהה בקשות webhook - יש לאמת מול תיעוד PayMe הרשמי איזה מנגנון הם תומכים בו בפועל.
 PAYME_WEBHOOK_SECRET=
-PAYME_SUCCESS_URL=http://localhost:5173/wallet/payme/success
-PAYME_FAIL_URL=http://localhost:5173/wallet/payme/fail
+# מקור הלקוח (client origin) בלבד - הנתיב המדויק (/organizations/:id/wallet/payme/success|fail)
+# ופרמטר requestId נבנים לפי בקשה ב-paymeClient.ts.
+PAYME_SUCCESS_URL=http://localhost:5173
+PAYME_FAIL_URL=http://localhost:5173
 PAYME_NOTIFY_URL=http://localhost:3001/organizations/:id/wallet/payme/webhook

--- a/apps/server/src/services/paymeClient.ts
+++ b/apps/server/src/services/paymeClient.ts
@@ -15,8 +15,11 @@ const PAYME_BASE_URL =
 
 const SELLER_ID = process.env.PAYME_SELLER_ID || "";
 const API_KEY = process.env.PAYME_API_KEY || "";
-const SUCCESS_URL = process.env.PAYME_SUCCESS_URL || "http://localhost:5173/wallet/payme/success";
-const FAIL_URL = process.env.PAYME_FAIL_URL || "http://localhost:5173/wallet/payme/fail";
+// Client origin only - the org-specific success/fail page path is appended
+// per-request below, since it needs organizationId + our own requestId to
+// look up the transaction status (see PaymeResultPage.tsx on the client).
+const CLIENT_ORIGIN = process.env.PAYME_SUCCESS_URL || "http://localhost:5173";
+const CLIENT_FAIL_ORIGIN = process.env.PAYME_FAIL_URL || "http://localhost:5173";
 const NOTIFY_URL = process.env.PAYME_NOTIFY_URL || "http://localhost:3001/organizations/payme/webhook";
 
 export interface GenerateSaleResult {
@@ -38,6 +41,10 @@ export async function generateSale(params: {
   currency: string;
 }): Promise<GenerateSaleResult> {
   try {
+    const resultQuery = `requestId=${encodeURIComponent(params.requestId)}`;
+    const goodUrl = `${CLIENT_ORIGIN}/organizations/${params.organizationId}/wallet/payme/success?${resultQuery}`;
+    const errorUrl = `${CLIENT_FAIL_ORIGIN}/organizations/${params.organizationId}/wallet/payme/fail?${resultQuery}`;
+
     const query: Record<string, string> = {
       action: "pay",
       What: "Wallet top-up",
@@ -47,8 +54,8 @@ export async function generateSale(params: {
         requestId: params.requestId,
         organizationId: params.organizationId,
       }),
-      GoodURL: SUCCESS_URL,
-      ErrorURL: FAIL_URL,
+      GoodURL: goodUrl,
+      ErrorURL: errorUrl,
       NotifyURL: NOTIFY_URL,
       sellerid: SELLER_ID,
       apikey: API_KEY,


### PR DESCRIPTION
## SCRUM-258: Frontend — real PayMe wallet top-up flow (initiate/success/fail)

Stacked on #336 (SCRUM-257, backend PayMe endpoints) — opened against `feature/SCRUM-257-payme-service`, not `develop`, until that lands.

### What
- `OrganizationUsersPage.tsx` — `handleTopUp` now calls `POST /organizations/:id/wallet/payme/initiate` via the standard `apiCall()`/`API_ENDPOINTS` pattern and redirects the browser to the returned PayMe iframe URL, instead of the old mock `/top-up` call + instant `alert()`.
- New `PaymeResultPage.tsx`, registered at `/organizations/:id/wallet/payme/success` and `.../fail` — where PayMe redirects the browser back to. Looks up the real transaction status via `GET .../wallet/payme/status/:transactionId` (not just which of the two URLs PayMe redirected to), then fetches the organization's current `walletBalance` to display on success. Fail page shows a clear message + a "try again" action.
- `API_ENDPOINTS.payme.{initiate,status}` added, following the existing `adminOrganizations` namespace convention.
- Small necessary backend follow-up in `paymeClient.ts` (SCRUM-257's file): `GoodURL`/`ErrorURL` were static client-origin URLs with no way to know which transaction a redirect belonged to. Now built per-request as `/organizations/:id/wallet/payme/success|fail?requestId=...`, so the result page above can actually look up the transaction.

### Not touched
`OrganizationDetail.tsx` / `OrganizationsTable.tsx` — they only read `organization.walletBalance` from existing state/API calls, no dependency on the top-up handler. Confirmed no regression.

### Verification
- `npm run typecheck` / `npm run lint` / `npm run build` under `apps/client` — pass. (lint caught and fixed a real issue: synchronous `setState` inside a `useEffect` body in `PaymeResultPage.tsx`.)
- `apps/server` typecheck/build/full test suite (114 tests) — still pass after the `paymeClient.ts` change.

### Known gap
No automated tests for this PR yet (frontend integration tests for this flow are still to be written).
