### PR TITLE
fix(server): rewrite PayMe integration against the real, documented API

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -54,14 +54,20 @@ AWS_BUCKET_NAME=שם_הבאקט_שלך
 BOT_USER_ID=
 
 # --- payme-wallet הסבר: משתנים אלו משמשים לטעינת ארנק ארגון דרך PayMe (server/src/services/paymeService.ts).
-# PAYME_ENV קובע אם לפנות ל-sandbox או ל-production של PayMe.
+# מבוסס על התיעוד הרשמי: https://docs.payme.io/docs/payments
+# PAYME_ENV קובע אם לפנות ל-sandbox (sandbox.payme.io) או ל-production (live.payme.io) של PayMe.
 PAYME_ENV=sandbox
+# ה-seller_payme_id הפרטי שלך במערכת PayMe (מחרוזת "MPL..."). אין API key נפרד -
+# זהו המזהה היחיד שנשלח בכל בקשה. תמצאי אותו בפורטל PayMe שלך תחת "אינטגרציה".
 PAYME_SELLER_ID=
-PAYME_API_KEY=
-# הסוד שאיתו PayMe חותם/מזהה בקשות webhook - יש לאמת מול תיעוד PayMe הרשמי איזה מנגנון הם תומכים בו בפועל.
-PAYME_WEBHOOK_SECRET=
-# מקור הלקוח (client origin) בלבד - הנתיב המדויק (/organizations/:id/wallet/payme/success|fail)
-# ופרמטר requestId נבנים לפי בקשה ב-paymeClient.ts.
+# מקור הלקוח (client origin) בלבד - ל-generate-sale יש כתובת redirect יחידה
+# (sale_return_url), לא success/fail נפרדים. הנתיב המדויק ופרמטר requestId
+# נבנים לפי בקשה ב-paymeClient.ts.
 PAYME_SUCCESS_URL=http://localhost:5173
-PAYME_FAIL_URL=http://localhost:5173
+# sale_callback_url - PayMe שולח לכתובת הזו POST מסוג x-www-form-urlencoded
+# (ה"Sale Callback"/IPN) כשהעסקה מסתיימת. לא ניתן להזין כאן כתובת localhost -
+# לבדיקות מקומיות צריך טאנל חוץ (ngrok וכו').
 PAYME_NOTIFY_URL=http://localhost:3001/organizations/:id/wallet/payme/webhook
+# הערה: אימות חתימת ה-webhook (payme_signature) עדיין לא ממומש - הנוסחה לא
+# מתועדת פומבית, פנייה נשלחה ל-support@payme.io. עד לתשובה, כל webhook נדחה
+# כברירת מחדל (ראו verifyWebhookSignature ב-paymeService.ts).

--- a/apps/server/src/controllers/__tests__/paymeController.test.ts
+++ b/apps/server/src/controllers/__tests__/paymeController.test.ts
@@ -21,13 +21,11 @@ beforeEach(() => {
 });
 
 describe("paymeController.paymeWebhookHandler", () => {
-  it("rejects with 401 and never touches the DB when the signature is missing or invalid", async () => {
+  it("rejects with 401 and never touches the DB when the signature does not verify", async () => {
     (mockedPaymeService.verifyWebhookSignature as jest.Mock).mockReturnValue(false as never);
 
     const req: any = {
-      headers: {},
-      rawBody: "{}",
-      body: {},
+      body: { status_code: "0" },
     };
     const res = mockRes();
 
@@ -37,31 +35,14 @@ describe("paymeController.paymeWebhookHandler", () => {
     expect(mockedPaymeService.processWalletTopUpWebhook).not.toHaveBeenCalled();
   });
 
-  it("rejects with 401 when rawBody was never captured (e.g. unexpected content-type)", async () => {
-    const req: any = {
-      headers: { "x-payme-signature": "deadbeef" },
-      rawBody: undefined,
-      body: {},
-    };
-    const res = mockRes();
-
-    await paymeWebhookHandler(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(mockedPaymeService.verifyWebhookSignature).not.toHaveBeenCalled();
-    expect(mockedPaymeService.processWalletTopUpWebhook).not.toHaveBeenCalled();
-  });
-
-  it("processes the webhook once the signature is valid", async () => {
+  it("processes the webhook once the signature verifies", async () => {
     (mockedPaymeService.verifyWebhookSignature as jest.Mock).mockReturnValue(true as never);
     (mockedPaymeService.processWalletTopUpWebhook as jest.Mock).mockResolvedValue({
       handled: true,
     } as never);
 
     const req: any = {
-      headers: { "x-payme-signature": "deadbeef" },
-      rawBody: "{}",
-      body: { StatusCode: "0" },
+      body: { status_code: "0", notify_type: "sale-complete" },
     };
     const res = mockRes();
 

--- a/apps/server/src/controllers/paymeController.ts
+++ b/apps/server/src/controllers/paymeController.ts
@@ -7,6 +7,7 @@ import {
   processWalletTopUpWebhook,
   getWalletTopUpStatus,
 } from "../services/paymeService";
+import { MIN_SALE_PRICE_AGOROT } from "../services/paymeClient";
 
 /**
  * Admin or the organization's own owner may initiate/check a top-up -
@@ -35,8 +36,10 @@ export async function initiatePaymeTopUpHandler(req: Request<{ id: string }>, re
     const orgId = req.params.id;
     const { amount, currency } = req.body;
 
-    if (amount === undefined || typeof amount !== "number" || amount <= 0) {
-      return res.status(400).json({ error: "A valid positive amount is required" });
+    if (amount === undefined || typeof amount !== "number" || amount * 100 < MIN_SALE_PRICE_AGOROT) {
+      return res
+        .status(400)
+        .json({ error: `A valid amount of at least ${MIN_SALE_PRICE_AGOROT / 100} is required` });
     }
 
     if (!(await isAdminOrOwner(req, res))) return;
@@ -59,12 +62,9 @@ export async function initiatePaymeTopUpHandler(req: Request<{ id: string }>, re
 
 export async function paymeWebhookHandler(req: Request, res: Response) {
   try {
-    const signatureHeader = req.headers["x-payme-signature"] as string | undefined;
-    const rawBody = (req as any).rawBody as string | undefined;
-
-    if (!rawBody || !verifyWebhookSignature(rawBody, signatureHeader)) {
+    if (!verifyWebhookSignature(req.body)) {
       logger.warn("Rejected PayMe webhook - invalid or missing signature", {
-        hasSignature: Boolean(signatureHeader),
+        hasSignature: Boolean(req.body?.payme_signature),
       });
       return res.status(401).json({ error: "Invalid signature" });
     }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -54,21 +54,9 @@ app.use(cookieParser());
 app.use(compression());
 
 // הגדרה ל-50 מגה-בייט כדי להיות בטוחים
-// verify שומר את ה-body הגולמי על req.rawBody - נדרש לאימות חתימת webhook
-// של PayMe (paymeController.ts), שצריך לחשב HMAC על הבייטים המדויקים שהתקבלו.
-app.use(express.json({
-  limit: "50mb",
-  verify: (req: any, _res, buf) => {
-    req.rawBody = buf.toString("utf8");
-  },
-}));
-app.use(express.urlencoded({
-  limit: "50mb",
-  extended: true,
-  verify: (req: any, _res, buf) => {
-    req.rawBody = buf.toString("utf8");
-  },
-}));
+app.use(express.json({ limit: "50mb" }));
+// PayMe's Sale Callback (webhook) is posted as x-www-form-urlencoded.
+app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
 app.use(requestLogger);
 

--- a/apps/server/src/services/__tests__/paymeService.test.ts
+++ b/apps/server/src/services/__tests__/paymeService.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import crypto from "crypto";
 import * as paymeService from "../paymeService";
 import * as walletTransactionRepo from "../../repositories/walletTransactionRepository";
 import * as organizationRepo from "../../repositories/organizationRepository";
@@ -15,24 +14,31 @@ const mockedPaymeClient = jest.mocked(paymeClient);
 
 beforeEach(() => {
   jest.clearAllMocks();
-  process.env.PAYME_WEBHOOK_SECRET = "test-secret";
 });
 
 describe("paymeService.initiateWalletTopUp", () => {
-  it("creates a pending transaction and returns the PayMe iframe URL on success", async () => {
+  it("creates a pending transaction and returns the PayMe hosted-page URL on success", async () => {
     (mockedWalletRepo.createPendingTransaction as jest.Mock).mockResolvedValue({
       requestId: "req1",
     } as never);
     (mockedPaymeClient.generateSale as jest.Mock).mockResolvedValue({
       success: true,
-      iframeUrl: "https://sandbox.paymeservice.com/api/generate-sale?x=1",
+      iframeUrl: "https://sandbox.payme.io/sale/generate/xxx",
     } as never);
 
     const result = await paymeService.initiateWalletTopUp("org1", 100, "ILS");
 
     expect(result.success).toBe(true);
-    expect(result.iframeUrl).toContain("generate-sale");
+    expect(result.iframeUrl).toContain("sandbox.payme.io");
     expect(mockedWalletRepo.markFailedIfPending).not.toHaveBeenCalled();
+  });
+
+  it("rejects amounts below PayMe's minimum sale price without calling PayMe", async () => {
+    const result = await paymeService.initiateWalletTopUp("org1", 1, "ILS");
+
+    expect(result.success).toBe(false);
+    expect(mockedWalletRepo.createPendingTransaction).not.toHaveBeenCalled();
+    expect(mockedPaymeClient.generateSale).not.toHaveBeenCalled();
   });
 
   it("marks the transaction failed and returns an error when PayMe generate-sale fails", async () => {
@@ -52,33 +58,14 @@ describe("paymeService.initiateWalletTopUp", () => {
 });
 
 describe("paymeService.verifyWebhookSignature", () => {
-  const secret = "test-secret";
-  const body = JSON.stringify({ StatusCode: "0", TransactionId: "tx1" });
-
-  function sign(payload: string) {
-    return crypto.createHmac("sha256", secret).update(payload).digest("hex");
-  }
-
-  it("rejects a request with no signature header", () => {
-    expect(paymeService.verifyWebhookSignature(body, undefined)).toBe(false);
+  it("rejects a callback with no payme_signature field", () => {
+    expect(paymeService.verifyWebhookSignature({})).toBe(false);
   });
 
-  it("rejects a request with an invalid signature", () => {
-    expect(paymeService.verifyWebhookSignature(body, "0".repeat(64))).toBe(false);
-  });
-
-  it("rejects a request signed with a different secret (tampered body / wrong signer)", () => {
-    const wrongSignature = crypto.createHmac("sha256", "wrong-secret").update(body).digest("hex");
-    expect(paymeService.verifyWebhookSignature(body, wrongSignature)).toBe(false);
-  });
-
-  it("accepts a request with a valid signature over the exact raw body", () => {
-    expect(paymeService.verifyWebhookSignature(body, sign(body))).toBe(true);
-  });
-
-  it("rejects when PAYME_WEBHOOK_SECRET is not configured (fail closed)", () => {
-    delete process.env.PAYME_WEBHOOK_SECRET;
-    expect(paymeService.verifyWebhookSignature(body, sign(body))).toBe(false);
+  it("rejects a callback even with a payme_signature present (verification not yet implemented - fails closed)", () => {
+    expect(paymeService.verifyWebhookSignature({ payme_signature: "75e99dbcb25cdfbe1c62f0b9376f4144" })).toBe(
+      false
+    );
   });
 });
 
@@ -90,7 +77,7 @@ describe("paymeService.processWalletTopUpWebhook", () => {
     status: "pending",
   };
 
-  it("credits the wallet atomically when the webhook reports success with the correct amount", async () => {
+  it("credits the wallet atomically when the callback reports sale-complete with the correct amount", async () => {
     (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
     (mockedWalletRepo.markCompletedIfPending as jest.Mock).mockResolvedValue({
       ...pendingTransaction,
@@ -98,10 +85,11 @@ describe("paymeService.processWalletTopUpWebhook", () => {
     } as never);
 
     const result = await paymeService.processWalletTopUpWebhook({
-      StatusCode: "0",
-      TransactionId: "payme-tx-1",
-      Amount: 100,
-      MoreData: JSON.stringify({ requestId: "req1" }),
+      status_code: "0",
+      notify_type: "sale-complete",
+      payme_transaction_id: "TRANXXXX",
+      price: 10000, // agorot -> 100 ILS
+      transaction_id: "req1",
     });
 
     expect(result.handled).toBe(true);
@@ -112,10 +100,11 @@ describe("paymeService.processWalletTopUpWebhook", () => {
     (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
 
     const result = await paymeService.processWalletTopUpWebhook({
-      StatusCode: "0",
-      TransactionId: "payme-tx-1",
-      Amount: 999,
-      MoreData: JSON.stringify({ requestId: "req1" }),
+      status_code: "0",
+      notify_type: "sale-complete",
+      payme_transaction_id: "TRANXXXX",
+      price: 99900, // 999 ILS, not the requested 100
+      transaction_id: "req1",
     });
 
     expect(result.handled).toBe(false);
@@ -123,17 +112,18 @@ describe("paymeService.processWalletTopUpWebhook", () => {
     expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
   });
 
-  it("does not credit the wallet twice for a duplicate webhook delivery of the same transaction", async () => {
+  it("does not credit the wallet twice for a duplicate callback delivery of the same transaction", async () => {
     (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue({
       ...pendingTransaction,
       status: "completed",
     } as never);
 
     const result = await paymeService.processWalletTopUpWebhook({
-      StatusCode: "0",
-      TransactionId: "payme-tx-1",
-      Amount: 100,
-      MoreData: JSON.stringify({ requestId: "req1" }),
+      status_code: "0",
+      notify_type: "sale-complete",
+      payme_transaction_id: "TRANXXXX",
+      price: 10000,
+      transaction_id: "req1",
     });
 
     expect(result.handled).toBe(true);
@@ -146,24 +136,25 @@ describe("paymeService.processWalletTopUpWebhook", () => {
     (mockedWalletRepo.markCompletedIfPending as jest.Mock).mockResolvedValue(null as never);
 
     const result = await paymeService.processWalletTopUpWebhook({
-      StatusCode: "0",
-      TransactionId: "payme-tx-1",
-      Amount: 100,
-      MoreData: JSON.stringify({ requestId: "req1" }),
+      status_code: "0",
+      notify_type: "sale-complete",
+      payme_transaction_id: "TRANXXXX",
+      price: 10000,
+      transaction_id: "req1",
     });
 
     expect(result.handled).toBe(true);
     expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
   });
 
-  it("marks the transaction failed and does not credit the wallet when PayMe reports a non-success StatusCode", async () => {
+  it("marks the transaction failed and does not credit the wallet when PayMe reports sale-failure", async () => {
     (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(pendingTransaction as never);
 
     const result = await paymeService.processWalletTopUpWebhook({
-      StatusCode: "1",
-      TransactionId: "payme-tx-1",
-      Amount: 100,
-      MoreData: JSON.stringify({ requestId: "req1" }),
+      status_code: "1",
+      notify_type: "sale-failure",
+      price: 10000,
+      transaction_id: "req1",
     });
 
     expect(result.handled).toBe(true);
@@ -171,16 +162,28 @@ describe("paymeService.processWalletTopUpWebhook", () => {
     expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
   });
 
-  it("rejects a webhook for an unknown requestId", async () => {
+  it("rejects a callback for an unknown transaction_id", async () => {
     (mockedWalletRepo.findByRequestId as jest.Mock).mockResolvedValue(null as never);
 
     const result = await paymeService.processWalletTopUpWebhook({
-      StatusCode: "0",
-      Amount: 100,
-      MoreData: JSON.stringify({ requestId: "does-not-exist" }),
+      status_code: "0",
+      notify_type: "sale-complete",
+      price: 10000,
+      transaction_id: "does-not-exist",
     });
 
     expect(result.handled).toBe(false);
     expect(mockedOrgRepo.incrementWalletBalance).not.toHaveBeenCalled();
+  });
+
+  it("rejects a callback with no transaction_id", async () => {
+    const result = await paymeService.processWalletTopUpWebhook({
+      status_code: "0",
+      notify_type: "sale-complete",
+      price: 10000,
+    });
+
+    expect(result.handled).toBe(false);
+    expect(mockedWalletRepo.findByRequestId).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/paymeClient.ts
+++ b/apps/server/src/services/paymeClient.ts
@@ -1,26 +1,42 @@
 /**
  * server/src/services/paymeClient.ts
  *
- * Thin HTTP client for PayMe's "generate sale" API. No shared outbound
- * HTTP client exists elsewhere in this codebase to reuse, so this is a
- * small dedicated wrapper rather than a general-purpose one.
+ * Thin HTTP client for PayMe's real "generate-sale" API
+ * (https://docs.payme.io/docs/payments), rewritten after confirming the
+ * actual API shape against PayMe's official documentation. The first
+ * version of this file (and the old feature/payment-payme branch before
+ * it) targeted a different, incorrect API shape entirely - a GET with
+ * query params to sandbox.paymeservice.com/icom.yaad.net - which does not
+ * match PayMe's documented generate-sale/get-transactions endpoints
+ * (POST JSON to sandbox.payme.io/live.payme.io) at all. No shared
+ * outbound HTTP client exists elsewhere in this codebase to reuse, so
+ * this is a small dedicated wrapper rather than a general-purpose one.
  */
 
 import logger from "../logger";
 
 const PAYME_BASE_URL =
   process.env.PAYME_ENV === "production"
-    ? "https://icom.yaad.net/p/"
-    : "https://sandbox.paymeservice.com/api/generate-sale";
+    ? "https://live.payme.io/api"
+    : "https://sandbox.payme.io/api";
 
-const SELLER_ID = process.env.PAYME_SELLER_ID || "";
-const API_KEY = process.env.PAYME_API_KEY || "";
-// Client origin only - the org-specific success/fail page path is appended
-// per-request below, since it needs organizationId + our own requestId to
-// look up the transaction status (see PaymeResultPage.tsx on the client).
+// The seller's private key in PayMe's system ("MPL..."). This is not a
+// separate secret alongside an API key - PayMe's API has no separate API
+// key concept. Sent as seller_payme_id in every request body.
+const SELLER_PAYME_ID = process.env.PAYME_SELLER_ID || "";
+
+// Client origin for the single post-payment redirect (sale_return_url).
+// PayMe's generate-sale API has only one redirect URL, not separate
+// success/fail URLs - the result page itself (PaymeResultPage.tsx) looks
+// up the real transaction status rather than trusting the redirect.
 const CLIENT_ORIGIN = process.env.PAYME_SUCCESS_URL || "http://localhost:5173";
-const CLIENT_FAIL_ORIGIN = process.env.PAYME_FAIL_URL || "http://localhost:5173";
-const NOTIFY_URL = process.env.PAYME_NOTIFY_URL || "http://localhost:3001/organizations/payme/webhook";
+
+// sale_callback_url - PayMe POSTs sale details here (x-www-form-urlencoded)
+// once the sale is paid. Per PayMe's docs this may not be a localhost URL.
+const CALLBACK_URL = process.env.PAYME_NOTIFY_URL || "http://localhost:3001/organizations/payme/webhook";
+
+// PayMe's stated minimum sale_price, in agorot (5.00 ILS).
+export const MIN_SALE_PRICE_AGOROT = 500;
 
 export interface GenerateSaleResult {
   success: boolean;
@@ -29,10 +45,12 @@ export interface GenerateSaleResult {
 }
 
 /**
- * Builds the PayMe "generate sale" iframe URL for a wallet top-up.
- * requestId is our own correlation id (WalletTransaction.requestId),
- * passed through PayMe as MoreData so the webhook can be matched back
- * to the pending transaction that triggered it.
+ * Calls PayMe's generate-sale endpoint to create a wallet top-up sale
+ * and get back the hosted payment page URL to redirect the buyer to.
+ * requestId (our own WalletTransaction.requestId) is sent as PayMe's
+ * transaction_id field, PayMe's own correlator field for exactly this
+ * purpose - so the webhook can be matched back to the pending
+ * transaction without inventing our own encoding scheme.
  */
 export async function generateSale(params: {
   requestId: string;
@@ -41,35 +59,44 @@ export async function generateSale(params: {
   currency: string;
 }): Promise<GenerateSaleResult> {
   try {
-    const resultQuery = `requestId=${encodeURIComponent(params.requestId)}`;
-    const goodUrl = `${CLIENT_ORIGIN}/organizations/${params.organizationId}/wallet/payme/success?${resultQuery}`;
-    const errorUrl = `${CLIENT_FAIL_ORIGIN}/organizations/${params.organizationId}/wallet/payme/fail?${resultQuery}`;
+    const salePriceAgorot = Math.round(params.amount * 100);
 
-    const query: Record<string, string> = {
-      action: "pay",
-      What: "Wallet top-up",
-      Amount: String(params.amount),
-      Currency: params.currency,
-      MoreData: JSON.stringify({
-        requestId: params.requestId,
-        organizationId: params.organizationId,
+    const response = await fetch(`${PAYME_BASE_URL}/generate-sale`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        seller_payme_id: SELLER_PAYME_ID,
+        sale_price: salePriceAgorot,
+        currency: params.currency,
+        product_name: "Wallet top-up",
+        transaction_id: params.requestId,
+        sale_callback_url: CALLBACK_URL,
+        sale_return_url: `${CLIENT_ORIGIN}/organizations/${params.organizationId}/wallet/payme/success?requestId=${encodeURIComponent(params.requestId)}`,
       }),
-      GoodURL: goodUrl,
-      ErrorURL: errorUrl,
-      NotifyURL: NOTIFY_URL,
-      sellerid: SELLER_ID,
-      apikey: API_KEY,
+    });
+
+    const data = (await response.json()) as {
+      status_code?: number;
+      sale_url?: string;
+      status_error_details?: string;
     };
 
-    const iframeUrl = `${PAYME_BASE_URL}?${new URLSearchParams(query).toString()}`;
+    if (data.status_code !== 0 || !data.sale_url) {
+      logger.warn("PayMe generate-sale rejected the request", {
+        requestId: params.requestId,
+        statusCode: data.status_code,
+        error: data.status_error_details,
+      });
+      return { success: false, error: data.status_error_details || "PayMe rejected the sale request" };
+    }
 
-    logger.info("PayMe generate-sale requested", {
+    logger.info("PayMe generate-sale succeeded", {
       requestId: params.requestId,
       organizationId: params.organizationId,
       amount: params.amount,
     });
 
-    return { success: true, iframeUrl };
+    return { success: true, iframeUrl: data.sale_url };
   } catch (error: any) {
     logger.error("PayMe generate-sale failed", {
       error: error.message,

--- a/apps/server/src/services/paymeService.ts
+++ b/apps/server/src/services/paymeService.ts
@@ -8,11 +8,17 @@
  * made /initiate always fail, an inverted StatusCode check that treated
  * successful payments as failed, no webhook signature check, no
  * idempotency, no amount verification). None of that is reused here.
+ *
+ * Rewritten a second time after confirming PayMe's actual, documented
+ * API shape (https://docs.payme.io/docs/payments): the first version of
+ * this file guessed at a callback payload shape (StatusCode/TransactionId/
+ * Amount/MoreData) that does not match PayMe's real Sale Callback
+ * attributes (status_code/notify_type/transaction_id/price/payme_transaction_id).
  */
 
 import crypto from "crypto";
 import logger from "../logger";
-import { generateSale } from "./paymeClient";
+import { generateSale, MIN_SALE_PRICE_AGOROT } from "./paymeClient";
 import * as walletTransactionRepo from "../repositories/walletTransactionRepository";
 import * as organizationRepo from "../repositories/organizationRepository";
 
@@ -28,6 +34,10 @@ export async function initiateWalletTopUp(
   amount: number,
   currency = "ILS",
 ): Promise<InitiateTopUpResult> {
+  if (Math.round(amount * 100) < MIN_SALE_PRICE_AGOROT) {
+    return { success: false, error: `Amount must be at least ${MIN_SALE_PRICE_AGOROT / 100} ${currency}` };
+  }
+
   const requestId = crypto.randomUUID();
 
   const transaction = await walletTransactionRepo.createPendingTransaction({
@@ -56,34 +66,26 @@ export async function initiateWalletTopUp(
 }
 
 /**
- * Verifies that a webhook request actually came from PayMe, before any
- * DB access happens. Uses HMAC-SHA256 over the raw request body with
- * PAYME_WEBHOOK_SECRET, compared with a timing-safe check.
+ * Verifies that a Sale Callback actually came from PayMe, before any DB
+ * access happens.
  *
- * NOTE: PayMe's exact webhook-authentication mechanism must be confirmed
- * against their official documentation before this goes to production -
- * this HMAC scheme is the standard fallback, not a confirmed PayMe
- * contract. If PayMe uses a different mechanism (e.g. a signature header
- * with a different algorithm), this function is the only place that
- * needs to change.
+ * NOT YET IMPLEMENTED: PayMe's callback payload includes a
+ * payme_signature field, but the formula for computing/verifying it
+ * (which fields, in what order, with what algorithm and key) is not in
+ * PayMe's public API docs. We've asked PayMe support directly; until
+ * they confirm it, this fails closed - every callback is rejected - so a
+ * missing verification step can never be mistaken for a passing one.
+ * Once confirmed, this is the only function that needs to change.
  */
-export function verifyWebhookSignature(rawBody: string, signatureHeader: string | undefined): boolean {
-  const secret = process.env.PAYME_WEBHOOK_SECRET || "";
-
-  if (!secret || !signatureHeader) {
+export function verifyWebhookSignature(body: { payme_signature?: string }): boolean {
+  if (!body.payme_signature) {
     return false;
   }
 
-  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
-
-  const expectedBuf = Buffer.from(expected, "hex");
-  const receivedBuf = Buffer.from(signatureHeader, "hex");
-
-  if (expectedBuf.length !== receivedBuf.length) {
-    return false;
-  }
-
-  return crypto.timingSafeEqual(expectedBuf, receivedBuf);
+  logger.warn(
+    "PayMe webhook signature verification is not yet implemented (formula not confirmed with PayMe support) - rejecting by default",
+  );
+  return false;
 }
 
 export interface WebhookProcessResult {
@@ -91,33 +93,38 @@ export interface WebhookProcessResult {
   reason?: string;
 }
 
+export interface PaymeSaleCallbackBody {
+  status_code?: string | number;
+  notify_type?: string;
+  transaction_id?: string;
+  payme_transaction_id?: string;
+  price?: string | number;
+  currency?: string;
+  payme_signature?: string;
+  [key: string]: unknown;
+}
+
 /**
- * Applies a verified webhook to the matching pending WalletTransaction.
- * Caller is responsible for signature verification before calling this -
- * this function assumes the request is authentic.
+ * Applies a verified Sale Callback to the matching pending
+ * WalletTransaction. Caller is responsible for signature verification
+ * before calling this - this function assumes the request is authentic.
+ *
+ * transaction_id here is PayMe's echo of our own WalletTransaction.requestId
+ * (sent as transaction_id in the generate-sale request) - PayMe's own
+ * correlator field, not something we had to invent an encoding for.
  */
-export async function processWalletTopUpWebhook(body: {
-  StatusCode?: string;
-  TransactionId?: string;
-  Amount?: string | number;
-  MoreData?: string;
-}): Promise<WebhookProcessResult> {
-  let requestId: string | undefined;
-  try {
-    requestId = JSON.parse(body.MoreData || "{}").requestId;
-  } catch {
-    requestId = undefined;
-  }
+export async function processWalletTopUpWebhook(body: PaymeSaleCallbackBody): Promise<WebhookProcessResult> {
+  const requestId = body.transaction_id;
 
   if (!requestId) {
-    logger.warn("PayMe webhook missing requestId in MoreData", { body });
-    return { handled: false, reason: "Missing requestId" };
+    logger.warn("PayMe webhook missing transaction_id", { body });
+    return { handled: false, reason: "Missing transaction_id" };
   }
 
   const transaction = await walletTransactionRepo.findByRequestId(requestId);
   if (!transaction) {
-    logger.warn("PayMe webhook for unknown requestId", { requestId });
-    return { handled: false, reason: "Unknown requestId" };
+    logger.warn("PayMe webhook for unknown transaction_id", { requestId });
+    return { handled: false, reason: "Unknown transaction_id" };
   }
 
   if (transaction.status !== "pending") {
@@ -131,23 +138,24 @@ export async function processWalletTopUpWebhook(body: {
     return { handled: true, reason: "Already resolved" };
   }
 
-  const approvedAmount = Number(body.Amount);
+  // price is in agorot (e.g. 5075 = 50.75 ILS) - WalletTransaction.amount is ILS.
+  const approvedAmount = Number(body.price) / 100;
   if (!Number.isFinite(approvedAmount) || approvedAmount !== transaction.amount) {
     await walletTransactionRepo.markFailedIfPending(requestId, body);
     logger.warn("PayMe webhook amount mismatch - rejecting", {
       requestId,
       expected: transaction.amount,
-      received: body.Amount,
+      received: body.price,
     });
     return { handled: false, reason: "Amount mismatch" };
   }
 
-  const paymeSuccess = body.StatusCode === "0";
-  const payMeTransactionId = body.TransactionId || "";
+  const paymeSuccess = body.notify_type === "sale-complete" && String(body.status_code) === "0";
+  const payMeTransactionId = body.payme_transaction_id || "";
 
   if (!paymeSuccess) {
     await walletTransactionRepo.markFailedIfPending(requestId, body);
-    return { handled: true, reason: "PayMe reported failure" };
+    return { handled: true, reason: `PayMe notify_type: ${body.notify_type}` };
   }
 
   const resolved = await walletTransactionRepo.markCompletedIfPending(


### PR DESCRIPTION
## Fix: PayMe integration was built against the wrong API entirely

Stacked on the SCRUM-256/257/258 chain — opened against `feature/SCRUM-256-wallet-transaction-model` (which already carries all three), not `develop`.

### The problem

SCRUM-257's `paymeClient.ts`/`paymeService.ts` (already merged via #336) targeted a GET-with-query-params API at `sandbox.paymeservice.com` / `icom.yaad.net`, inherited from assumptions in the old `feature/payment-payme` branch. After connecting to the company's real PayMe sandbox account and reading PayMe's actual official docs (docs.payme.io/docs/payments), it turns out that's not PayMe's real API at all.

### The real API

POST-JSON REST API at `sandbox.payme.io` / `live.payme.io`:
- No separate API key — auth is `seller_payme_id` itself, sent in the body.
- `sale_price` is an integer in **agorot** (100 = 1 ILS), minimum 500.
- **One** redirect URL (`sale_return_url`) — not separate success/fail URLs like the old code assumed.
- The webhook ("Sale Callback") POSTs `status_code`/`notify_type`/`transaction_id`/`payme_transaction_id`/`price` — completely different field names than previously guessed (`StatusCode`/`TransactionId`/`Amount`/`MoreData`).
- `transaction_id` in the callback is PayMe's own echo of whatever we sent as `transaction_id` in the request — so `WalletTransaction.requestId` is now sent as PayMe's own correlator field directly, replacing the `MoreData` JSON-encoding workaround.

### What's fixed here
- `paymeClient.ts` — full rewrite: correct base URLs, JSON POST body, real field names, agorot conversion, single return URL.
- `paymeService.ts` — `processWalletTopUpWebhook` rewritten for the real callback shape; `initiateWalletTopUp` now validates PayMe's real minimum sale price.
- `paymeController.ts` — signature check now reads `payme_signature` from the body, not a header.
- `index.ts` — dropped the now-pointless rawBody/HMAC-over-raw-bytes capture.
- `.env.example` — dropped `PAYME_API_KEY` (doesn't exist in the real API) and `PAYME_FAIL_URL` (no separate fail URL), clarified `PAYME_SELLER_ID`.
- Tests updated for the real callback/field shapes.

### Known gap (unchanged from before, now more precisely scoped)
PayMe's `payme_signature` verification formula isn't in their public docs. `verifyWebhookSignature` **fails closed** — every webhook is rejected — until PayMe support confirms it (email sent). This means the webhook is currently non-functional end-to-end against the real sandbox, by design, rather than silently insecure.

### Verification
`npm run typecheck` / `build` / full test suite (112 tests) under `apps/server` — all pass. Client typecheck confirmed unaffected (the `/status` response shape it consumes is our own DB record, unchanged).
