### PR TITLE
Rebrand primary color from green to teal-blue

### DIFF
--- a/apps/client/public/SafeAI.svg
+++ b/apps/client/public/SafeAI.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- מעבר צבעים טורקיז למגן -->
     <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#2E6E7E;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1E4852;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#48B4D6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#2996B7;stop-opacity:1" />
     </linearGradient>
     
     <!-- צל עדין להבלטה -->

--- a/apps/client/public/SafeAI.svg
+++ b/apps/client/public/SafeAI.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- מעבר צבעים טורקיז למגן -->
     <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0C6250;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#084034;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#2E6E7E;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1E4852;stop-opacity:1" />
     </linearGradient>
     
     <!-- צל עדין להבלטה -->

--- a/apps/client/public/SafeAI.svg
+++ b/apps/client/public/SafeAI.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- מעבר צבעים טורקיז למגן -->
     <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#25596B;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1C4E5E;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#0C6250;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#084034;stop-opacity:1" />
     </linearGradient>
     
     <!-- צל עדין להבלטה -->

--- a/apps/client/public/SafeAI.svg
+++ b/apps/client/public/SafeAI.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- מעבר צבעים טורקיז למגן -->
     <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10a37f;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0d8f6f;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#25596B;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1C4E5E;stop-opacity:1" />
     </linearGradient>
     
     <!-- צל עדין להבלטה -->

--- a/apps/client/public/SafeAI.svg
+++ b/apps/client/public/SafeAI.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- מעבר צבעים טורקיז למגן -->
     <linearGradient id="shieldGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#48B4D6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#2996B7;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#1C7AA6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#135471;stop-opacity:1" />
     </linearGradient>
     
     <!-- צל עדין להבלטה -->

--- a/apps/client/public/icon.svg
+++ b/apps/client/public/icon.svg
@@ -1,8 +1,8 @@
 <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="shieldGradientNew" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0C6250;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#084034;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#2E6E7E;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1E4852;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/icon.svg
+++ b/apps/client/public/icon.svg
@@ -1,8 +1,8 @@
 <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="shieldGradientNew" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#2E6E7E;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1E4852;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#48B4D6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#2996B7;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/icon.svg
+++ b/apps/client/public/icon.svg
@@ -1,8 +1,8 @@
 <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="shieldGradientNew" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#25596B;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1C4E5E;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#0C6250;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#084034;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/icon.svg
+++ b/apps/client/public/icon.svg
@@ -1,8 +1,8 @@
 <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="shieldGradientNew" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#48B4D6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#2996B7;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#1C7AA6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#135471;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/icon.svg
+++ b/apps/client/public/icon.svg
@@ -1,8 +1,8 @@
 <svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="shieldGradientNew" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10a37f;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0d8f6f;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#25596B;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1C4E5E;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/logo.svg
+++ b/apps/client/public/logo.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- הגדרת מעבר הצבעים המקורי -->
     <linearGradient id="brandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#2E6E7E;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1E4852;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#48B4D6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#2996B7;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/logo.svg
+++ b/apps/client/public/logo.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- הגדרת מעבר הצבעים המקורי -->
     <linearGradient id="brandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#48B4D6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#2996B7;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#1C7AA6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#135471;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/logo.svg
+++ b/apps/client/public/logo.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- הגדרת מעבר הצבעים המקורי -->
     <linearGradient id="brandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0C6250;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#084034;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#2E6E7E;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1E4852;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/logo.svg
+++ b/apps/client/public/logo.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- הגדרת מעבר הצבעים המקורי -->
     <linearGradient id="brandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#25596B;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1C4E5E;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#0C6250;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#084034;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/public/logo.svg
+++ b/apps/client/public/logo.svg
@@ -2,8 +2,8 @@
   <defs>
     <!-- הגדרת מעבר הצבעים המקורי -->
     <linearGradient id="brandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10a37f;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0d8f6f;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#25596B;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1C4E5E;stop-opacity:1" />
     </linearGradient>
   </defs>
   

--- a/apps/client/src/features/auth/RegisterForm.tsx
+++ b/apps/client/src/features/auth/RegisterForm.tsx
@@ -297,7 +297,7 @@ export default function RegisterForm() {
                   border: "1px solid #d1d5db",
                   borderRadius: "3px",
                   background: "#ffffff",
-                  accentColor: "#2E6E7E",
+                  accentColor: "#48B4D6",
                 }}
               />
               <span>

--- a/apps/client/src/features/auth/RegisterForm.tsx
+++ b/apps/client/src/features/auth/RegisterForm.tsx
@@ -297,7 +297,7 @@ export default function RegisterForm() {
                   border: "1px solid #d1d5db",
                   borderRadius: "3px",
                   background: "#ffffff",
-                  accentColor: "#10a37f",
+                  accentColor: "#25596B",
                 }}
               />
               <span>

--- a/apps/client/src/features/auth/RegisterForm.tsx
+++ b/apps/client/src/features/auth/RegisterForm.tsx
@@ -297,7 +297,7 @@ export default function RegisterForm() {
                   border: "1px solid #d1d5db",
                   borderRadius: "3px",
                   background: "#ffffff",
-                  accentColor: "#48B4D6",
+                  accentColor: "#1C7AA6",
                 }}
               />
               <span>

--- a/apps/client/src/features/auth/RegisterForm.tsx
+++ b/apps/client/src/features/auth/RegisterForm.tsx
@@ -297,7 +297,7 @@ export default function RegisterForm() {
                   border: "1px solid #d1d5db",
                   borderRadius: "3px",
                   background: "#ffffff",
-                  accentColor: "#25596B",
+                  accentColor: "#0C6250",
                 }}
               />
               <span>

--- a/apps/client/src/features/auth/RegisterForm.tsx
+++ b/apps/client/src/features/auth/RegisterForm.tsx
@@ -297,7 +297,7 @@ export default function RegisterForm() {
                   border: "1px solid #d1d5db",
                   borderRadius: "3px",
                   background: "#ffffff",
-                  accentColor: "#0C6250",
+                  accentColor: "#2E6E7E",
                 }}
               />
               <span>

--- a/apps/client/src/features/forum/AddPostModal.tsx
+++ b/apps/client/src/features/forum/AddPostModal.tsx
@@ -414,7 +414,7 @@ const handleAiAssist = async (mode: 'refine' | 'titles' | 'tags') => {
               styles={{
                 control: (base) => ({
                   ...base,
-                  borderColor: '#d1fae5',
+                  borderColor: '#DEEFF7',
                   borderWidth: '2px',
                   borderRadius: '6px',
                   minHeight: '40px',
@@ -425,7 +425,7 @@ const handleAiAssist = async (mode: 'refine' | 'titles' | 'tags') => {
                   paddingLeft: '8px',
                   paddingRight: '8px',
                   boxSizing: 'border-box',
-                  '&:hover': { borderColor: '#10b981' }
+                  '&:hover': { borderColor: '#1C7AA6' }
                 }),
                 valueContainer: (base) => ({
                   ...base,
@@ -440,19 +440,19 @@ const handleAiAssist = async (mode: 'refine' | 'titles' | 'tags') => {
                 menu: (base) => ({
                   ...base,
                   zIndex: 1050,
-                  border: '1px solid #10b981',
+                  border: '1px solid #1C7AA6',
                   boxShadow: '0 -4px 12px rgba(0,0,0,0.1)'
                 }),
                 multiValue: (base) => ({
                   ...base,
-                  backgroundColor: '#ecfdf5',
+                  backgroundColor: '#DEEFF7',
                   borderRadius: '4px',
-                  border: '1px solid #a7f3d0',
+                  border: '1px solid #A6C9D9',
                   margin: '2px'
                 }),
                 multiValueLabel: (base) => ({
                   ...base,
-                  color: '#065f46',
+                  color: '#135471',
                   fontWeight: 'bold',
                   fontSize: '13px'
                 }),

--- a/apps/client/src/pages/AboutPage.tsx
+++ b/apps/client/src/pages/AboutPage.tsx
@@ -174,8 +174,8 @@ export default function AboutPage() {
                 x2="100%"
                 y2="100%"
               >
-                <stop offset="0%" stopColor="#2E6E7E" stopOpacity="1" />
-                <stop offset="100%" stopColor="#1E4852" stopOpacity="1" />
+                <stop offset="0%" stopColor="#48B4D6" stopOpacity="1" />
+                <stop offset="100%" stopColor="#2996B7" stopOpacity="1" />
               </linearGradient>
 
               <filter

--- a/apps/client/src/pages/AboutPage.tsx
+++ b/apps/client/src/pages/AboutPage.tsx
@@ -174,8 +174,8 @@ export default function AboutPage() {
                 x2="100%"
                 y2="100%"
               >
-                <stop offset="0%" stopColor="#0C6250" stopOpacity="1" />
-                <stop offset="100%" stopColor="#084034" stopOpacity="1" />
+                <stop offset="0%" stopColor="#2E6E7E" stopOpacity="1" />
+                <stop offset="100%" stopColor="#1E4852" stopOpacity="1" />
               </linearGradient>
 
               <filter

--- a/apps/client/src/pages/AboutPage.tsx
+++ b/apps/client/src/pages/AboutPage.tsx
@@ -174,8 +174,8 @@ export default function AboutPage() {
                 x2="100%"
                 y2="100%"
               >
-                <stop offset="0%" stopColor="#48B4D6" stopOpacity="1" />
-                <stop offset="100%" stopColor="#2996B7" stopOpacity="1" />
+                <stop offset="0%" stopColor="#1C7AA6" stopOpacity="1" />
+                <stop offset="100%" stopColor="#135471" stopOpacity="1" />
               </linearGradient>
 
               <filter

--- a/apps/client/src/pages/AboutPage.tsx
+++ b/apps/client/src/pages/AboutPage.tsx
@@ -174,8 +174,8 @@ export default function AboutPage() {
                 x2="100%"
                 y2="100%"
               >
-                <stop offset="0%" stopColor="#25596B" stopOpacity="1" />
-                <stop offset="100%" stopColor="#1C4E5E" stopOpacity="1" />
+                <stop offset="0%" stopColor="#0C6250" stopOpacity="1" />
+                <stop offset="100%" stopColor="#084034" stopOpacity="1" />
               </linearGradient>
 
               <filter

--- a/apps/client/src/pages/AboutPage.tsx
+++ b/apps/client/src/pages/AboutPage.tsx
@@ -174,8 +174,8 @@ export default function AboutPage() {
                 x2="100%"
                 y2="100%"
               >
-                <stop offset="0%" stopColor="#10a37f" stopOpacity="1" />
-                <stop offset="100%" stopColor="#0d8f6f" stopOpacity="1" />  
+                <stop offset="0%" stopColor="#25596B" stopOpacity="1" />
+                <stop offset="100%" stopColor="#1C4E5E" stopOpacity="1" />
               </linearGradient>
 
               <filter

--- a/apps/client/src/pages/TenderBoardPage.tsx
+++ b/apps/client/src/pages/TenderBoardPage.tsx
@@ -358,7 +358,7 @@ export default function TenderBoardPage() {
 
           {isSmartSearching && (
             <div style={{ display: 'flex', justifyContent: 'center', margin: '12px 0' }}>
-              <AiThinkingLoader color="#16a34a" />
+              <AiThinkingLoader color="#1C7AA6" />
             </div>
           )}
           {errorMessage && (

--- a/apps/client/src/styles/about-page.css
+++ b/apps/client/src/styles/about-page.css
@@ -33,7 +33,7 @@
 }
 
 .about-section h2 {
-  color: #10a37f;
+  color: #25596B;
   font-size: 24px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -75,15 +75,15 @@
 
 .about-section ul li::before {
   content: "•";
-  color: #10a37f;
+  color: #25596B;
   font-weight: bold;
   position: absolute;
   right: 0;
 }
 
 .about-cta {
-  background: linear-gradient(135deg, rgba(16, 163, 127, 0.08) 0%, rgba(13, 143, 111, 0.08) 100%);
-  border: 2px solid #10a37f;
+  background: linear-gradient(135deg, rgba(37, 89, 107, 0.08) 0%, rgba(28, 78, 94, 0.08) 100%);
+  border: 2px solid #25596B;
   border-radius: 12px;
   padding: 32px;
   text-align: center;
@@ -91,7 +91,7 @@
 }
 
 .about-cta h2 {
-  color: #10a37f;
+  color: #25596B;
   font-size: 28px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -126,27 +126,27 @@
 }
 
 .about-cta .btn-primary {
-  background: #10a37f;
+  background: #25596B;
   color: white;
   border: none;
 }
 
 .about-cta .btn-primary:hover {
-  background: #0d8c6c;
+  background: #2E6E7E;
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(16, 163, 127, 0.3);
+  box-shadow: 0 4px 12px rgba(37, 89, 107, 0.3);
 }
 
 .about-cta .btn-secondary {
   background: white;
-  color: #10a37f;
-  border: 2px solid #10a37f;
+  color: #25596B;
+  border: 2px solid #25596B;
 }
 
 .about-cta .btn-secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(16, 163, 127, 0.2);
+  box-shadow: 0 4px 8px rgba(37, 89, 107, 0.2);
 }
 
 .cta-buttons {

--- a/apps/client/src/styles/about-page.css
+++ b/apps/client/src/styles/about-page.css
@@ -33,7 +33,7 @@
 }
 
 .about-section h2 {
-  color: #0C6250;
+  color: #2E6E7E;
   font-size: 24px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -75,15 +75,15 @@
 
 .about-section ul li::before {
   content: "•";
-  color: #0C6250;
+  color: #2E6E7E;
   font-weight: bold;
   position: absolute;
   right: 0;
 }
 
 .about-cta {
-  background: linear-gradient(135deg, rgba(12, 98, 80, 0.08) 0%, rgba(8, 64, 52, 0.08) 100%);
-  border: 2px solid #0C6250;
+  background: linear-gradient(135deg, rgba(46, 110, 126, 0.08) 0%, rgba(30, 72, 82, 0.08) 100%);
+  border: 2px solid #2E6E7E;
   border-radius: 12px;
   padding: 32px;
   text-align: center;
@@ -91,7 +91,7 @@
 }
 
 .about-cta h2 {
-  color: #0C6250;
+  color: #2E6E7E;
   font-size: 28px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -126,27 +126,27 @@
 }
 
 .about-cta .btn-primary {
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
   border: none;
 }
 
 .about-cta .btn-primary:hover {
-  background: #129176;
+  background: #3C90A4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(12, 98, 80, 0.3);
+  box-shadow: 0 4px 12px rgba(46, 110, 126, 0.3);
 }
 
 .about-cta .btn-secondary {
   background: white;
-  color: #0C6250;
-  border: 2px solid #0C6250;
+  color: #2E6E7E;
+  border: 2px solid #2E6E7E;
 }
 
 .about-cta .btn-secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(12, 98, 80, 0.2);
+  box-shadow: 0 4px 8px rgba(46, 110, 126, 0.2);
 }
 
 .cta-buttons {

--- a/apps/client/src/styles/about-page.css
+++ b/apps/client/src/styles/about-page.css
@@ -144,7 +144,7 @@
 }
 
 .about-cta .btn-secondary:hover {
-  background: #f0fdf4;
+  background: #DEEFF7;
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(28, 122, 166, 0.2);
 }

--- a/apps/client/src/styles/about-page.css
+++ b/apps/client/src/styles/about-page.css
@@ -33,7 +33,7 @@
 }
 
 .about-section h2 {
-  color: #25596B;
+  color: #0C6250;
   font-size: 24px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -75,15 +75,15 @@
 
 .about-section ul li::before {
   content: "•";
-  color: #25596B;
+  color: #0C6250;
   font-weight: bold;
   position: absolute;
   right: 0;
 }
 
 .about-cta {
-  background: linear-gradient(135deg, rgba(37, 89, 107, 0.08) 0%, rgba(28, 78, 94, 0.08) 100%);
-  border: 2px solid #25596B;
+  background: linear-gradient(135deg, rgba(12, 98, 80, 0.08) 0%, rgba(8, 64, 52, 0.08) 100%);
+  border: 2px solid #0C6250;
   border-radius: 12px;
   padding: 32px;
   text-align: center;
@@ -91,7 +91,7 @@
 }
 
 .about-cta h2 {
-  color: #25596B;
+  color: #0C6250;
   font-size: 28px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -126,27 +126,27 @@
 }
 
 .about-cta .btn-primary {
-  background: #25596B;
+  background: #0C6250;
   color: white;
   border: none;
 }
 
 .about-cta .btn-primary:hover {
-  background: #2E6E7E;
+  background: #129176;
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(37, 89, 107, 0.3);
+  box-shadow: 0 4px 12px rgba(12, 98, 80, 0.3);
 }
 
 .about-cta .btn-secondary {
   background: white;
-  color: #25596B;
-  border: 2px solid #25596B;
+  color: #0C6250;
+  border: 2px solid #0C6250;
 }
 
 .about-cta .btn-secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(37, 89, 107, 0.2);
+  box-shadow: 0 4px 8px rgba(12, 98, 80, 0.2);
 }
 
 .cta-buttons {

--- a/apps/client/src/styles/about-page.css
+++ b/apps/client/src/styles/about-page.css
@@ -33,7 +33,7 @@
 }
 
 .about-section h2 {
-  color: #48B4D6;
+  color: #1C7AA6;
   font-size: 24px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -75,15 +75,15 @@
 
 .about-section ul li::before {
   content: "•";
-  color: #48B4D6;
+  color: #1C7AA6;
   font-weight: bold;
   position: absolute;
   right: 0;
 }
 
 .about-cta {
-  background: linear-gradient(135deg, rgba(72, 180, 214, 0.08) 0%, rgba(41, 150, 183, 0.08) 100%);
-  border: 2px solid #48B4D6;
+  background: linear-gradient(135deg, rgba(28, 122, 166, 0.08) 0%, rgba(19, 84, 113, 0.08) 100%);
+  border: 2px solid #1C7AA6;
   border-radius: 12px;
   padding: 32px;
   text-align: center;
@@ -91,7 +91,7 @@
 }
 
 .about-cta h2 {
-  color: #48B4D6;
+  color: #1C7AA6;
   font-size: 28px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -126,27 +126,27 @@
 }
 
 .about-cta .btn-primary {
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
   border: none;
 }
 
 .about-cta .btn-primary:hover {
-  background: #71C6DF;
+  background: #239AD1;
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(72, 180, 214, 0.3);
+  box-shadow: 0 4px 12px rgba(28, 122, 166, 0.3);
 }
 
 .about-cta .btn-secondary {
   background: white;
-  color: #48B4D6;
-  border: 2px solid #48B4D6;
+  color: #1C7AA6;
+  border: 2px solid #1C7AA6;
 }
 
 .about-cta .btn-secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(72, 180, 214, 0.2);
+  box-shadow: 0 4px 8px rgba(28, 122, 166, 0.2);
 }
 
 .cta-buttons {

--- a/apps/client/src/styles/about-page.css
+++ b/apps/client/src/styles/about-page.css
@@ -33,7 +33,7 @@
 }
 
 .about-section h2 {
-  color: #2E6E7E;
+  color: #48B4D6;
   font-size: 24px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -75,15 +75,15 @@
 
 .about-section ul li::before {
   content: "•";
-  color: #2E6E7E;
+  color: #48B4D6;
   font-weight: bold;
   position: absolute;
   right: 0;
 }
 
 .about-cta {
-  background: linear-gradient(135deg, rgba(46, 110, 126, 0.08) 0%, rgba(30, 72, 82, 0.08) 100%);
-  border: 2px solid #2E6E7E;
+  background: linear-gradient(135deg, rgba(72, 180, 214, 0.08) 0%, rgba(41, 150, 183, 0.08) 100%);
+  border: 2px solid #48B4D6;
   border-radius: 12px;
   padding: 32px;
   text-align: center;
@@ -91,7 +91,7 @@
 }
 
 .about-cta h2 {
-  color: #2E6E7E;
+  color: #48B4D6;
   font-size: 28px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -126,27 +126,27 @@
 }
 
 .about-cta .btn-primary {
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
   border: none;
 }
 
 .about-cta .btn-primary:hover {
-  background: #3C90A4;
+  background: #71C6DF;
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(46, 110, 126, 0.3);
+  box-shadow: 0 4px 12px rgba(72, 180, 214, 0.3);
 }
 
 .about-cta .btn-secondary {
   background: white;
-  color: #2E6E7E;
-  border: 2px solid #2E6E7E;
+  color: #48B4D6;
+  border: 2px solid #48B4D6;
 }
 
 .about-cta .btn-secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(46, 110, 126, 0.2);
+  box-shadow: 0 4px 8px rgba(72, 180, 214, 0.2);
 }
 
 .cta-buttons {

--- a/apps/client/src/styles/agent-downloads-page.css
+++ b/apps/client/src/styles/agent-downloads-page.css
@@ -58,7 +58,7 @@
 }
 
 .primary-btn {
-  background: #2E6E7E;
+  background: #48B4D6;
   color: #ffffff;
 }
 
@@ -66,7 +66,7 @@
 .card-btn:hover,
 .secondary-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 40px rgba(46, 110, 126, 0.18);
+  box-shadow: 0 18px 40px rgba(72, 180, 214, 0.18);
 }
 
 .secondary-btn {
@@ -97,7 +97,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #2E6E7E;
+  color: #48B4D6;
 }
 
 .preview-list {
@@ -123,7 +123,7 @@
 .section-label {
   display: inline-block;
   margin-bottom: 14px;
-  color: #2E6E7E;
+  color: #48B4D6;
   font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -199,9 +199,9 @@
 }
 
 .featured-card {
-  background: #2E6E7E;
+  background: #48B4D6;
   color: #ffffff;
-  border-color: #2E6E7E;
+  border-color: #48B4D6;
 }
 
 .featured-card h3,
@@ -218,11 +218,11 @@
 .card-btn {
   width: fit-content;
   color: #ffffff;
-  background: #2E6E7E;
+  background: #48B4D6;
 }
 
 .card-btn:hover {
-  background: #3C90A4;
+  background: #71C6DF;
 }
 
 @media (max-width: 900px) {

--- a/apps/client/src/styles/agent-downloads-page.css
+++ b/apps/client/src/styles/agent-downloads-page.css
@@ -58,7 +58,7 @@
 }
 
 .primary-btn {
-  background: #0C6250;
+  background: #2E6E7E;
   color: #ffffff;
 }
 
@@ -66,7 +66,7 @@
 .card-btn:hover,
 .secondary-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 40px rgba(12, 98, 80, 0.18);
+  box-shadow: 0 18px 40px rgba(46, 110, 126, 0.18);
 }
 
 .secondary-btn {
@@ -97,7 +97,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #0C6250;
+  color: #2E6E7E;
 }
 
 .preview-list {
@@ -123,7 +123,7 @@
 .section-label {
   display: inline-block;
   margin-bottom: 14px;
-  color: #0C6250;
+  color: #2E6E7E;
   font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -199,9 +199,9 @@
 }
 
 .featured-card {
-  background: #0C6250;
+  background: #2E6E7E;
   color: #ffffff;
-  border-color: #0C6250;
+  border-color: #2E6E7E;
 }
 
 .featured-card h3,
@@ -218,11 +218,11 @@
 .card-btn {
   width: fit-content;
   color: #ffffff;
-  background: #0C6250;
+  background: #2E6E7E;
 }
 
 .card-btn:hover {
-  background: #129176;
+  background: #3C90A4;
 }
 
 @media (max-width: 900px) {

--- a/apps/client/src/styles/agent-downloads-page.css
+++ b/apps/client/src/styles/agent-downloads-page.css
@@ -58,7 +58,7 @@
 }
 
 .primary-btn {
-  background: #10a37f;
+  background: #25596B;
   color: #ffffff;
 }
 
@@ -66,7 +66,7 @@
 .card-btn:hover,
 .secondary-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 40px rgba(16, 163, 127, 0.18);
+  box-shadow: 0 18px 40px rgba(37, 89, 107, 0.18);
 }
 
 .secondary-btn {
@@ -97,7 +97,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #10a37f;
+  color: #25596B;
 }
 
 .preview-list {
@@ -123,7 +123,7 @@
 .section-label {
   display: inline-block;
   margin-bottom: 14px;
-  color: #10a37f;
+  color: #25596B;
   font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -199,9 +199,9 @@
 }
 
 .featured-card {
-  background: #10a37f;
+  background: #25596B;
   color: #ffffff;
-  border-color: #10a37f;
+  border-color: #25596B;
 }
 
 .featured-card h3,
@@ -218,11 +218,11 @@
 .card-btn {
   width: fit-content;
   color: #ffffff;
-  background: #10a37f;
+  background: #25596B;
 }
 
 .card-btn:hover {
-  background: #0d8f6f;
+  background: #2E6E7E;
 }
 
 @media (max-width: 900px) {

--- a/apps/client/src/styles/agent-downloads-page.css
+++ b/apps/client/src/styles/agent-downloads-page.css
@@ -58,7 +58,7 @@
 }
 
 .primary-btn {
-  background: #48B4D6;
+  background: #1C7AA6;
   color: #ffffff;
 }
 
@@ -66,7 +66,7 @@
 .card-btn:hover,
 .secondary-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 40px rgba(72, 180, 214, 0.18);
+  box-shadow: 0 18px 40px rgba(28, 122, 166, 0.18);
 }
 
 .secondary-btn {
@@ -97,7 +97,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #48B4D6;
+  color: #1C7AA6;
 }
 
 .preview-list {
@@ -123,7 +123,7 @@
 .section-label {
   display: inline-block;
   margin-bottom: 14px;
-  color: #48B4D6;
+  color: #1C7AA6;
   font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -199,9 +199,9 @@
 }
 
 .featured-card {
-  background: #48B4D6;
+  background: #1C7AA6;
   color: #ffffff;
-  border-color: #48B4D6;
+  border-color: #1C7AA6;
 }
 
 .featured-card h3,
@@ -218,11 +218,11 @@
 .card-btn {
   width: fit-content;
   color: #ffffff;
-  background: #48B4D6;
+  background: #1C7AA6;
 }
 
 .card-btn:hover {
-  background: #71C6DF;
+  background: #239AD1;
 }
 
 @media (max-width: 900px) {

--- a/apps/client/src/styles/agent-downloads-page.css
+++ b/apps/client/src/styles/agent-downloads-page.css
@@ -58,7 +58,7 @@
 }
 
 .primary-btn {
-  background: #25596B;
+  background: #0C6250;
   color: #ffffff;
 }
 
@@ -66,7 +66,7 @@
 .card-btn:hover,
 .secondary-btn:hover {
   transform: translateY(-1px);
-  box-shadow: 0 18px 40px rgba(37, 89, 107, 0.18);
+  box-shadow: 0 18px 40px rgba(12, 98, 80, 0.18);
 }
 
 .secondary-btn {
@@ -97,7 +97,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #25596B;
+  color: #0C6250;
 }
 
 .preview-list {
@@ -123,7 +123,7 @@
 .section-label {
   display: inline-block;
   margin-bottom: 14px;
-  color: #25596B;
+  color: #0C6250;
   font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -199,9 +199,9 @@
 }
 
 .featured-card {
-  background: #25596B;
+  background: #0C6250;
   color: #ffffff;
-  border-color: #25596B;
+  border-color: #0C6250;
 }
 
 .featured-card h3,
@@ -218,11 +218,11 @@
 .card-btn {
   width: fit-content;
   color: #ffffff;
-  background: #25596B;
+  background: #0C6250;
 }
 
 .card-btn:hover {
-  background: #2E6E7E;
+  background: #129176;
 }
 
 @media (max-width: 900px) {

--- a/apps/client/src/styles/beta-banner.css
+++ b/apps/client/src/styles/beta-banner.css
@@ -1,7 +1,7 @@
 /* Beta Banner Styles */
 
 .beta-banner {
-  background: linear-gradient(135deg, #48B4D6 0%, #2996B7 100%);
+  background: linear-gradient(135deg, #1C7AA6 0%, #135471 100%);
   color: white;
   padding: 10px 0;
   text-align: center;

--- a/apps/client/src/styles/beta-banner.css
+++ b/apps/client/src/styles/beta-banner.css
@@ -1,7 +1,7 @@
 /* Beta Banner Styles */
 
 .beta-banner {
-  background: linear-gradient(135deg, #10a37f 0%, #0d8f6f 100%);
+  background: linear-gradient(135deg, #25596B 0%, #1C4E5E 100%);
   color: white;
   padding: 10px 0;
   text-align: center;

--- a/apps/client/src/styles/beta-banner.css
+++ b/apps/client/src/styles/beta-banner.css
@@ -1,7 +1,7 @@
 /* Beta Banner Styles */
 
 .beta-banner {
-  background: linear-gradient(135deg, #2E6E7E 0%, #1E4852 100%);
+  background: linear-gradient(135deg, #48B4D6 0%, #2996B7 100%);
   color: white;
   padding: 10px 0;
   text-align: center;

--- a/apps/client/src/styles/beta-banner.css
+++ b/apps/client/src/styles/beta-banner.css
@@ -1,7 +1,7 @@
 /* Beta Banner Styles */
 
 .beta-banner {
-  background: linear-gradient(135deg, #0C6250 0%, #084034 100%);
+  background: linear-gradient(135deg, #2E6E7E 0%, #1E4852 100%);
   color: white;
   padding: 10px 0;
   text-align: center;

--- a/apps/client/src/styles/beta-banner.css
+++ b/apps/client/src/styles/beta-banner.css
@@ -1,7 +1,7 @@
 /* Beta Banner Styles */
 
 .beta-banner {
-  background: linear-gradient(135deg, #25596B 0%, #1C4E5E 100%);
+  background: linear-gradient(135deg, #0C6250 0%, #084034 100%);
   color: white;
   padding: 10px 0;
   text-align: center;

--- a/apps/client/src/styles/contact-page.css
+++ b/apps/client/src/styles/contact-page.css
@@ -29,8 +29,8 @@
 
 /* Design Partner Banner */
 .design-partner-banner {
-  background: linear-gradient(135deg, rgba(16, 163, 127, 0.08) 0%, rgba(13, 143, 111, 0.08) 100%);
-  border: 2px solid #10a37f;
+  background: linear-gradient(135deg, rgba(37, 89, 107, 0.08) 0%, rgba(28, 78, 94, 0.08) 100%);
+  border: 2px solid #25596B;
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 32px;
@@ -47,7 +47,7 @@
 
 .design-partner-content h3 {
   font-size: 20px;
-  color: #10a37f;
+  color: #25596B;
   margin: 0 0 12px 0;
   font-weight: 700;
 }
@@ -67,16 +67,16 @@
   background: white;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid #10a37f;
+  border: 1px solid #25596B;
   font-weight: 600;
-  color: #10a37f !important;
+  color: #25596B !important;
 }
 
 /* Guides Link Section */
 .guides-link-section {
   margin-top: 20px;
   padding-top: 20px;
-  border-top: 1px solid rgba(16, 163, 127, 0.2);
+  border-top: 1px solid rgba(37, 89, 107, 0.2);
 }
 
 .guides-link-section p {
@@ -88,7 +88,7 @@
 
 .guides-link-button {
   display: inline-block;
-  background: #10a37f;
+  background: #25596B;
   color: white;
   padding: 10px 20px;
   border-radius: 8px;
@@ -101,21 +101,21 @@
 }
 
 .guides-link-button:hover {
-  background: #0d8c6c;
+  background: #2E6E7E;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(16, 163, 127, 0.3);
+  box-shadow: 0 4px 8px rgba(37, 89, 107, 0.3);
 }
 
 .guides-link-button.secondary {
   background: white;
-  color: #10a37f;
-  border: 2px solid #10a37f;
+  color: #25596B;
+  border: 2px solid #25596B;
 }
 
 .guides-link-button.secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(16, 163, 127, 0.2);
+  box-shadow: 0 4px 8px rgba(37, 89, 107, 0.2);
 }
 
 .contact-form {
@@ -151,8 +151,8 @@
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #10a37f;
-  box-shadow: 0 0 0 3px rgba(16, 163, 127, 0.1);
+  border-color: #25596B;
+  box-shadow: 0 0 0 3px rgba(37, 89, 107, 0.1);
 }
 
 .form-group textarea {
@@ -170,7 +170,7 @@
 .message.success {
   background-color: #d1fae5;
   color: #065f46;
-  border: 1px solid #10a37f;
+  border: 1px solid #25596B;
 }
 
 .message.error {
@@ -190,14 +190,14 @@
 }
 
 .btn-primary {
-  background: #10a37f;
+  background: #25596B;
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: #0d8f6f;
+  background: #2E6E7E;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(16, 163, 127, 0.3);
+  box-shadow: 0 4px 12px rgba(37, 89, 107, 0.3);
 }
 
 .btn-primary:disabled {

--- a/apps/client/src/styles/contact-page.css
+++ b/apps/client/src/styles/contact-page.css
@@ -113,7 +113,7 @@
 }
 
 .guides-link-button.secondary:hover {
-  background: #f0fdf4;
+  background: #DEEFF7;
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(28, 122, 166, 0.2);
 }

--- a/apps/client/src/styles/contact-page.css
+++ b/apps/client/src/styles/contact-page.css
@@ -29,8 +29,8 @@
 
 /* Design Partner Banner */
 .design-partner-banner {
-  background: linear-gradient(135deg, rgba(37, 89, 107, 0.08) 0%, rgba(28, 78, 94, 0.08) 100%);
-  border: 2px solid #25596B;
+  background: linear-gradient(135deg, rgba(12, 98, 80, 0.08) 0%, rgba(8, 64, 52, 0.08) 100%);
+  border: 2px solid #0C6250;
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 32px;
@@ -47,7 +47,7 @@
 
 .design-partner-content h3 {
   font-size: 20px;
-  color: #25596B;
+  color: #0C6250;
   margin: 0 0 12px 0;
   font-weight: 700;
 }
@@ -67,16 +67,16 @@
   background: white;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid #25596B;
+  border: 1px solid #0C6250;
   font-weight: 600;
-  color: #25596B !important;
+  color: #0C6250 !important;
 }
 
 /* Guides Link Section */
 .guides-link-section {
   margin-top: 20px;
   padding-top: 20px;
-  border-top: 1px solid rgba(37, 89, 107, 0.2);
+  border-top: 1px solid rgba(12, 98, 80, 0.2);
 }
 
 .guides-link-section p {
@@ -88,7 +88,7 @@
 
 .guides-link-button {
   display: inline-block;
-  background: #25596B;
+  background: #0C6250;
   color: white;
   padding: 10px 20px;
   border-radius: 8px;
@@ -101,21 +101,21 @@
 }
 
 .guides-link-button:hover {
-  background: #2E6E7E;
+  background: #129176;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(37, 89, 107, 0.3);
+  box-shadow: 0 4px 8px rgba(12, 98, 80, 0.3);
 }
 
 .guides-link-button.secondary {
   background: white;
-  color: #25596B;
-  border: 2px solid #25596B;
+  color: #0C6250;
+  border: 2px solid #0C6250;
 }
 
 .guides-link-button.secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(37, 89, 107, 0.2);
+  box-shadow: 0 4px 8px rgba(12, 98, 80, 0.2);
 }
 
 .contact-form {
@@ -151,8 +151,8 @@
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #25596B;
-  box-shadow: 0 0 0 3px rgba(37, 89, 107, 0.1);
+  border-color: #0C6250;
+  box-shadow: 0 0 0 3px rgba(12, 98, 80, 0.1);
 }
 
 .form-group textarea {
@@ -170,7 +170,7 @@
 .message.success {
   background-color: #d1fae5;
   color: #065f46;
-  border: 1px solid #25596B;
+  border: 1px solid #0C6250;
 }
 
 .message.error {
@@ -190,14 +190,14 @@
 }
 
 .btn-primary {
-  background: #25596B;
+  background: #0C6250;
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: #2E6E7E;
+  background: #129176;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(37, 89, 107, 0.3);
+  box-shadow: 0 4px 12px rgba(12, 98, 80, 0.3);
 }
 
 .btn-primary:disabled {

--- a/apps/client/src/styles/contact-page.css
+++ b/apps/client/src/styles/contact-page.css
@@ -29,8 +29,8 @@
 
 /* Design Partner Banner */
 .design-partner-banner {
-  background: linear-gradient(135deg, rgba(46, 110, 126, 0.08) 0%, rgba(30, 72, 82, 0.08) 100%);
-  border: 2px solid #2E6E7E;
+  background: linear-gradient(135deg, rgba(72, 180, 214, 0.08) 0%, rgba(41, 150, 183, 0.08) 100%);
+  border: 2px solid #48B4D6;
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 32px;
@@ -47,7 +47,7 @@
 
 .design-partner-content h3 {
   font-size: 20px;
-  color: #2E6E7E;
+  color: #48B4D6;
   margin: 0 0 12px 0;
   font-weight: 700;
 }
@@ -67,16 +67,16 @@
   background: white;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid #2E6E7E;
+  border: 1px solid #48B4D6;
   font-weight: 600;
-  color: #2E6E7E !important;
+  color: #48B4D6 !important;
 }
 
 /* Guides Link Section */
 .guides-link-section {
   margin-top: 20px;
   padding-top: 20px;
-  border-top: 1px solid rgba(46, 110, 126, 0.2);
+  border-top: 1px solid rgba(72, 180, 214, 0.2);
 }
 
 .guides-link-section p {
@@ -88,7 +88,7 @@
 
 .guides-link-button {
   display: inline-block;
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
   padding: 10px 20px;
   border-radius: 8px;
@@ -101,21 +101,21 @@
 }
 
 .guides-link-button:hover {
-  background: #3C90A4;
+  background: #71C6DF;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(46, 110, 126, 0.3);
+  box-shadow: 0 4px 8px rgba(72, 180, 214, 0.3);
 }
 
 .guides-link-button.secondary {
   background: white;
-  color: #2E6E7E;
-  border: 2px solid #2E6E7E;
+  color: #48B4D6;
+  border: 2px solid #48B4D6;
 }
 
 .guides-link-button.secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(46, 110, 126, 0.2);
+  box-shadow: 0 4px 8px rgba(72, 180, 214, 0.2);
 }
 
 .contact-form {
@@ -151,8 +151,8 @@
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #2E6E7E;
-  box-shadow: 0 0 0 3px rgba(46, 110, 126, 0.1);
+  border-color: #48B4D6;
+  box-shadow: 0 0 0 3px rgba(72, 180, 214, 0.1);
 }
 
 .form-group textarea {
@@ -170,7 +170,7 @@
 .message.success {
   background-color: #d1fae5;
   color: #065f46;
-  border: 1px solid #2E6E7E;
+  border: 1px solid #48B4D6;
 }
 
 .message.error {
@@ -190,14 +190,14 @@
 }
 
 .btn-primary {
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: #3C90A4;
+  background: #71C6DF;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(46, 110, 126, 0.3);
+  box-shadow: 0 4px 12px rgba(72, 180, 214, 0.3);
 }
 
 .btn-primary:disabled {

--- a/apps/client/src/styles/contact-page.css
+++ b/apps/client/src/styles/contact-page.css
@@ -29,8 +29,8 @@
 
 /* Design Partner Banner */
 .design-partner-banner {
-  background: linear-gradient(135deg, rgba(12, 98, 80, 0.08) 0%, rgba(8, 64, 52, 0.08) 100%);
-  border: 2px solid #0C6250;
+  background: linear-gradient(135deg, rgba(46, 110, 126, 0.08) 0%, rgba(30, 72, 82, 0.08) 100%);
+  border: 2px solid #2E6E7E;
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 32px;
@@ -47,7 +47,7 @@
 
 .design-partner-content h3 {
   font-size: 20px;
-  color: #0C6250;
+  color: #2E6E7E;
   margin: 0 0 12px 0;
   font-weight: 700;
 }
@@ -67,16 +67,16 @@
   background: white;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid #0C6250;
+  border: 1px solid #2E6E7E;
   font-weight: 600;
-  color: #0C6250 !important;
+  color: #2E6E7E !important;
 }
 
 /* Guides Link Section */
 .guides-link-section {
   margin-top: 20px;
   padding-top: 20px;
-  border-top: 1px solid rgba(12, 98, 80, 0.2);
+  border-top: 1px solid rgba(46, 110, 126, 0.2);
 }
 
 .guides-link-section p {
@@ -88,7 +88,7 @@
 
 .guides-link-button {
   display: inline-block;
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
   padding: 10px 20px;
   border-radius: 8px;
@@ -101,21 +101,21 @@
 }
 
 .guides-link-button:hover {
-  background: #129176;
+  background: #3C90A4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(12, 98, 80, 0.3);
+  box-shadow: 0 4px 8px rgba(46, 110, 126, 0.3);
 }
 
 .guides-link-button.secondary {
   background: white;
-  color: #0C6250;
-  border: 2px solid #0C6250;
+  color: #2E6E7E;
+  border: 2px solid #2E6E7E;
 }
 
 .guides-link-button.secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(12, 98, 80, 0.2);
+  box-shadow: 0 4px 8px rgba(46, 110, 126, 0.2);
 }
 
 .contact-form {
@@ -151,8 +151,8 @@
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #0C6250;
-  box-shadow: 0 0 0 3px rgba(12, 98, 80, 0.1);
+  border-color: #2E6E7E;
+  box-shadow: 0 0 0 3px rgba(46, 110, 126, 0.1);
 }
 
 .form-group textarea {
@@ -170,7 +170,7 @@
 .message.success {
   background-color: #d1fae5;
   color: #065f46;
-  border: 1px solid #0C6250;
+  border: 1px solid #2E6E7E;
 }
 
 .message.error {
@@ -190,14 +190,14 @@
 }
 
 .btn-primary {
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: #129176;
+  background: #3C90A4;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(12, 98, 80, 0.3);
+  box-shadow: 0 4px 12px rgba(46, 110, 126, 0.3);
 }
 
 .btn-primary:disabled {

--- a/apps/client/src/styles/contact-page.css
+++ b/apps/client/src/styles/contact-page.css
@@ -29,8 +29,8 @@
 
 /* Design Partner Banner */
 .design-partner-banner {
-  background: linear-gradient(135deg, rgba(72, 180, 214, 0.08) 0%, rgba(41, 150, 183, 0.08) 100%);
-  border: 2px solid #48B4D6;
+  background: linear-gradient(135deg, rgba(28, 122, 166, 0.08) 0%, rgba(19, 84, 113, 0.08) 100%);
+  border: 2px solid #1C7AA6;
   border-radius: 12px;
   padding: 24px;
   margin-bottom: 32px;
@@ -47,7 +47,7 @@
 
 .design-partner-content h3 {
   font-size: 20px;
-  color: #48B4D6;
+  color: #1C7AA6;
   margin: 0 0 12px 0;
   font-weight: 700;
 }
@@ -67,16 +67,16 @@
   background: white;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid #48B4D6;
+  border: 1px solid #1C7AA6;
   font-weight: 600;
-  color: #48B4D6 !important;
+  color: #1C7AA6 !important;
 }
 
 /* Guides Link Section */
 .guides-link-section {
   margin-top: 20px;
   padding-top: 20px;
-  border-top: 1px solid rgba(72, 180, 214, 0.2);
+  border-top: 1px solid rgba(28, 122, 166, 0.2);
 }
 
 .guides-link-section p {
@@ -88,7 +88,7 @@
 
 .guides-link-button {
   display: inline-block;
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
   padding: 10px 20px;
   border-radius: 8px;
@@ -101,21 +101,21 @@
 }
 
 .guides-link-button:hover {
-  background: #71C6DF;
+  background: #239AD1;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(72, 180, 214, 0.3);
+  box-shadow: 0 4px 8px rgba(28, 122, 166, 0.3);
 }
 
 .guides-link-button.secondary {
   background: white;
-  color: #48B4D6;
-  border: 2px solid #48B4D6;
+  color: #1C7AA6;
+  border: 2px solid #1C7AA6;
 }
 
 .guides-link-button.secondary:hover {
   background: #f0fdf4;
   transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(72, 180, 214, 0.2);
+  box-shadow: 0 4px 8px rgba(28, 122, 166, 0.2);
 }
 
 .contact-form {
@@ -151,8 +151,8 @@
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #48B4D6;
-  box-shadow: 0 0 0 3px rgba(72, 180, 214, 0.1);
+  border-color: #1C7AA6;
+  box-shadow: 0 0 0 3px rgba(28, 122, 166, 0.1);
 }
 
 .form-group textarea {
@@ -170,7 +170,7 @@
 .message.success {
   background-color: #d1fae5;
   color: #065f46;
-  border: 1px solid #48B4D6;
+  border: 1px solid #1C7AA6;
 }
 
 .message.error {
@@ -190,14 +190,14 @@
 }
 
 .btn-primary {
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: #71C6DF;
+  background: #239AD1;
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(72, 180, 214, 0.3);
+  box-shadow: 0 4px 12px rgba(28, 122, 166, 0.3);
 }
 
 .btn-primary:disabled {

--- a/apps/client/src/styles/docs-page.css
+++ b/apps/client/src/styles/docs-page.css
@@ -154,8 +154,8 @@
 
 .guide-category {
   display: inline-block;
-  background: #f0fdf4;
-  color: #15803d;
+  background: #DEEFF7;
+  color: #135471;
   padding: 6px 12px;
   border-radius: 6px;
   font-size: 12px;
@@ -442,7 +442,7 @@
 
 .resource-link:hover {
   border-color: #1C7AA6;
-  background: #f0fdf4;
+  background: #DEEFF7;
   transform: translateX(-4px);
 }
 

--- a/apps/client/src/styles/docs-page.css
+++ b/apps/client/src/styles/docs-page.css
@@ -101,15 +101,15 @@
 
 .search-input:focus {
   outline: none;
-  border-color: #48B4D6;
-  box-shadow: 0 0 0 3px rgba(72, 180, 214, 0.1);
+  border-color: #1C7AA6;
+  box-shadow: 0 0 0 3px rgba(28, 122, 166, 0.1);
 }
 
 .search-button {
   padding: 14px 24px;
   border: none;
   border-radius: 8px;
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
   font-size: 20px;
   cursor: pointer;
@@ -117,7 +117,7 @@
 }
 
 .search-button:hover {
-  background: #71C6DF;
+  background: #239AD1;
   transform: scale(1.05);
 }
 
@@ -143,9 +143,9 @@
 }
 
 .guide-card:hover {
-  border-color: #48B4D6;
+  border-color: #1C7AA6;
   transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(72, 180, 214, 0.15);
+  box-shadow: 0 8px 16px rgba(28, 122, 166, 0.15);
 }
 
 .guide-card-header {
@@ -186,7 +186,7 @@
 }
 
 .guide-link-text {
-  color: #48B4D6;
+  color: #1C7AA6;
   font-weight: 600;
   font-size: 14px;
 }
@@ -212,7 +212,7 @@
 }
 
 .clear-search-button {
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
   border: none;
   padding: 12px 24px;
@@ -224,7 +224,7 @@
 }
 
 .clear-search-button:hover {
-  background: #71C6DF;
+  background: #239AD1;
   transform: scale(1.05);
 }
 
@@ -441,7 +441,7 @@
 }
 
 .resource-link:hover {
-  border-color: #48B4D6;
+  border-color: #1C7AA6;
   background: #f0fdf4;
   transform: translateX(-4px);
 }

--- a/apps/client/src/styles/docs-page.css
+++ b/apps/client/src/styles/docs-page.css
@@ -101,15 +101,15 @@
 
 .search-input:focus {
   outline: none;
-  border-color: #10a37f;
-  box-shadow: 0 0 0 3px rgba(16, 163, 127, 0.1);
+  border-color: #25596B;
+  box-shadow: 0 0 0 3px rgba(37, 89, 107, 0.1);
 }
 
 .search-button {
   padding: 14px 24px;
   border: none;
   border-radius: 8px;
-  background: #10a37f;
+  background: #25596B;
   color: white;
   font-size: 20px;
   cursor: pointer;
@@ -117,7 +117,7 @@
 }
 
 .search-button:hover {
-  background: #0d8c6c;
+  background: #2E6E7E;
   transform: scale(1.05);
 }
 
@@ -143,9 +143,9 @@
 }
 
 .guide-card:hover {
-  border-color: #10a37f;
+  border-color: #25596B;
   transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(16, 163, 127, 0.15);
+  box-shadow: 0 8px 16px rgba(37, 89, 107, 0.15);
 }
 
 .guide-card-header {
@@ -186,7 +186,7 @@
 }
 
 .guide-link-text {
-  color: #10a37f;
+  color: #25596B;
   font-weight: 600;
   font-size: 14px;
 }
@@ -212,7 +212,7 @@
 }
 
 .clear-search-button {
-  background: #10a37f;
+  background: #25596B;
   color: white;
   border: none;
   padding: 12px 24px;
@@ -224,7 +224,7 @@
 }
 
 .clear-search-button:hover {
-  background: #0d8c6c;
+  background: #2E6E7E;
   transform: scale(1.05);
 }
 
@@ -441,7 +441,7 @@
 }
 
 .resource-link:hover {
-  border-color: #10a37f;
+  border-color: #25596B;
   background: #f0fdf4;
   transform: translateX(-4px);
 }

--- a/apps/client/src/styles/docs-page.css
+++ b/apps/client/src/styles/docs-page.css
@@ -101,15 +101,15 @@
 
 .search-input:focus {
   outline: none;
-  border-color: #2E6E7E;
-  box-shadow: 0 0 0 3px rgba(46, 110, 126, 0.1);
+  border-color: #48B4D6;
+  box-shadow: 0 0 0 3px rgba(72, 180, 214, 0.1);
 }
 
 .search-button {
   padding: 14px 24px;
   border: none;
   border-radius: 8px;
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
   font-size: 20px;
   cursor: pointer;
@@ -117,7 +117,7 @@
 }
 
 .search-button:hover {
-  background: #3C90A4;
+  background: #71C6DF;
   transform: scale(1.05);
 }
 
@@ -143,9 +143,9 @@
 }
 
 .guide-card:hover {
-  border-color: #2E6E7E;
+  border-color: #48B4D6;
   transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(46, 110, 126, 0.15);
+  box-shadow: 0 8px 16px rgba(72, 180, 214, 0.15);
 }
 
 .guide-card-header {
@@ -186,7 +186,7 @@
 }
 
 .guide-link-text {
-  color: #2E6E7E;
+  color: #48B4D6;
   font-weight: 600;
   font-size: 14px;
 }
@@ -212,7 +212,7 @@
 }
 
 .clear-search-button {
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
   border: none;
   padding: 12px 24px;
@@ -224,7 +224,7 @@
 }
 
 .clear-search-button:hover {
-  background: #3C90A4;
+  background: #71C6DF;
   transform: scale(1.05);
 }
 
@@ -441,7 +441,7 @@
 }
 
 .resource-link:hover {
-  border-color: #2E6E7E;
+  border-color: #48B4D6;
   background: #f0fdf4;
   transform: translateX(-4px);
 }

--- a/apps/client/src/styles/docs-page.css
+++ b/apps/client/src/styles/docs-page.css
@@ -101,15 +101,15 @@
 
 .search-input:focus {
   outline: none;
-  border-color: #25596B;
-  box-shadow: 0 0 0 3px rgba(37, 89, 107, 0.1);
+  border-color: #0C6250;
+  box-shadow: 0 0 0 3px rgba(12, 98, 80, 0.1);
 }
 
 .search-button {
   padding: 14px 24px;
   border: none;
   border-radius: 8px;
-  background: #25596B;
+  background: #0C6250;
   color: white;
   font-size: 20px;
   cursor: pointer;
@@ -117,7 +117,7 @@
 }
 
 .search-button:hover {
-  background: #2E6E7E;
+  background: #129176;
   transform: scale(1.05);
 }
 
@@ -143,9 +143,9 @@
 }
 
 .guide-card:hover {
-  border-color: #25596B;
+  border-color: #0C6250;
   transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(37, 89, 107, 0.15);
+  box-shadow: 0 8px 16px rgba(12, 98, 80, 0.15);
 }
 
 .guide-card-header {
@@ -186,7 +186,7 @@
 }
 
 .guide-link-text {
-  color: #25596B;
+  color: #0C6250;
   font-weight: 600;
   font-size: 14px;
 }
@@ -212,7 +212,7 @@
 }
 
 .clear-search-button {
-  background: #25596B;
+  background: #0C6250;
   color: white;
   border: none;
   padding: 12px 24px;
@@ -224,7 +224,7 @@
 }
 
 .clear-search-button:hover {
-  background: #2E6E7E;
+  background: #129176;
   transform: scale(1.05);
 }
 
@@ -441,7 +441,7 @@
 }
 
 .resource-link:hover {
-  border-color: #25596B;
+  border-color: #0C6250;
   background: #f0fdf4;
   transform: translateX(-4px);
 }

--- a/apps/client/src/styles/docs-page.css
+++ b/apps/client/src/styles/docs-page.css
@@ -101,15 +101,15 @@
 
 .search-input:focus {
   outline: none;
-  border-color: #0C6250;
-  box-shadow: 0 0 0 3px rgba(12, 98, 80, 0.1);
+  border-color: #2E6E7E;
+  box-shadow: 0 0 0 3px rgba(46, 110, 126, 0.1);
 }
 
 .search-button {
   padding: 14px 24px;
   border: none;
   border-radius: 8px;
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
   font-size: 20px;
   cursor: pointer;
@@ -117,7 +117,7 @@
 }
 
 .search-button:hover {
-  background: #129176;
+  background: #3C90A4;
   transform: scale(1.05);
 }
 
@@ -143,9 +143,9 @@
 }
 
 .guide-card:hover {
-  border-color: #0C6250;
+  border-color: #2E6E7E;
   transform: translateY(-4px);
-  box-shadow: 0 8px 16px rgba(12, 98, 80, 0.15);
+  box-shadow: 0 8px 16px rgba(46, 110, 126, 0.15);
 }
 
 .guide-card-header {
@@ -186,7 +186,7 @@
 }
 
 .guide-link-text {
-  color: #0C6250;
+  color: #2E6E7E;
   font-weight: 600;
   font-size: 14px;
 }
@@ -212,7 +212,7 @@
 }
 
 .clear-search-button {
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
   border: none;
   padding: 12px 24px;
@@ -224,7 +224,7 @@
 }
 
 .clear-search-button:hover {
-  background: #129176;
+  background: #3C90A4;
   transform: scale(1.05);
 }
 
@@ -441,7 +441,7 @@
 }
 
 .resource-link:hover {
-  border-color: #0C6250;
+  border-color: #2E6E7E;
   background: #f0fdf4;
   transform: translateX(-4px);
 }

--- a/apps/client/src/styles/footer.css
+++ b/apps/client/src/styles/footer.css
@@ -26,13 +26,13 @@
 }
 
 .site-footer-link {
-  color: #0C6250;
+  color: #2E6E7E;
   text-decoration: underline;
   transition: color 0.2s;
 }
 
 .site-footer-link:hover {
-  color: #129176;
+  color: #3C90A4;
 }
 
 @media (max-width: 480px) {

--- a/apps/client/src/styles/footer.css
+++ b/apps/client/src/styles/footer.css
@@ -26,13 +26,13 @@
 }
 
 .site-footer-link {
-  color: #10a37f;
+  color: #25596B;
   text-decoration: underline;
   transition: color 0.2s;
 }
 
 .site-footer-link:hover {
-  color: #0d8f6f;
+  color: #2E6E7E;
 }
 
 @media (max-width: 480px) {

--- a/apps/client/src/styles/footer.css
+++ b/apps/client/src/styles/footer.css
@@ -26,13 +26,13 @@
 }
 
 .site-footer-link {
-  color: #2E6E7E;
+  color: #48B4D6;
   text-decoration: underline;
   transition: color 0.2s;
 }
 
 .site-footer-link:hover {
-  color: #3C90A4;
+  color: #71C6DF;
 }
 
 @media (max-width: 480px) {

--- a/apps/client/src/styles/footer.css
+++ b/apps/client/src/styles/footer.css
@@ -26,13 +26,13 @@
 }
 
 .site-footer-link {
-  color: #25596B;
+  color: #0C6250;
   text-decoration: underline;
   transition: color 0.2s;
 }
 
 .site-footer-link:hover {
-  color: #2E6E7E;
+  color: #129176;
 }
 
 @media (max-width: 480px) {

--- a/apps/client/src/styles/footer.css
+++ b/apps/client/src/styles/footer.css
@@ -26,13 +26,13 @@
 }
 
 .site-footer-link {
-  color: #48B4D6;
+  color: #1C7AA6;
   text-decoration: underline;
   transition: color 0.2s;
 }
 
 .site-footer-link:hover {
-  color: #71C6DF;
+  color: #239AD1;
 }
 
 @media (max-width: 480px) {

--- a/apps/client/src/styles/forum.css
+++ b/apps/client/src/styles/forum.css
@@ -19,7 +19,7 @@
 }
 
 .forum-add-btn {
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   padding: 10px 25px;
   border: none;
@@ -40,7 +40,7 @@
   width: 100%;
   padding: 10px 35px 10px 15px;
   border-radius: 6px;
-  border: 2px solid #d1fae5;
+  border: 2px solid #DEEFF7;
   font-size: 15px;
   outline: none;
 }
@@ -50,7 +50,7 @@
   top: 50%;
   right: 12px;
   transform: translateY(-50%);
-  color: #10b981;
+  color: #1C7AA6;
   font-size: 16px;
 }
 
@@ -58,13 +58,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 3px solid #10b981;
+  border-bottom: 3px solid #1C7AA6;
   padding-bottom: 10px;
   margin-bottom: 25px;
 }
 
 .forum-header-title {
-  color: #064e3b;
+  color: #135471;
   margin: 0;
   font-weight: bold;
   font-size: 20px;
@@ -86,7 +86,7 @@
 
 .forum-loading {
   padding: 50px;
-  color: #10b981;
+  color: #1C7AA6;
   font-weight: bold;
   text-align: center;
 }
@@ -112,7 +112,7 @@
 }
 
 .forum-show-all-btn {
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   border: none;
   padding: 8px 20px;
@@ -160,7 +160,7 @@
 }
 
 .forum-card-rating-badge {
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   padding: 3px 8px;
   border-radius: 20px;
@@ -173,7 +173,7 @@
   width: 45px;
   height: 45px;
   border-radius: 50%;
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   display: flex;
   align-items: center;
@@ -185,7 +185,7 @@
 
 .forum-author-name {
   font-weight: bold;
-  color: #064e3b;
+  color: #135471;
   font-size: 13px;
   text-align: center;
   overflow: hidden;
@@ -233,8 +233,8 @@
 }
 
 .forum-category-badge {
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: #DEEFF7;
+  color: #135471;
   padding: 1px 6px;
   border-radius: 3px;
   font-size: 11px;
@@ -293,7 +293,7 @@
 }
 
 .forum-read-more {
-  color: #10b981;
+  color: #1C7AA6;
   font-weight: bold;
   font-size: 13px;
   cursor: pointer;
@@ -329,11 +329,11 @@
 }
 
 .forum-last-comment-author {
-  color: #064e3b;
+  color: #135471;
 }
 
 .forum-last-comment-link {
-  color: #16a34a;
+  color: #1C7AA6;
   cursor: pointer;
   font-size: 11px;
   font-weight: bold;
@@ -366,7 +366,7 @@
 }
 
 .forum-block-btn-active {
-  background-color: #10b981;
+  background-color: #1C7AA6;
 }
 
 .forum-lock-btn {
@@ -382,7 +382,7 @@
 
 .forum-comments-btn {
   background-color: #fff;
-  color: #064e3b;
+  color: #135471;
   border: 1px solid #cbd5e1;
   padding: 3px 10px;
   border-radius: 4px;
@@ -402,7 +402,7 @@
 
 .forum-page-nav-btn {
   background-color: #fff;
-  color: #10b981;
+  color: #1C7AA6;
   border: 1px solid #cbd5e1;
   padding: 8px 14px;
   border-radius: 6px;
@@ -434,7 +434,7 @@
 }
 
 .forum-page-num-btn-active {
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
 }
 
@@ -447,7 +447,7 @@
 }
 
 .forum-recommendations-title {
-  color: #064e3b;
+  color: #135471;
   margin: 0 0 15px 0;
   font-size: 15px;
   font-weight: bold;
@@ -477,7 +477,7 @@
 }
 
 .forum-recommendation-card:hover {
-  border-color: #10b981;
+  border-color: #1C7AA6;
 }
 
 .forum-recommendation-title {
@@ -491,7 +491,7 @@
 }
 
 .forum-recommendation-link {
-  color: #10b981;
+  color: #1C7AA6;
   font-size: 12px;
   font-weight: bold;
   display: inline-block;
@@ -521,13 +521,13 @@
   width: 800px;
   max-width: 90%;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-  border: 2px solid #10b981;
+  border: 2px solid #1C7AA6;
   max-height: 95vh;
   overflow-y: auto;
 }
 
 .forum-modal-title {
-  color: #064e3b;
+  color: #135471;
   text-align: center;
   margin-bottom: 25px;
   font-weight: bold;
@@ -550,7 +550,7 @@
 
 .forum-field-label {
   font-weight: bold;
-  color: #064e3b;
+  color: #135471;
   font-size: 14px;
 }
 
@@ -559,7 +559,7 @@
   height: 40px;
   padding: 0 10px;
   border-radius: 6px;
-  border: 2px solid #d1fae5;
+  border: 2px solid #DEEFF7;
   background-color: #fff;
   font-size: 14px;
   outline: none;
@@ -578,7 +578,7 @@
   height: 40px;
   padding: 0 12px;
   border-radius: 6px;
-  border: 2px solid #d1fae5;
+  border: 2px solid #DEEFF7;
   font-size: 14px;
   outline: none;
   box-sizing: border-box;
@@ -589,11 +589,11 @@
   top: 100%;
   right: 0;
   left: 0;
-  background: #f0fdf4;
+  background: #DEEFF7;
   padding: 12px;
   margin-top: 5px;
   border-radius: 6px;
-  border: 1px solid #10b981;
+  border: 1px solid #1C7AA6;
   z-index: 999;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
@@ -606,14 +606,14 @@
 }
 
 .forum-similar-posts-label {
-  color: #065f46;
+  color: #135471;
   font-weight: bold;
 }
 
 .forum-similar-posts-close {
   background: none;
   border: none;
-  color: #059669;
+  color: #1C7AA6;
   cursor: pointer;
   font-weight: bold;
   font-size: 12px;
@@ -625,7 +625,7 @@
 
 .forum-similar-post-link {
   font-size: 13px;
-  color: #059669;
+  color: #1C7AA6;
   text-decoration: underline;
 }
 
@@ -639,7 +639,7 @@
   font-weight: bold;
   display: block;
   margin-bottom: 5px;
-  color: #064e3b;
+  color: #135471;
 }
 
 .forum-content-textarea {
@@ -661,12 +661,12 @@
   position: absolute;
   bottom: 15px;
   left: 15px;
-  background-color: #ecfdf5;
-  border: 1px solid #10b981;
+  background-color: #DEEFF7;
+  border: 1px solid #1C7AA6;
   padding: 6px 14px;
   border-radius: 6px;
   cursor: pointer;
-  color: #059669;
+  color: #1C7AA6;
   font-size: 13px;
   display: flex;
   align-items: center;
@@ -698,7 +698,7 @@
 }
 
 .forum-ai-emoji {
-  color: #10b981;
+  color: #1C7AA6;
 }
 
 .forum-ai-refine-btn,
@@ -730,7 +730,7 @@
 
 .forum-ai-titles-btn {
   background-color: #fff;
-  color: #059669;
+  color: #1C7AA6;
 }
 
 .forum-ai-titles-btn-disabled {
@@ -847,7 +847,7 @@
 
 .forum-submit-btn {
   padding: 10px 40px;
-  background: #10b981;
+  background: #1C7AA6;
   color: white;
   border: none;
   border-radius: 6px;
@@ -857,7 +857,7 @@
 }
 
 .forum-submit-btn-submitting {
-  background: #a7f3d0;
+  background: #A6C9D9;
   cursor: not-allowed;
 }
 
@@ -880,7 +880,7 @@
   width: 75px;
   height: 75px;
   border-radius: 8px;
-  border: 1px solid #10b981;
+  border: 1px solid #1C7AA6;
   overflow: hidden;
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
@@ -961,7 +961,7 @@
 .forum-thread-loading {
   text-align: center;
   padding: 50px;
-  color: #10b981;
+  color: #1C7AA6;
   font-weight: bold;
   direction: rtl;
 }
@@ -987,7 +987,7 @@
   cursor: pointer;
   background: none;
   border: none;
-  color: #10b981;
+  color: #1C7AA6;
   font-weight: bold;
   font-size: 15px;
   display: flex;
@@ -1021,7 +1021,7 @@
   width: 50px;
   height: 50px;
   border-radius: 50%;
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   display: flex;
   align-items: center;
@@ -1033,7 +1033,7 @@
 
 .forum-post-author-name {
   font-weight: bold;
-  color: #064e3b;
+  color: #135471;
   font-size: 14px;
   text-align: center;
 }
@@ -1070,8 +1070,8 @@
 }
 
 .forum-post-category-badge {
-  background-color: #d1fae5;
-  color: #065f46;
+  background-color: #DEEFF7;
+  color: #135471;
   padding: 1px 6px;
   border-radius: 3px;
   font-size: 11px;
@@ -1093,7 +1093,7 @@
 .forum-post-title {
   margin: 0;
   font-size: 19px;
-  color: #064e3b;
+  color: #135471;
   font-weight: bold;
 }
 
@@ -1119,12 +1119,12 @@
 }
 
 .forum-post-tag-chip {
-  background-color: #f0fdf4;
-  color: #16a34a;
+  background-color: #DEEFF7;
+  color: #1C7AA6;
   padding: 1px 6px;
   border-radius: 4px;
   font-size: 11px;
-  border: 1px solid #bbf7d0;
+  border: 1px solid #A6C9D9;
   font-weight: bold;
 }
 
@@ -1214,18 +1214,18 @@
   width: 38px;
   height: 38px;
   border-radius: 50%;
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 14px;
   font-weight: bold;
-  box-shadow: 0 2px 5px rgba(16, 185, 129, 0.1);
+  box-shadow: 0 2px 5px rgba(28, 122, 166, 0.1);
 }
 
 .forum-comment-author-name {
-  color: #064e3b;
+  color: #135471;
   font-size: 11px;
   margin-top: 4px;
   text-align: center;
@@ -1313,10 +1313,10 @@
 }
 
 .forum-comment-form-wrap {
-  border: 1px solid #10b981;
+  border: 1px solid #1C7AA6;
   border-radius: 4px;
   padding: 15px;
-  background-color: #f0fdf4;
+  background-color: #DEEFF7;
   display: flex;
   gap: 15px;
   align-items: flex-start;
@@ -1334,18 +1334,18 @@
   width: 45px;
   height: 45px;
   border-radius: 50%;
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 16px;
   font-weight: bold;
-  box-shadow: 0 2px 5px rgba(16, 185, 129, 0.2);
+  box-shadow: 0 2px 5px rgba(28, 122, 166, 0.2);
 }
 
 .forum-comment-form-username {
-  color: #064e3b;
+  color: #135471;
   font-weight: bold;
   margin-top: 3px;
   font-size: 11px;
@@ -1357,7 +1357,7 @@
   display: flex;
   flex-direction: column;
   gap: 0px;
-  border: 1px solid #d1fae5;
+  border: 1px solid #DEEFF7;
   border-radius: 6px;
   overflow: hidden;
   background-color: #fff;
@@ -1431,13 +1431,13 @@
 
 .forum-selected-file-banner {
   padding: 6px 12px;
-  background-color: #f0fdf4;
-  border-bottom: 1px solid #d1fae5;
+  background-color: #DEEFF7;
+  border-bottom: 1px solid #DEEFF7;
   display: flex;
   align-items: center;
   justify-items: flex-start;
   gap: 8px;
-  color: #15803d;
+  color: #135471;
   font-size: 13px;
   font-weight: 500;
 }
@@ -1475,7 +1475,7 @@
 }
 
 .forum-comment-submit-btn {
-  background-color: #10b981;
+  background-color: #1C7AA6;
   color: white;
   padding: 6px 20px;
   border: none;
@@ -1486,14 +1486,14 @@
 }
 
 .forum-comment-submit-btn:disabled {
-  background-color: #a7f3d0;
+  background-color: #A6C9D9;
   cursor: not-allowed;
 }
 
 .forum-attach-comment-btn {
   background: none;
   border: none;
-  color: #059669;
+  color: #1C7AA6;
   font-size: 12px;
   cursor: pointer;
   font-weight: bold;
@@ -1513,7 +1513,7 @@
 }
 
 .forum-thread-recommendations-title {
-  color: #064e3b;
+  color: #135471;
   margin: 0 0 15px 0;
   font-size: 16px;
   font-weight: bold;
@@ -1521,7 +1521,7 @@
 
 .forum-thread-recommendations-icon {
   margin-left: 8px;
-  color: #10b981;
+  color: #1C7AA6;
 }
 
 .forum-thread-recommendations-grid {
@@ -1541,7 +1541,7 @@
 }
 
 .forum-thread-recommendation-card:hover {
-  border-color: #10b981;
+  border-color: #1C7AA6;
 }
 
 .forum-thread-recommendation-title {
@@ -1555,7 +1555,7 @@
 }
 
 .forum-thread-recommendation-link {
-  color: #10b981;
+  color: #1C7AA6;
   font-size: 12px;
   font-weight: bold;
 }

--- a/apps/client/src/styles/landing-page.css
+++ b/apps/client/src/styles/landing-page.css
@@ -56,15 +56,15 @@
 }
 
 .section-nav-btn:hover {
-  border-color: #2E6E7E;
-  box-shadow: 0 4px 12px rgba(46, 110, 126, 0.1);
+  border-color: #48B4D6;
+  box-shadow: 0 4px 12px rgba(72, 180, 214, 0.1);
   transform: translateY(-2px);
 }
 
 .section-nav-btn.active {
-  background: linear-gradient(135deg, #2E6E7E 0%, #1E4852 100%);
-  border-color: #2E6E7E;
-  box-shadow: 0 8px 20px rgba(46, 110, 126, 0.2);
+  background: linear-gradient(135deg, #48B4D6 0%, #2996B7 100%);
+  border-color: #48B4D6;
+  box-shadow: 0 8px 20px rgba(72, 180, 214, 0.2);
 }
 
 .section-nav-btn.active .section-nav-title,
@@ -434,9 +434,9 @@
   margin-top: 20px;
   padding: 10px 24px;
   background: white;
-  border: 2px solid #2E6E7E;
+  border: 2px solid #48B4D6;
   border-radius: 8px;
-  color: #2E6E7E;
+  color: #48B4D6;
   text-decoration: none;
   font-size: 15px;
   font-weight: 600;
@@ -444,7 +444,7 @@
 }
 
 .hero-org-owner-link:hover {
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
   text-decoration: none;
 }

--- a/apps/client/src/styles/landing-page.css
+++ b/apps/client/src/styles/landing-page.css
@@ -56,15 +56,15 @@
 }
 
 .section-nav-btn:hover {
-  border-color: #10a37f;
-  box-shadow: 0 4px 12px rgba(16, 163, 127, 0.1);
+  border-color: #25596B;
+  box-shadow: 0 4px 12px rgba(37, 89, 107, 0.1);
   transform: translateY(-2px);
 }
 
 .section-nav-btn.active {
-  background: linear-gradient(135deg, #10a37f 0%, #0d8f6f 100%);
-  border-color: #10a37f;
-  box-shadow: 0 8px 20px rgba(16, 163, 127, 0.2);
+  background: linear-gradient(135deg, #25596B 0%, #1C4E5E 100%);
+  border-color: #25596B;
+  box-shadow: 0 8px 20px rgba(37, 89, 107, 0.2);
 }
 
 .section-nav-btn.active .section-nav-title,
@@ -434,9 +434,9 @@
   margin-top: 20px;
   padding: 10px 24px;
   background: white;
-  border: 2px solid #10a37f;
+  border: 2px solid #25596B;
   border-radius: 8px;
-  color: #10a37f;
+  color: #25596B;
   text-decoration: none;
   font-size: 15px;
   font-weight: 600;
@@ -444,7 +444,7 @@
 }
 
 .hero-org-owner-link:hover {
-  background: #10a37f;
+  background: #25596B;
   color: white;
   text-decoration: none;
 }

--- a/apps/client/src/styles/landing-page.css
+++ b/apps/client/src/styles/landing-page.css
@@ -56,15 +56,15 @@
 }
 
 .section-nav-btn:hover {
-  border-color: #0C6250;
-  box-shadow: 0 4px 12px rgba(12, 98, 80, 0.1);
+  border-color: #2E6E7E;
+  box-shadow: 0 4px 12px rgba(46, 110, 126, 0.1);
   transform: translateY(-2px);
 }
 
 .section-nav-btn.active {
-  background: linear-gradient(135deg, #0C6250 0%, #084034 100%);
-  border-color: #0C6250;
-  box-shadow: 0 8px 20px rgba(12, 98, 80, 0.2);
+  background: linear-gradient(135deg, #2E6E7E 0%, #1E4852 100%);
+  border-color: #2E6E7E;
+  box-shadow: 0 8px 20px rgba(46, 110, 126, 0.2);
 }
 
 .section-nav-btn.active .section-nav-title,
@@ -434,9 +434,9 @@
   margin-top: 20px;
   padding: 10px 24px;
   background: white;
-  border: 2px solid #0C6250;
+  border: 2px solid #2E6E7E;
   border-radius: 8px;
-  color: #0C6250;
+  color: #2E6E7E;
   text-decoration: none;
   font-size: 15px;
   font-weight: 600;
@@ -444,7 +444,7 @@
 }
 
 .hero-org-owner-link:hover {
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
   text-decoration: none;
 }

--- a/apps/client/src/styles/landing-page.css
+++ b/apps/client/src/styles/landing-page.css
@@ -56,15 +56,15 @@
 }
 
 .section-nav-btn:hover {
-  border-color: #25596B;
-  box-shadow: 0 4px 12px rgba(37, 89, 107, 0.1);
+  border-color: #0C6250;
+  box-shadow: 0 4px 12px rgba(12, 98, 80, 0.1);
   transform: translateY(-2px);
 }
 
 .section-nav-btn.active {
-  background: linear-gradient(135deg, #25596B 0%, #1C4E5E 100%);
-  border-color: #25596B;
-  box-shadow: 0 8px 20px rgba(37, 89, 107, 0.2);
+  background: linear-gradient(135deg, #0C6250 0%, #084034 100%);
+  border-color: #0C6250;
+  box-shadow: 0 8px 20px rgba(12, 98, 80, 0.2);
 }
 
 .section-nav-btn.active .section-nav-title,
@@ -434,9 +434,9 @@
   margin-top: 20px;
   padding: 10px 24px;
   background: white;
-  border: 2px solid #25596B;
+  border: 2px solid #0C6250;
   border-radius: 8px;
-  color: #25596B;
+  color: #0C6250;
   text-decoration: none;
   font-size: 15px;
   font-weight: 600;
@@ -444,7 +444,7 @@
 }
 
 .hero-org-owner-link:hover {
-  background: #25596B;
+  background: #0C6250;
   color: white;
   text-decoration: none;
 }

--- a/apps/client/src/styles/landing-page.css
+++ b/apps/client/src/styles/landing-page.css
@@ -56,15 +56,15 @@
 }
 
 .section-nav-btn:hover {
-  border-color: #48B4D6;
-  box-shadow: 0 4px 12px rgba(72, 180, 214, 0.1);
+  border-color: #1C7AA6;
+  box-shadow: 0 4px 12px rgba(28, 122, 166, 0.1);
   transform: translateY(-2px);
 }
 
 .section-nav-btn.active {
-  background: linear-gradient(135deg, #48B4D6 0%, #2996B7 100%);
-  border-color: #48B4D6;
-  box-shadow: 0 8px 20px rgba(72, 180, 214, 0.2);
+  background: linear-gradient(135deg, #1C7AA6 0%, #135471 100%);
+  border-color: #1C7AA6;
+  box-shadow: 0 8px 20px rgba(28, 122, 166, 0.2);
 }
 
 .section-nav-btn.active .section-nav-title,
@@ -434,9 +434,9 @@
   margin-top: 20px;
   padding: 10px 24px;
   background: white;
-  border: 2px solid #48B4D6;
+  border: 2px solid #1C7AA6;
   border-radius: 8px;
-  color: #48B4D6;
+  color: #1C7AA6;
   text-decoration: none;
   font-size: 15px;
   font-weight: 600;
@@ -444,7 +444,7 @@
 }
 
 .hero-org-owner-link:hover {
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
   text-decoration: none;
 }

--- a/apps/client/src/styles/privacy-page.css
+++ b/apps/client/src/styles/privacy-page.css
@@ -41,7 +41,7 @@
 }
 
 .privacy-section h2 {
-  color: #0C6250;
+  color: #2E6E7E;
   font-size: 22px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -81,7 +81,7 @@
 
 .privacy-section ul li::before {
   content: "•";
-  color: #0C6250;
+  color: #2E6E7E;
   font-weight: bold;
   position: absolute;
   right: 0;
@@ -108,8 +108,8 @@
 }
 
 .privacy-contact-box {
-  background: linear-gradient(135deg, rgba(12, 98, 80, 0.08) 0%, rgba(8, 64, 52, 0.08) 100%);
-  border: 2px solid #0C6250;
+  background: linear-gradient(135deg, rgba(46, 110, 126, 0.08) 0%, rgba(30, 72, 82, 0.08) 100%);
+  border: 2px solid #2E6E7E;
   border-radius: 12px;
   padding: 24px;
   text-align: center;
@@ -121,7 +121,7 @@
 }
 
 .privacy-contact-box a {
-  color: #0C6250;
+  color: #2E6E7E;
   font-weight: 700;
   text-decoration: none;
 }

--- a/apps/client/src/styles/privacy-page.css
+++ b/apps/client/src/styles/privacy-page.css
@@ -41,7 +41,7 @@
 }
 
 .privacy-section h2 {
-  color: #10a37f;
+  color: #25596B;
   font-size: 22px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -81,7 +81,7 @@
 
 .privacy-section ul li::before {
   content: "•";
-  color: #10a37f;
+  color: #25596B;
   font-weight: bold;
   position: absolute;
   right: 0;
@@ -108,8 +108,8 @@
 }
 
 .privacy-contact-box {
-  background: linear-gradient(135deg, rgba(16, 163, 127, 0.08) 0%, rgba(13, 143, 111, 0.08) 100%);
-  border: 2px solid #10a37f;
+  background: linear-gradient(135deg, rgba(37, 89, 107, 0.08) 0%, rgba(28, 78, 94, 0.08) 100%);
+  border: 2px solid #25596B;
   border-radius: 12px;
   padding: 24px;
   text-align: center;
@@ -121,7 +121,7 @@
 }
 
 .privacy-contact-box a {
-  color: #10a37f;
+  color: #25596B;
   font-weight: 700;
   text-decoration: none;
 }

--- a/apps/client/src/styles/privacy-page.css
+++ b/apps/client/src/styles/privacy-page.css
@@ -41,7 +41,7 @@
 }
 
 .privacy-section h2 {
-  color: #25596B;
+  color: #0C6250;
   font-size: 22px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -81,7 +81,7 @@
 
 .privacy-section ul li::before {
   content: "•";
-  color: #25596B;
+  color: #0C6250;
   font-weight: bold;
   position: absolute;
   right: 0;
@@ -108,8 +108,8 @@
 }
 
 .privacy-contact-box {
-  background: linear-gradient(135deg, rgba(37, 89, 107, 0.08) 0%, rgba(28, 78, 94, 0.08) 100%);
-  border: 2px solid #25596B;
+  background: linear-gradient(135deg, rgba(12, 98, 80, 0.08) 0%, rgba(8, 64, 52, 0.08) 100%);
+  border: 2px solid #0C6250;
   border-radius: 12px;
   padding: 24px;
   text-align: center;
@@ -121,7 +121,7 @@
 }
 
 .privacy-contact-box a {
-  color: #25596B;
+  color: #0C6250;
   font-weight: 700;
   text-decoration: none;
 }

--- a/apps/client/src/styles/privacy-page.css
+++ b/apps/client/src/styles/privacy-page.css
@@ -102,8 +102,8 @@
 }
 
 .privacy-section th {
-  background: #f0fdf4;
-  color: #065f46;
+  background: #DEEFF7;
+  color: #135471;
   font-weight: 700;
 }
 

--- a/apps/client/src/styles/privacy-page.css
+++ b/apps/client/src/styles/privacy-page.css
@@ -41,7 +41,7 @@
 }
 
 .privacy-section h2 {
-  color: #48B4D6;
+  color: #1C7AA6;
   font-size: 22px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -81,7 +81,7 @@
 
 .privacy-section ul li::before {
   content: "•";
-  color: #48B4D6;
+  color: #1C7AA6;
   font-weight: bold;
   position: absolute;
   right: 0;
@@ -108,8 +108,8 @@
 }
 
 .privacy-contact-box {
-  background: linear-gradient(135deg, rgba(72, 180, 214, 0.08) 0%, rgba(41, 150, 183, 0.08) 100%);
-  border: 2px solid #48B4D6;
+  background: linear-gradient(135deg, rgba(28, 122, 166, 0.08) 0%, rgba(19, 84, 113, 0.08) 100%);
+  border: 2px solid #1C7AA6;
   border-radius: 12px;
   padding: 24px;
   text-align: center;
@@ -121,7 +121,7 @@
 }
 
 .privacy-contact-box a {
-  color: #48B4D6;
+  color: #1C7AA6;
   font-weight: 700;
   text-decoration: none;
 }

--- a/apps/client/src/styles/privacy-page.css
+++ b/apps/client/src/styles/privacy-page.css
@@ -41,7 +41,7 @@
 }
 
 .privacy-section h2 {
-  color: #2E6E7E;
+  color: #48B4D6;
   font-size: 22px;
   font-weight: 700;
   margin-bottom: 1rem;
@@ -81,7 +81,7 @@
 
 .privacy-section ul li::before {
   content: "•";
-  color: #2E6E7E;
+  color: #48B4D6;
   font-weight: bold;
   position: absolute;
   right: 0;
@@ -108,8 +108,8 @@
 }
 
 .privacy-contact-box {
-  background: linear-gradient(135deg, rgba(46, 110, 126, 0.08) 0%, rgba(30, 72, 82, 0.08) 100%);
-  border: 2px solid #2E6E7E;
+  background: linear-gradient(135deg, rgba(72, 180, 214, 0.08) 0%, rgba(41, 150, 183, 0.08) 100%);
+  border: 2px solid #48B4D6;
   border-radius: 12px;
   padding: 24px;
   text-align: center;
@@ -121,7 +121,7 @@
 }
 
 .privacy-contact-box a {
-  color: #2E6E7E;
+  color: #48B4D6;
   font-weight: 700;
   text-decoration: none;
 }

--- a/apps/client/src/styles/recommended-guides-page.css
+++ b/apps/client/src/styles/recommended-guides-page.css
@@ -152,7 +152,7 @@
   margin-bottom: 40px;
   padding: 24px;
   background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-  border: 2px solid #2E6E7E;
+  border: 2px solid #48B4D6;
   border-radius: 12px;
 }
 
@@ -166,7 +166,7 @@
 .stat-number {
   font-size: 36px;
   font-weight: 700;
-  color: #2E6E7E;
+  color: #48B4D6;
   line-height: 1;
   margin-bottom: 8px;
 }

--- a/apps/client/src/styles/recommended-guides-page.css
+++ b/apps/client/src/styles/recommended-guides-page.css
@@ -152,7 +152,7 @@
   margin-bottom: 40px;
   padding: 24px;
   background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-  border: 2px solid #0C6250;
+  border: 2px solid #2E6E7E;
   border-radius: 12px;
 }
 
@@ -166,7 +166,7 @@
 .stat-number {
   font-size: 36px;
   font-weight: 700;
-  color: #0C6250;
+  color: #2E6E7E;
   line-height: 1;
   margin-bottom: 8px;
 }

--- a/apps/client/src/styles/recommended-guides-page.css
+++ b/apps/client/src/styles/recommended-guides-page.css
@@ -152,7 +152,7 @@
   margin-bottom: 40px;
   padding: 24px;
   background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-  border: 2px solid #10a37f;
+  border: 2px solid #25596B;
   border-radius: 12px;
 }
 
@@ -166,7 +166,7 @@
 .stat-number {
   font-size: 36px;
   font-weight: 700;
-  color: #10a37f;
+  color: #25596B;
   line-height: 1;
   margin-bottom: 8px;
 }

--- a/apps/client/src/styles/recommended-guides-page.css
+++ b/apps/client/src/styles/recommended-guides-page.css
@@ -152,7 +152,7 @@
   margin-bottom: 40px;
   padding: 24px;
   background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-  border: 2px solid #25596B;
+  border: 2px solid #0C6250;
   border-radius: 12px;
 }
 
@@ -166,7 +166,7 @@
 .stat-number {
   font-size: 36px;
   font-weight: 700;
-  color: #25596B;
+  color: #0C6250;
   line-height: 1;
   margin-bottom: 8px;
 }

--- a/apps/client/src/styles/recommended-guides-page.css
+++ b/apps/client/src/styles/recommended-guides-page.css
@@ -152,7 +152,7 @@
   margin-bottom: 40px;
   padding: 24px;
   background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
-  border: 2px solid #48B4D6;
+  border: 2px solid #1C7AA6;
   border-radius: 12px;
 }
 
@@ -166,7 +166,7 @@
 .stat-number {
   font-size: 36px;
   font-weight: 700;
-  color: #48B4D6;
+  color: #1C7AA6;
   line-height: 1;
   margin-bottom: 8px;
 }

--- a/apps/client/src/styles/recommended-guides-page.css
+++ b/apps/client/src/styles/recommended-guides-page.css
@@ -151,7 +151,7 @@
   gap: 20px;
   margin-bottom: 40px;
   padding: 24px;
-  background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
+  background: linear-gradient(135deg, #DEEFF7 0%, #D0E7F1 100%);
   border: 2px solid #1C7AA6;
   border-radius: 12px;
 }
@@ -173,7 +173,7 @@
 
 .stat-label {
   font-size: 14px;
-  color: #15803d;
+  color: #135471;
   font-weight: 600;
 }
 

--- a/apps/client/src/styles/safeai-ui.css
+++ b/apps/client/src/styles/safeai-ui.css
@@ -47,8 +47,8 @@
 }
 
 .sub-nav-btn.active {
-  color: #25596B;
-  border-bottom-color: #25596B;
+  color: #0C6250;
+  border-bottom-color: #0C6250;
   font-weight: 600;
 }
 
@@ -59,7 +59,7 @@
   margin-left: 4px;
   padding: 0;
   background: transparent;
-  color: #25596B;
+  color: #0C6250;
   font-size: 14px;
   font-weight: 600;
   border: none;
@@ -78,7 +78,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: #25596B;
+  color: #0C6250;
   font-size: 12px;
   font-weight: 700;
 }
@@ -525,7 +525,7 @@
   margin-left: 8px;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #25596B;
+  background: #0C6250;
   color: white;
   font-size: 12px;
   font-weight: 700;

--- a/apps/client/src/styles/safeai-ui.css
+++ b/apps/client/src/styles/safeai-ui.css
@@ -47,8 +47,8 @@
 }
 
 .sub-nav-btn.active {
-  color: #10a37f;
-  border-bottom-color: #10a37f;
+  color: #25596B;
+  border-bottom-color: #25596B;
   font-weight: 600;
 }
 
@@ -59,7 +59,7 @@
   margin-left: 4px;
   padding: 0;
   background: transparent;
-  color: #10a37f;
+  color: #25596B;
   font-size: 14px;
   font-weight: 600;
   border: none;
@@ -78,7 +78,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: #10a37f;
+  color: #25596B;
   font-size: 12px;
   font-weight: 700;
 }
@@ -525,7 +525,7 @@
   margin-left: 8px;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #10a37f;
+  background: #25596B;
   color: white;
   font-size: 12px;
   font-weight: 700;

--- a/apps/client/src/styles/safeai-ui.css
+++ b/apps/client/src/styles/safeai-ui.css
@@ -47,8 +47,8 @@
 }
 
 .sub-nav-btn.active {
-  color: #48B4D6;
-  border-bottom-color: #48B4D6;
+  color: #1C7AA6;
+  border-bottom-color: #1C7AA6;
   font-weight: 600;
 }
 
@@ -59,7 +59,7 @@
   margin-left: 4px;
   padding: 0;
   background: transparent;
-  color: #48B4D6;
+  color: #1C7AA6;
   font-size: 14px;
   font-weight: 600;
   border: none;
@@ -78,7 +78,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: #48B4D6;
+  color: #1C7AA6;
   font-size: 12px;
   font-weight: 700;
 }
@@ -525,7 +525,7 @@
   margin-left: 8px;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #48B4D6;
+  background: #1C7AA6;
   color: white;
   font-size: 12px;
   font-weight: 700;

--- a/apps/client/src/styles/safeai-ui.css
+++ b/apps/client/src/styles/safeai-ui.css
@@ -47,8 +47,8 @@
 }
 
 .sub-nav-btn.active {
-  color: #0C6250;
-  border-bottom-color: #0C6250;
+  color: #2E6E7E;
+  border-bottom-color: #2E6E7E;
   font-weight: 600;
 }
 
@@ -59,7 +59,7 @@
   margin-left: 4px;
   padding: 0;
   background: transparent;
-  color: #0C6250;
+  color: #2E6E7E;
   font-size: 14px;
   font-weight: 600;
   border: none;
@@ -78,7 +78,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: #0C6250;
+  color: #2E6E7E;
   font-size: 12px;
   font-weight: 700;
 }
@@ -525,7 +525,7 @@
   margin-left: 8px;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #0C6250;
+  background: #2E6E7E;
   color: white;
   font-size: 12px;
   font-weight: 700;

--- a/apps/client/src/styles/safeai-ui.css
+++ b/apps/client/src/styles/safeai-ui.css
@@ -47,8 +47,8 @@
 }
 
 .sub-nav-btn.active {
-  color: #2E6E7E;
-  border-bottom-color: #2E6E7E;
+  color: #48B4D6;
+  border-bottom-color: #48B4D6;
   font-weight: 600;
 }
 
@@ -59,7 +59,7 @@
   margin-left: 4px;
   padding: 0;
   background: transparent;
-  color: #2E6E7E;
+  color: #48B4D6;
   font-size: 14px;
   font-weight: 600;
   border: none;
@@ -78,7 +78,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: #2E6E7E;
+  color: #48B4D6;
   font-size: 12px;
   font-weight: 700;
 }
@@ -525,7 +525,7 @@
   margin-left: 8px;
   padding: 2px 8px;
   border-radius: 999px;
-  background: #2E6E7E;
+  background: #48B4D6;
   color: white;
   font-size: 12px;
   font-weight: 700;

--- a/apps/client/src/styles/tender-board-page.css
+++ b/apps/client/src/styles/tender-board-page.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 :root {
-  --primary-color: #48B4D6;        /* טיל כחול אחיד לכל המערכת */
-  --primary-hover: #71C6DF;
+  --primary-color: #1C7AA6;        /* טיל כחול אחיד לכל המערכת */
+  --primary-hover: #239AD1;
   --secondary-bg: #f8fafc;
   --text-main: #111827;
   --text-muted: #64748b;
@@ -299,7 +299,7 @@
 .primary-button:hover, .button-green:hover, .submit-button:hover, .details-button:hover {
   background: var(--primary-hover);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(72, 180, 214, 0.24);
+  box-shadow: 0 12px 24px rgba(28, 122, 166, 0.24);
 }
 
 /* אינפוטים וטקסט-ארפיס גלובליים */
@@ -320,7 +320,7 @@
 .input:focus, .textarea:focus, textarea:focus, input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(72, 180, 214, 0.12);
+  box-shadow: 0 0 0 3px rgba(28, 122, 166, 0.12);
   background: #ffffff;
 }
 
@@ -357,7 +357,7 @@
 .tender-card:focus-within {
   transform: translateY(-6px);
   border-color: #16a34a; /* ירוק בוהק קל */
-  box-shadow: 0 14px 34px rgba(72,180,214,0.12);
+  box-shadow: 0 14px 34px rgba(28,122,166,0.12);
 }
 
 .tender-card:active {

--- a/apps/client/src/styles/tender-board-page.css
+++ b/apps/client/src/styles/tender-board-page.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 :root {
-  --primary-color: #25596B;        /* טיל כחול אחיד לכל המערכת */
-  --primary-hover: #2E6E7E;
+  --primary-color: #0C6250;        /* טיל כחול אחיד לכל המערכת */
+  --primary-hover: #129176;
   --secondary-bg: #f8fafc;
   --text-main: #111827;
   --text-muted: #64748b;
@@ -299,7 +299,7 @@
 .primary-button:hover, .button-green:hover, .submit-button:hover, .details-button:hover {
   background: var(--primary-hover);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(37, 89, 107, 0.24);
+  box-shadow: 0 12px 24px rgba(12, 98, 80, 0.24);
 }
 
 /* אינפוטים וטקסט-ארפיס גלובליים */
@@ -320,7 +320,7 @@
 .input:focus, .textarea:focus, textarea:focus, input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(37, 89, 107, 0.12);
+  box-shadow: 0 0 0 3px rgba(12, 98, 80, 0.12);
   background: #ffffff;
 }
 
@@ -357,7 +357,7 @@
 .tender-card:focus-within {
   transform: translateY(-6px);
   border-color: #16a34a; /* ירוק בוהק קל */
-  box-shadow: 0 14px 34px rgba(37,89,107,0.12);
+  box-shadow: 0 14px 34px rgba(12,98,80,0.12);
 }
 
 .tender-card:active {

--- a/apps/client/src/styles/tender-board-page.css
+++ b/apps/client/src/styles/tender-board-page.css
@@ -137,9 +137,9 @@
   gap: 12px;
   padding: 14px 28px;
   border-radius: var(--radius-md);
-  background: #f0fdf4;
-  border: 1px solid #bbf7d0;
-  color: #16a34a;
+  background: #DEEFF7;
+  border: 1px solid #A6C9D9;
+  color: #1C7AA6;
   font-size: 1.05rem;
   font-weight: 600;
   box-sizing: border-box;
@@ -147,7 +147,7 @@
 
 .metric-card p, .manage-summary strong {
   margin: 0;
-  color: #16a34a;
+  color: #1C7AA6;
 }
 
 .metric-card strong {
@@ -160,8 +160,8 @@
   margin-bottom: 32px;
   display: flex;
   justify-content: center;
-  background-color: #f0fdf4; /* רקע ירקרק עדין התואם למונה המכרזים */
-  border: 2px solid #22c55e;  /* מסגרת ירוקה נקייה כמו בתמונה השנייה */
+  background-color: #DEEFF7; /* רקע תכלת עדין התואם למונה המכרזים */
+  border: 2px solid #1C7AA6;  /* מסגרת כחולה נקייה תואמת מותג */
   border-radius: var(--radius-md);
   padding: 16px 24px;
   box-shadow: var(--shadow-sm);
@@ -356,7 +356,7 @@
 .tender-card:hover,
 .tender-card:focus-within {
   transform: translateY(-6px);
-  border-color: #16a34a; /* ירוק בוהק קל */
+  border-color: #239AD1; /* כחול בוהק קל */
   box-shadow: 0 14px 34px rgba(28,122,166,0.12);
 }
 
@@ -411,9 +411,9 @@
   align-items: center;
   padding: 6px 14px;
   border-radius: 999px;
-  background: #f0fdf4;
-  color: #0f766e;
-  border: 1px solid #bbf7d0;
+  background: #DEEFF7;
+  color: #135471;
+  border: 1px solid #A6C9D9;
   font-size: 0.85rem;
   font-weight: 600;
   gap: 6px;
@@ -517,9 +517,9 @@
 }
 
 .domain-chip.selected {
-  background: #ecfdf5;
+  background: #DEEFF7;
   border-color: var(--primary-color);
-  color: #0f766e;
+  color: #135471;
   font-weight: 600;
 }
 
@@ -754,16 +754,16 @@
 }
 
 .domain-pill--editable {
-  background: #ecfdf5;
-  border: 1px solid #a7f3d0;
-  color: #0f766e;
+  background: #DEEFF7;
+  border: 1px solid #A6C9D9;
+  color: #135471;
   padding: 4px 10px 4px 6px;
 }
 
 .domain-remove {
   background: transparent;
   border: none;
-  color: #059669;
+  color: #1C7AA6;
   margin-right: 4px;
   cursor: pointer;
   font-size: 1.1rem;

--- a/apps/client/src/styles/tender-board-page.css
+++ b/apps/client/src/styles/tender-board-page.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 :root {
-  --primary-color: #10a37f;        /* ירוק מנטה אחיד לכל המערכת */
-  --primary-hover: #0f9c6b;
+  --primary-color: #25596B;        /* טיל כחול אחיד לכל המערכת */
+  --primary-hover: #2E6E7E;
   --secondary-bg: #f8fafc;
   --text-main: #111827;
   --text-muted: #64748b;
@@ -299,7 +299,7 @@
 .primary-button:hover, .button-green:hover, .submit-button:hover, .details-button:hover {
   background: var(--primary-hover);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(16, 163, 127, 0.24);
+  box-shadow: 0 12px 24px rgba(37, 89, 107, 0.24);
 }
 
 /* אינפוטים וטקסט-ארפיס גלובליים */
@@ -320,7 +320,7 @@
 .input:focus, .textarea:focus, textarea:focus, input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(16, 163, 127, 0.12);
+  box-shadow: 0 0 0 3px rgba(37, 89, 107, 0.12);
   background: #ffffff;
 }
 
@@ -357,7 +357,7 @@
 .tender-card:focus-within {
   transform: translateY(-6px);
   border-color: #16a34a; /* ירוק בוהק קל */
-  box-shadow: 0 14px 34px rgba(16,163,127,0.12);
+  box-shadow: 0 14px 34px rgba(37,89,107,0.12);
 }
 
 .tender-card:active {

--- a/apps/client/src/styles/tender-board-page.css
+++ b/apps/client/src/styles/tender-board-page.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 :root {
-  --primary-color: #0C6250;        /* טיל כחול אחיד לכל המערכת */
-  --primary-hover: #129176;
+  --primary-color: #2E6E7E;        /* טיל כחול אחיד לכל המערכת */
+  --primary-hover: #3C90A4;
   --secondary-bg: #f8fafc;
   --text-main: #111827;
   --text-muted: #64748b;
@@ -299,7 +299,7 @@
 .primary-button:hover, .button-green:hover, .submit-button:hover, .details-button:hover {
   background: var(--primary-hover);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(12, 98, 80, 0.24);
+  box-shadow: 0 12px 24px rgba(46, 110, 126, 0.24);
 }
 
 /* אינפוטים וטקסט-ארפיס גלובליים */
@@ -320,7 +320,7 @@
 .input:focus, .textarea:focus, textarea:focus, input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(12, 98, 80, 0.12);
+  box-shadow: 0 0 0 3px rgba(46, 110, 126, 0.12);
   background: #ffffff;
 }
 
@@ -357,7 +357,7 @@
 .tender-card:focus-within {
   transform: translateY(-6px);
   border-color: #16a34a; /* ירוק בוהק קל */
-  box-shadow: 0 14px 34px rgba(12,98,80,0.12);
+  box-shadow: 0 14px 34px rgba(46,110,126,0.12);
 }
 
 .tender-card:active {

--- a/apps/client/src/styles/tender-board-page.css
+++ b/apps/client/src/styles/tender-board-page.css
@@ -3,8 +3,8 @@
    ========================================================================== */
 
 :root {
-  --primary-color: #2E6E7E;        /* טיל כחול אחיד לכל המערכת */
-  --primary-hover: #3C90A4;
+  --primary-color: #48B4D6;        /* טיל כחול אחיד לכל המערכת */
+  --primary-hover: #71C6DF;
   --secondary-bg: #f8fafc;
   --text-main: #111827;
   --text-muted: #64748b;
@@ -299,7 +299,7 @@
 .primary-button:hover, .button-green:hover, .submit-button:hover, .details-button:hover {
   background: var(--primary-hover);
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(46, 110, 126, 0.24);
+  box-shadow: 0 12px 24px rgba(72, 180, 214, 0.24);
 }
 
 /* אינפוטים וטקסט-ארפיס גלובליים */
@@ -320,7 +320,7 @@
 .input:focus, .textarea:focus, textarea:focus, input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(46, 110, 126, 0.12);
+  box-shadow: 0 0 0 3px rgba(72, 180, 214, 0.12);
   background: #ffffff;
 }
 
@@ -357,7 +357,7 @@
 .tender-card:focus-within {
   transform: translateY(-6px);
   border-color: #16a34a; /* ירוק בוהק קל */
-  box-shadow: 0 14px 34px rgba(46,110,126,0.12);
+  box-shadow: 0 14px 34px rgba(72,180,214,0.12);
 }
 
 .tender-card:active {

--- a/apps/client/src/styles/top-navigation.css
+++ b/apps/client/src/styles/top-navigation.css
@@ -112,14 +112,14 @@
 }
 
 .top-nav-btn-primary {
-  background-color: #48B4D6;
+  background-color: #1C7AA6;
   color: white;
-  border: 1px solid #48B4D6;
+  border: 1px solid #1C7AA6;
 }
 
 .top-nav-btn-primary:hover {
-  background-color: #71C6DF;
-  border-color: #71C6DF;
+  background-color: #239AD1;
+  border-color: #239AD1;
 }
 
 /* Developers Dropdown */
@@ -193,7 +193,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #48B4D6 0%, #2996B7 100%);
+  background: linear-gradient(135deg, #1C7AA6 0%, #135471 100%);
   color: white;
   display: flex;
   align-items: center;

--- a/apps/client/src/styles/top-navigation.css
+++ b/apps/client/src/styles/top-navigation.css
@@ -112,14 +112,14 @@
 }
 
 .top-nav-btn-primary {
-  background-color: #0C6250;
+  background-color: #2E6E7E;
   color: white;
-  border: 1px solid #0C6250;
+  border: 1px solid #2E6E7E;
 }
 
 .top-nav-btn-primary:hover {
-  background-color: #129176;
-  border-color: #129176;
+  background-color: #3C90A4;
+  border-color: #3C90A4;
 }
 
 /* Developers Dropdown */
@@ -193,7 +193,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #0C6250 0%, #084034 100%);
+  background: linear-gradient(135deg, #2E6E7E 0%, #1E4852 100%);
   color: white;
   display: flex;
   align-items: center;

--- a/apps/client/src/styles/top-navigation.css
+++ b/apps/client/src/styles/top-navigation.css
@@ -112,14 +112,14 @@
 }
 
 .top-nav-btn-primary {
-  background-color: #2E6E7E;
+  background-color: #48B4D6;
   color: white;
-  border: 1px solid #2E6E7E;
+  border: 1px solid #48B4D6;
 }
 
 .top-nav-btn-primary:hover {
-  background-color: #3C90A4;
-  border-color: #3C90A4;
+  background-color: #71C6DF;
+  border-color: #71C6DF;
 }
 
 /* Developers Dropdown */
@@ -193,7 +193,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #2E6E7E 0%, #1E4852 100%);
+  background: linear-gradient(135deg, #48B4D6 0%, #2996B7 100%);
   color: white;
   display: flex;
   align-items: center;

--- a/apps/client/src/styles/top-navigation.css
+++ b/apps/client/src/styles/top-navigation.css
@@ -112,14 +112,14 @@
 }
 
 .top-nav-btn-primary {
-  background-color: #25596B;
+  background-color: #0C6250;
   color: white;
-  border: 1px solid #25596B;
+  border: 1px solid #0C6250;
 }
 
 .top-nav-btn-primary:hover {
-  background-color: #2E6E7E;
-  border-color: #2E6E7E;
+  background-color: #129176;
+  border-color: #129176;
 }
 
 /* Developers Dropdown */
@@ -193,7 +193,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #25596B 0%, #1C4E5E 100%);
+  background: linear-gradient(135deg, #0C6250 0%, #084034 100%);
   color: white;
   display: flex;
   align-items: center;

--- a/apps/client/src/styles/top-navigation.css
+++ b/apps/client/src/styles/top-navigation.css
@@ -112,14 +112,14 @@
 }
 
 .top-nav-btn-primary {
-  background-color: #10a37f;
+  background-color: #25596B;
   color: white;
-  border: 1px solid #10a37f;
+  border: 1px solid #25596B;
 }
 
 .top-nav-btn-primary:hover {
-  background-color: #0d8f6f;
-  border-color: #0d8f6f;
+  background-color: #2E6E7E;
+  border-color: #2E6E7E;
 }
 
 /* Developers Dropdown */
@@ -193,7 +193,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #10a37f 0%, #0d8f6f 100%);
+  background: linear-gradient(135deg, #25596B 0%, #1C4E5E 100%);
   color: white;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Replaces the site-wide OpenAI-style green (`#10a37f` family) with a new teal-blue brand palette, settled after several rounds of preview/feedback: primary `#1C7AA6`, hover `#239AD1` (lighter), and `#135471` for the top announcement banner and decorative gradients.
- Covers buttons, links, borders, the BETA badge strip, highlighted/marked cards, the nav logo, and the favicon.
- Also catches two separate green accents the initial sweep missed: the forum module's own emerald palette (`#10b981` family) and several decorative "success-style" light-green highlight boxes (tender board stats/filters, recommended-guides stats bar, a few hover backgrounds) that weren't actually semantic success/error indicators.

## Explicitly left as green (intentional)
- Genuine success/error/positive feedback (`.success-banner`, `.alert-success`, `.message.success`, `.stat-change.positive`, etc.) — universal green=success convention, unrelated to brand color.
- The Excel file-type icon color in the forum's attachment renderer (matches real-world Office icon colors).
- The rich-text editor's "ירוק / ירוק בהיר" text-color-picker options — user-facing color names that must match their swatch.

## Test plan
- [x] `npm run typecheck` passes on `apps/client` after every commit
- [x] Verified no leftover instances of the old green hex family anywhere in `apps/client/src`
- [x] Verified WCAG contrast for white text on the final primary (`#1C7AA6`, ~4.8:1, passes AA)
- [ ] Manual visual QA in the browser across the affected pages (top nav, beta banner, forum, tender board, docs/about/contact/privacy pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)