### PR TITLE
AI News: image upload, Markdown rendering, editorial redesign, smart tags

### DIFF
--- a/apps/client/src/pages/AiNewsDetailsPage.tsx
+++ b/apps/client/src/pages/AiNewsDetailsPage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { Link, Navigate, useParams } from "react-router-dom";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { API_ENDPOINTS, apiCall } from "../config/api";
 import "../styles/news-page.css";
 
@@ -9,6 +11,7 @@ interface NewsItem {
   content: string;
   source?: string;
   tags?: string[];
+  imageUrl?: string;
   createdAt?: string;
 }
 
@@ -55,8 +58,8 @@ export default function AiNewsDetailsPage() {
 
   if (error) {
     return (
-      <div className="news-page-container">
-        <div className="news-card-wrapper">
+      <div className="news-details-page">
+        <div className="news-details-container">
           <div className="news-error-message">{error}</div>
         </div>
       </div>
@@ -68,35 +71,42 @@ export default function AiNewsDetailsPage() {
   }
 
   return (
-    <div className="news-page-container">
-      <div className="news-card-wrapper">
-        <div className="news-header-section">
-          <div className="news-header-content">
-            <h1 className="news-header-title">{news.title}</h1>
-            <div className="news-tags-row">
-              {news.tags?.map((tag) => (
-                <span key={tag} className="news-tag">
-                  #{tag}
-                </span>
-              ))}
-            </div>
-            <div className="news-item-meta">
-              <span className="news-date">
-                {new Date(news.createdAt || "").toLocaleDateString("he-IL", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
+    <div className="news-details-page">
+      <div className="news-details-container">
+        <Link to="/ai-news" className="news-back-link">
+          → חזרה לחדשות
+        </Link>
+
+        {news.tags?.length ? (
+          <div className="news-details-eyebrow">
+            {news.tags.map((tag) => (
+              <span key={tag} className="news-tag">
+                #{tag}
               </span>
-            </div>
-            <p className="news-header-subtitle">
-              {news.source ? `מקור: ${news.source}` : "מקור: User"}
-            </p>
+            ))}
           </div>
+        ) : null}
+
+        <h1 className="news-header-title">{news.title}</h1>
+
+        <div className="news-byline">
+          <span className="news-byline-source">{news.source || "User"}</span>
+          <span className="news-byline-dot">·</span>
+          <span>{new Date(news.createdAt || "").toLocaleDateString("he-IL", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}</span>
         </div>
-        <article className="news-article-card">
-          <p className="news-article-content">{news.content}</p>
-        </article>
+
+        {news.imageUrl && (
+          <img src={news.imageUrl} alt={news.title} className="news-details-image" />
+        )}
+
+        <div className="news-article-content">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{news.content}</ReactMarkdown>
+        </div>
+
         <div className="news-details-footer">
           <Link to="/ai-news" className="btn-reset">
             חזרה לחדשות

--- a/apps/client/src/pages/AiNewsDetailsPage.tsx
+++ b/apps/client/src/pages/AiNewsDetailsPage.tsx
@@ -106,12 +106,6 @@ export default function AiNewsDetailsPage() {
         <div className="news-article-content">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>{news.content}</ReactMarkdown>
         </div>
-
-        <div className="news-details-footer">
-          <Link to="/ai-news" className="btn-reset">
-            חזרה לחדשות
-          </Link>
-        </div>
       </div>
     </div>
   );

--- a/apps/client/src/pages/AiNewsPage.tsx
+++ b/apps/client/src/pages/AiNewsPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
 import { Link } from "react-router-dom";
+import { formatDistanceToNow } from "date-fns";
+import { he } from "date-fns/locale";
 import { API_ENDPOINTS, apiCall } from "../config/api";
 import "../styles/news-page.css";
-
 
 interface NewsItem {
   _id: string;
@@ -10,6 +11,7 @@ interface NewsItem {
   content: string;
   source?: string;
   tags?: string[];
+  imageUrl?: string;
   createdAt?: string;
 }
 
@@ -18,6 +20,7 @@ interface NewsFormState {
   content: string;
   source: string;
   tags: string;
+  imageUrl: string;
 }
 
 const initialFormState: NewsFormState = {
@@ -25,7 +28,39 @@ const initialFormState: NewsFormState = {
   content: "",
   source: "",
   tags: "",
+  imageUrl: "",
 };
+
+function formatRelativeTime(value?: string) {
+  if (!value) return "";
+  return formatDistanceToNow(new Date(value), { locale: he, addSuffix: true });
+}
+
+function SearchIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="11" cy="11" r="7" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  );
+}
+
+function SkeletonList({ count }: { count: number }) {
+  return (
+    <div className="news-skeleton-list">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="news-skeleton-row">
+          <div className="news-skeleton-image news-skeleton-shimmer" />
+          <div className="news-skeleton-body">
+            <div className="news-skeleton-line news-skeleton-shimmer short" />
+            <div className="news-skeleton-line news-skeleton-shimmer" />
+            <div className="news-skeleton-line news-skeleton-shimmer" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function AiNewsPage() {
   const [news, setNews] = useState<NewsItem[]>([]);
@@ -36,9 +71,12 @@ export default function AiNewsPage() {
   const [showForm, setShowForm] = useState(false);
   const [formData, setFormData] = useState<NewsFormState>(initialFormState);
   const [searchTerm, setSearchTerm] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<NewsItem | null>(null);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
+  const [uploadingImage, setUploadingImage] = useState(false);
+  const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
   const PAGE_LIMIT = 10;
 
   const user = JSON.parse(localStorage.getItem("user") || "null");
@@ -69,6 +107,7 @@ export default function AiNewsPage() {
     setFormData(initialFormState);
     setEditingId(null);
     setShowForm(false);
+    setSelectedFileName(null);
   };
 
   const handleStartCreate = () => {
@@ -76,6 +115,57 @@ export default function AiNewsPage() {
     setFormData(initialFormState);
     setShowForm(true);
     setError(null);
+    setSelectedFileName(null);
+  };
+
+  const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setSelectedFileName(file.name);
+
+    try {
+      setUploadingImage(true);
+      setError(null);
+
+      const urlResponse = await fetch(API_ENDPOINTS.upload.getUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fileName: file.name,
+          fileType: file.type,
+          fileSize: file.size,
+          context: "newsImage",
+        }),
+      });
+
+      if (!urlResponse.ok) {
+        const data = await urlResponse.json().catch(() => null);
+        throw new Error(data?.error || "נכשלה קבלת קישור מאובטח מהשרת");
+      }
+
+      const { uploadUrl, fileUrl } = await urlResponse.json();
+
+      const s3Response = await fetch(uploadUrl, {
+        method: "PUT",
+        headers: { "Content-Type": file.type },
+        body: file,
+      });
+
+      if (!s3Response.ok) throw new Error("העלאת התמונה נכשלה");
+
+      setFormData((prev) => ({ ...prev, imageUrl: fileUrl }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "שגיאה בהעלאת התמונה");
+    } finally {
+      setUploadingImage(false);
+      e.target.value = "";
+    }
+  };
+
+  const handleRemoveImage = () => {
+    setFormData((prev) => ({ ...prev, imageUrl: "" }));
+    setSelectedFileName(null);
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -95,25 +185,23 @@ export default function AiNewsPage() {
         .map((tag) => tag.trim())
         .filter(Boolean);
 
+      const payload = {
+        title: formData.title.trim(),
+        content: formData.content.trim(),
+        source: formData.source.trim() || "User",
+        tags: tagsArray,
+        imageUrl: formData.imageUrl || undefined,
+      };
+
       if (editingId) {
         await apiCall(`${API_ENDPOINTS.news}/${editingId}`, {
           method: "PUT",
-          body: JSON.stringify({
-            title: formData.title.trim(),
-            content: formData.content.trim(),
-            source: formData.source.trim() || "User",
-            tags: tagsArray,
-          }),
+          body: JSON.stringify(payload),
         });
       } else {
         await apiCall(API_ENDPOINTS.news, {
           method: "POST",
-          body: JSON.stringify({
-            title: formData.title.trim(),
-            content: formData.content.trim(),
-            source: formData.source.trim() || "User",
-            tags: tagsArray,
-          }),
+          body: JSON.stringify(payload),
         });
       }
 
@@ -133,9 +221,11 @@ export default function AiNewsPage() {
       content: item.content,
       source: item.source || "",
       tags: item.tags?.join(", ") || "",
+      imageUrl: item.imageUrl || "",
     });
     setShowForm(true);
     setError(null);
+    setSelectedFileName(null);
   };
 
   const openDeleteModal = (item: NewsItem) => {
@@ -168,43 +258,43 @@ export default function AiNewsPage() {
     }
   };
 
-  const filteredNews = news.filter((item) =>
-    item.title.toLowerCase().includes(searchTerm.toLowerCase().trim()),
-  );
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    news.forEach((item) => item.tags?.forEach((tag) => set.add(tag)));
+    return Array.from(set);
+  }, [news]);
 
-  if (loading) {
-    return (
-      <div className="news-loading-container">
-        <div className="news-loading-content">
-          <div className="news-spinner" />
-          <div className="news-loading-text">טוען חדשות...</div>
-        </div>
-      </div>
-    );
-  }
+  const filteredNews = news.filter((item) => {
+    const matchesSearch = item.title
+      .toLowerCase()
+      .includes(searchTerm.toLowerCase().trim());
+    const matchesTag = !activeTag || item.tags?.includes(activeTag);
+    return matchesSearch && matchesTag;
+  });
+
+  const [featured, ...rest] = filteredNews;
+  const showSkeleton = loading && news.length === 0;
 
   return (
-    <div className="news-page-container">
-      <div className="news-card-wrapper">
-        <div className="news-header-section">
-          <div className="news-header-content">
-            <h1 className="news-header-title">AI News</h1>
-            <p className="news-header-subtitle">
-              חדשות AI הכי חמות שיש!!!
-            </p>
+    <div className="news-page">
+      <header className="news-masthead">
+        <div className="news-masthead-inner">
+          <div className="news-brand">
+            <div className="news-brand-mark">AI</div>
+            <div className="news-brand-text">
+              <h1>AI News</h1>
+              <p>חדשות AI הכי חמות שיש</p>
+            </div>
           </div>
           {isAdmin && (
-            <button
-              type="button"
-              onClick={handleStartCreate}
-              className="btn-add-news"
-            >
-              הוספת חדשות
-            </button>)}
+            <button type="button" onClick={handleStartCreate} className="btn-add-news">
+              + הוספת חדשות
+            </button>
+          )}
         </div>
 
-        {!showForm && (
-          <div className="news-search-section">
+        <div className="news-toolbar">
+          <div className="news-search-wrap">
             <input
               type="text"
               value={searchTerm}
@@ -212,28 +302,160 @@ export default function AiNewsPage() {
               placeholder="חיפוש לפי כותרת"
               className="news-search-input"
             />
-            <div className="news-results-count">
-              {filteredNews.length} תוצאות
+            <span className="news-search-icon">
+              <SearchIcon />
+            </span>
+          </div>
+
+          {allTags.length > 0 && (
+            <div className="news-tag-filter">
+              <button
+                type="button"
+                onClick={() => setActiveTag(null)}
+                className={`news-tag-pill${activeTag === null ? " active" : ""}`}
+              >
+                הכל
+              </button>
+              {allTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => setActiveTag((prev) => (prev === tag ? null : tag))}
+                  className={`news-tag-pill${activeTag === tag ? " active" : ""}`}
+                >
+                  #{tag}
+                </button>
+              ))}
             </div>
-          </div>
-        )}
+          )}
+        </div>
+      </header>
 
-        {error && (
-          <div className="news-error-message">
-            {error}
-          </div>
-        )}
+      <main className="news-main">
+        {error && <div className="news-error-message">{error}</div>}
 
-        {showForm && (
-          <form
-            onSubmit={handleSubmit}
-            className="news-form-container"
+        {showSkeleton ? (
+          <SkeletonList count={7} />
+        ) : news.length === 0 ? (
+          <div className="news-empty">
+            <h3>אין חדשות עדיין</h3>
+            <p>ברגע שיתווספו חדשות הן יופיעו כאן</p>
+            {isAdmin && (
+              <button type="button" onClick={handleStartCreate} className="btn-add-news">
+                צור חדשות ראשונה
+              </button>
+            )}
+          </div>
+        ) : filteredNews.length === 0 ? (
+          <p className="news-empty-message">אין חדשות מתאימות.</p>
+        ) : (
+          <>
+            <div className="news-results-count">{filteredNews.length} תוצאות</div>
+
+            <div className="news-list">
+              {featured && (
+                <article className="news-list-row news-list-row--lead">
+                  <Link to={`/ai-news/${featured._id}`} className="news-list-image-link">
+                    {featured.imageUrl ? (
+                      <img src={featured.imageUrl} alt={featured.title} className="news-list-image" />
+                    ) : (
+                      <div className="news-list-image-placeholder">
+                        {featured.title.trim().charAt(0)}
+                      </div>
+                    )}
+                  </Link>
+                  <div className="news-list-body">
+                    <span className="news-lead-badge">הכתבה המובילה</span>
+                    {featured.tags?.[0] && <span className="news-card-eyebrow">#{featured.tags[0]}</span>}
+                    <Link to={`/ai-news/${featured._id}`} className="news-article-title">
+                      {featured.title}
+                    </Link>
+                    <p className="news-preview">{featured.content}</p>
+                    <div className="news-card-footer">
+                      <div className="news-item-meta">
+                        <span className="news-byline-source">{featured.source || "User"}</span>
+                        <span className="news-byline-dot">·</span>
+                        <span className="news-date">{formatRelativeTime(featured.createdAt)}</span>
+                      </div>
+                      {isAdmin && (
+                        <div className="news-card-actions">
+                          <button type="button" onClick={() => handleEdit(featured)} className="btn-edit">
+                            ערוך
+                          </button>
+                          <button type="button" onClick={() => openDeleteModal(featured)} className="btn-delete">
+                            מחק
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </article>
+              )}
+
+              {rest.map((item) => (
+                <article key={item._id} className="news-list-row">
+                  <Link to={`/ai-news/${item._id}`} className="news-list-image-link">
+                    {item.imageUrl ? (
+                      <img src={item.imageUrl} alt={item.title} className="news-list-image" />
+                    ) : (
+                      <div className="news-list-image-placeholder">
+                        {item.title.trim().charAt(0)}
+                      </div>
+                    )}
+                  </Link>
+                  <div className="news-list-body">
+                    {item.tags?.[0] && <span className="news-card-eyebrow">#{item.tags[0]}</span>}
+                    <Link to={`/ai-news/${item._id}`} className="news-article-title">
+                      {item.title}
+                    </Link>
+                    <p className="news-preview">{item.content}</p>
+                    <div className="news-card-footer">
+                      <div className="news-item-meta">
+                        <span className="news-byline-source">{item.source || "User"}</span>
+                        <span className="news-byline-dot">·</span>
+                        <span className="news-date">{formatRelativeTime(item.createdAt)}</span>
+                      </div>
+                      {isAdmin && (
+                        <div className="news-card-actions">
+                          <button type="button" onClick={() => handleEdit(item)} className="btn-edit">
+                            ערוך
+                          </button>
+                          <button type="button" onClick={() => openDeleteModal(item)} className="btn-delete">
+                            מחק
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+
+            {hasMore && (
+              <div className="load-more-wrapper">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={loading}
+                  className="load-more-btn"
+                >
+                  {loading ? "טוען..." : "טען עוד"}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+
+      {showForm && (
+        <div className="modal-overlay" onClick={resetForm}>
+          <div
+            className="modal-content news-form-modal"
+            onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="news-form-title">
-              {editingId ? "עריכת חדשות" : "יצירת חדשות"}
-            </h3>
+            <h3 className="news-form-title">{editingId ? "עריכת חדשות" : "יצירת חדשות"}</h3>
 
-            <div className="news-form-inputs">
+            <form onSubmit={handleSubmit} className="news-form-inputs">
               <input
                 type="text"
                 placeholder="כותרת"
@@ -243,7 +465,7 @@ export default function AiNewsPage() {
               />
 
               <textarea
-                placeholder="תוכן"
+                placeholder="תוכן (נתמכת כתיבה במארקדאון - Markdown)"
                 value={formData.content}
                 onChange={(e) => setFormData({ ...formData, content: e.target.value })}
                 rows={6}
@@ -266,139 +488,62 @@ export default function AiNewsPage() {
                 className="news-input-field"
               />
 
+              <div className="news-image-upload">
+                {formData.imageUrl ? (
+                  <div className="news-image-preview-wrapper">
+                    <img src={formData.imageUrl} alt="תצוגה מקדימה" className="news-image-preview" />
+                    <button type="button" onClick={handleRemoveImage} className="btn-reset">
+                      הסר תמונה
+                    </button>
+                  </div>
+                ) : (
+                  <label
+                    htmlFor="news-image-file-input"
+                    className={`news-file-field${uploadingImage ? " is-disabled" : ""}`}
+                  >
+                    <input
+                      id="news-image-file-input"
+                      type="file"
+                      accept="image/png, image/jpeg, image/webp, image/gif"
+                      onChange={handleImageChange}
+                      disabled={uploadingImage}
+                      aria-label="בחירת תמונה לכתבה"
+                      className="news-file-input-hidden"
+                    />
+                    <span className="news-file-button">בחירת קובץ</span>
+                    <span className="news-file-name">
+                      {selectedFileName || "לא נבחר קובץ"}
+                    </span>
+                  </label>
+                )}
+                {uploadingImage && <span className="news-upload-status">מעלה תמונה...</span>}
+              </div>
+
               <div className="news-form-buttons">
-                <button
-                  type="submit"
-                  disabled={submitting}
-                  className="btn-submit"
-                >
+                <button type="submit" disabled={submitting || uploadingImage} className="btn-submit">
                   {submitting ? "שומר..." : editingId ? "עדכון" : "שמירה"}
                 </button>
-                <button
-                  type="button"
-                  onClick={resetForm}
-                  className="btn-reset"
-                >
-                  איפוס
+                <button type="button" onClick={resetForm} className="btn-reset">
+                  ביטול
                 </button>
               </div>
-            </div>
-          </form>
-        )}
-
-        {!showForm && (
-          news.length === 0 ? (
-            <div className="news-empty">
-              <h3>אין חדשות עדיין</h3>
-              <p>ברגע שיתווספו חדשות הן יופיעו כאן</p>
-              {isAdmin && (
-                <button
-                  type="button"
-                  onClick={handleStartCreate}
-                  className="btn-add-news"
-                >
-                  צור חדשות ראשונה
-                </button>
-              )}
-            </div>
-          ) : filteredNews.length === 0 ? (
-            <p className="news-empty-message">אין חדשות מתאימות.</p>
-          ) : (
-            <>
-              <div className="news-grid">
-                {filteredNews.map((item) => (
-                  <article
-                    key={item._id}
-                    className="news-article-card"
-                  >
-                    <div className="news-article-header">
-                      <div>
-                        <Link to={`/ai-news/${item._id}`} className="news-article-title">
-                          {item.title}
-                        </Link>
-                        <div className="news-item-meta">
-                          <span className="news-date">
-                            {new Date(item.createdAt || "").toLocaleDateString("he-IL", {
-                              year: "numeric",
-                              month: "long",
-                              day: "numeric",
-                            })}
-                          </span>
-                        </div>
-                        {item.tags?.length ? (
-                          <div className="news-tag-list">
-                            {item.tags.map((tag) => (
-                              <span key={tag} className="news-tag">
-                                #{tag}
-                              </span>
-                            ))}
-                          </div>
-                        ) : null}
-                      </div>
-                      <div className="news-article-actions">
-                          {isAdmin && (
-                        <button
-                          type="button"
-                          onClick={() => handleEdit(item)}
-                          className="btn-edit"
-                        >
-                          ערוך
-                        </button>)}
-                          {isAdmin && (
-                        <button
-                          type="button"
-                          onClick={() => openDeleteModal(item)}
-                          className="btn-delete"
-                        >
-                          מחק
-                        </button>)}
-                      </div>
-                    </div>
-                    <p className="news-preview">
-                      {item.content.length > 120
-                        ? item.content.slice(0, 120) + "..."
-                        : item.content}
-                    </p>
-                  </article>
-                ))}
-              </div>
-              {hasMore && (
-                <div className="load-more-wrapper">
-                  <button
-                    type="button"
-                    onClick={() => setPage((p) => p + 1)}
-                    className="load-more-btn"
-                  >
-                    טען עוד
-                  </button>
-                </div>
-              )}
-            </>
-          )
-        )}
-      </div>
+            </form>
+          </div>
+        </div>
+      )}
 
       {deleteTarget && (
-        <div className="modal-overlay">
-          <div className="modal-content">
+        <div className="modal-overlay" onClick={cancelDelete}>
+          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
             <h2 className="modal-title">אישור מחיקה</h2>
             <p className="modal-message">
               האם אתה בטוח שברצונך למחוק את הפריט "{deleteTarget.title}"?
             </p>
             <div className="modal-buttons">
-              <button
-                type="button"
-                onClick={cancelDelete}
-                className="btn-cancel"
-              >
+              <button type="button" onClick={cancelDelete} className="btn-cancel">
                 לא
               </button>
-              <button
-                type="button"
-                onClick={confirmDelete}
-                disabled={submitting}
-                className="btn-confirm-delete"
-              >
+              <button type="button" onClick={confirmDelete} disabled={submitting} className="btn-confirm-delete">
                 כן
               </button>
             </div>

--- a/apps/client/src/pages/AiNewsPage.tsx
+++ b/apps/client/src/pages/AiNewsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from "react";
 import { Link } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import { he } from "date-fns/locale";
@@ -19,7 +19,7 @@ interface NewsFormState {
   title: string;
   content: string;
   source: string;
-  tags: string;
+  tags: string[];
   imageUrl: string;
 }
 
@@ -27,13 +27,79 @@ const initialFormState: NewsFormState = {
   title: "",
   content: "",
   source: "",
-  tags: "",
+  tags: [],
   imageUrl: "",
 };
 
 function formatRelativeTime(value?: string) {
   if (!value) return "";
   return formatDistanceToNow(new Date(value), { locale: he, addSuffix: true });
+}
+
+// מילות קישור נפוצות בעברית ובאנגלית - לא מוצעות כתגיות מוצע מילות מפתח
+const STOPWORDS = new Set([
+  "של", "את", "עם", "על", "אל", "כי", "גם", "רק", "לא", "כן", "יש", "אין",
+  "הוא", "היא", "הם", "הן", "אני", "אתה", "את", "אנחנו", "אתם", "אתן",
+  "זה", "זאת", "זו", "אלה", "אלו", "אבל", "או", "אם", "כל", "כמה", "עוד",
+  "כבר", "פה", "שם", "כאן", "הזה", "הזאת", "מה", "מי", "איך", "למה", "מתי",
+  "כאשר", "כדי", "היה", "היתה", "יהיה", "תהיה", "ולא", "וגם", "ואת",
+  "the", "a", "an", "and", "or", "but", "is", "are", "was", "were", "in",
+  "on", "at", "to", "for", "of", "with", "this", "that", "these", "those",
+  "it", "as", "be", "by", "from", "will", "can", "not",
+]);
+
+function tokenize(text: string): string[] {
+  return text.split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+}
+
+// מילות חיבור עבריות (ו-, ה-, ב-, ל-, כ-, מ-, ש-) נדבקות ישירות למילה
+// שאחריהן בלי רווח, למשל "וטכנולוגיה". בודקים אם הסרת אות מוביל אחת
+// הופכת את המילה לתגית שכבר מוכרת - כדי לא להציע גם את הגרסה עם המילית
+// וגם את המילה עצמה כשתי הצעות נפרדות. לעולם לא מציגים את הצורה המקוצרת
+// עצמה (זו לא בהכרח מילה תקנית), רק משתמשים בה לבדיקת כפילות.
+function isPrefixedKnownTag(word: string, knownLower: Set<string>): boolean {
+  if (word.length <= 3 || !"והבלכמש".includes(word[0])) return false;
+  return knownLower.has(word.slice(1));
+}
+
+// הצעה בסיסית של תגיות: תגיות קיימות שמופיעות בתוכן, ומילים חוזרות
+// (2+ הופעות) שאינן מילות קישור ואינן כבר בשימוש
+function getSuggestedTags(
+  title: string,
+  content: string,
+  selectedTags: string[],
+  existingTags: string[],
+): string[] {
+  const text = `${title} ${content}`;
+  const normalizedText = text.toLowerCase();
+  const selectedLower = new Set(selectedTags.map((t) => t.toLowerCase()));
+  const existingLower = new Set(existingTags.map((t) => t.toLowerCase()));
+  const knownLower = new Set([...selectedLower, ...existingLower]);
+
+  const fromExisting = existingTags.filter((tag) => {
+    const lower = tag.toLowerCase();
+    return !selectedLower.has(lower) && normalizedText.includes(lower);
+  });
+
+  const counts = new Map<string, number>();
+  for (const raw of tokenize(text)) {
+    const word = raw.toLowerCase();
+    if (
+      word.length < 2 ||
+      STOPWORDS.has(word) ||
+      knownLower.has(word) ||
+      isPrefixedKnownTag(word, knownLower)
+    ) {
+      continue;
+    }
+    counts.set(word, (counts.get(word) || 0) + 1);
+  }
+  const fromFrequency = Array.from(counts.entries())
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1])
+    .map(([word]) => word);
+
+  return Array.from(new Set([...fromExisting, ...fromFrequency])).slice(0, 6);
 }
 
 function SearchIcon() {
@@ -77,6 +143,8 @@ export default function AiNewsPage() {
   const [hasMore, setHasMore] = useState(true);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [selectedFileName, setSelectedFileName] = useState<string | null>(null);
+  const [allExistingTags, setAllExistingTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState("");
   const PAGE_LIMIT = 10;
 
   const user = JSON.parse(localStorage.getItem("user") || "null");
@@ -85,6 +153,20 @@ export default function AiNewsPage() {
   useEffect(() => {
     void loadNews(page);
   }, [page]);
+
+  useEffect(() => {
+    void loadAllTags();
+  }, []);
+
+  const loadAllTags = async () => {
+    try {
+      const tags = await apiCall<string[]>(`${API_ENDPOINTS.news}/tags`);
+      setAllExistingTags(tags);
+    } catch {
+      // תגיות קיימות הן נוחות בלבד (autocomplete) - כשל בטעינתן לא אמור
+      // לחסום את שאר העמוד
+    }
+  };
 
   const loadNews = async (pageNumber = 1) => {
     try {
@@ -108,6 +190,7 @@ export default function AiNewsPage() {
     setEditingId(null);
     setShowForm(false);
     setSelectedFileName(null);
+    setTagInput("");
   };
 
   const handleStartCreate = () => {
@@ -116,6 +199,31 @@ export default function AiNewsPage() {
     setShowForm(true);
     setError(null);
     setSelectedFileName(null);
+    setTagInput("");
+  };
+
+  const addTag = (raw: string) => {
+    const value = raw.trim();
+    if (!value) return;
+    setFormData((prev) =>
+      prev.tags.some((t) => t.toLowerCase() === value.toLowerCase())
+        ? prev
+        : { ...prev, tags: [...prev.tags, value] },
+    );
+    setTagInput("");
+  };
+
+  const removeTag = (tag: string) => {
+    setFormData((prev) => ({ ...prev, tags: prev.tags.filter((t) => t !== tag) }));
+  };
+
+  const handleTagInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addTag(tagInput);
+    } else if (e.key === "Backspace" && !tagInput && formData.tags.length > 0) {
+      removeTag(formData.tags[formData.tags.length - 1]);
+    }
   };
 
   const handleImageChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -180,16 +288,11 @@ export default function AiNewsPage() {
       setSubmitting(true);
       setError(null);
 
-      const tagsArray = formData.tags
-        .split(",")
-        .map((tag) => tag.trim())
-        .filter(Boolean);
-
       const payload = {
         title: formData.title.trim(),
         content: formData.content.trim(),
         source: formData.source.trim() || "User",
-        tags: tagsArray,
+        tags: formData.tags,
         imageUrl: formData.imageUrl || undefined,
       };
 
@@ -206,6 +309,7 @@ export default function AiNewsPage() {
       }
 
       await loadNews();
+      void loadAllTags();
       resetForm();
     } catch (err) {
       setError(err instanceof Error ? err.message : "שגיאה בשמירת החדשות");
@@ -220,12 +324,13 @@ export default function AiNewsPage() {
       title: item.title,
       content: item.content,
       source: item.source || "",
-      tags: item.tags?.join(", ") || "",
+      tags: item.tags || [],
       imageUrl: item.imageUrl || "",
     });
     setShowForm(true);
     setError(null);
     setSelectedFileName(null);
+    setTagInput("");
   };
 
   const openDeleteModal = (item: NewsItem) => {
@@ -258,11 +363,19 @@ export default function AiNewsPage() {
     }
   };
 
-  const allTags = useMemo(() => {
-    const set = new Set<string>();
-    news.forEach((item) => item.tags?.forEach((tag) => set.add(tag)));
-    return Array.from(set);
-  }, [news]);
+  const tagAutocompleteMatches = useMemo(() => {
+    const query = tagInput.trim().toLowerCase();
+    if (!query) return [];
+    const selectedLower = new Set(formData.tags.map((t) => t.toLowerCase()));
+    return allExistingTags
+      .filter((tag) => !selectedLower.has(tag.toLowerCase()) && tag.toLowerCase().includes(query))
+      .slice(0, 8);
+  }, [tagInput, allExistingTags, formData.tags]);
+
+  const keywordTagSuggestions = useMemo(
+    () => getSuggestedTags(formData.title, formData.content, formData.tags, allExistingTags),
+    [formData.title, formData.content, formData.tags, allExistingTags],
+  );
 
   const filteredNews = news.filter((item) => {
     const matchesSearch = item.title
@@ -307,7 +420,7 @@ export default function AiNewsPage() {
             </span>
           </div>
 
-          {allTags.length > 0 && (
+          {allExistingTags.length > 0 && (
             <div className="news-tag-filter">
               <button
                 type="button"
@@ -316,7 +429,7 @@ export default function AiNewsPage() {
               >
                 הכל
               </button>
-              {allTags.map((tag) => (
+              {allExistingTags.map((tag) => (
                 <button
                   key={tag}
                   type="button"
@@ -480,13 +593,69 @@ export default function AiNewsPage() {
                 className="news-input-field"
               />
 
-              <input
-                type="text"
-                placeholder="תגיות (מופרדות בפסיק)"
-                value={formData.tags}
-                onChange={(e) => setFormData({ ...formData, tags: e.target.value })}
-                className="news-input-field"
-              />
+              <div className="news-tags-field">
+                <div className="news-tags-chips">
+                  {formData.tags.map((tag) => (
+                    <span key={tag} className="news-tag-chip">
+                      {tag}
+                      <button
+                        type="button"
+                        onClick={() => removeTag(tag)}
+                        aria-label={`הסר תגית ${tag}`}
+                        className="news-tag-chip-remove"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  ))}
+                  <input
+                    type="text"
+                    value={tagInput}
+                    onChange={(e) => setTagInput(e.target.value)}
+                    onKeyDown={handleTagInputKeyDown}
+                    placeholder={formData.tags.length ? "" : "הקלד תגית ולחץ Enter"}
+                    className="news-tags-input"
+                    role="combobox"
+                    aria-expanded={tagAutocompleteMatches.length > 0}
+                    aria-autocomplete="list"
+                    aria-controls="news-tag-suggestions-list"
+                  />
+                </div>
+
+                {tagAutocompleteMatches.length > 0 && (
+                  <ul id="news-tag-suggestions-list" className="news-tag-suggestions" role="listbox">
+                    {tagAutocompleteMatches.map((tag) => (
+                      <li key={tag}>
+                        <button
+                          type="button"
+                          onClick={() => addTag(tag)}
+                          className="news-tag-suggestion-item"
+                          role="option"
+                          aria-selected={false}
+                        >
+                          #{tag}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {!tagInput && keywordTagSuggestions.length > 0 && (
+                  <div className="news-tag-keyword-suggestions">
+                    <span className="news-tag-keyword-label">הצעות תגיות לפי התוכן:</span>
+                    {keywordTagSuggestions.map((tag) => (
+                      <button
+                        key={tag}
+                        type="button"
+                        onClick={() => addTag(tag)}
+                        className="news-tag-suggestion-chip"
+                      >
+                        + {tag}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
 
               <div className="news-image-upload">
                 {formData.imageUrl ? (

--- a/apps/client/src/pages/AiNewsPage.tsx
+++ b/apps/client/src/pages/AiNewsPage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { formatDistanceToNow } from "date-fns";
 import { he } from "date-fns/locale";
 import { API_ENDPOINTS, apiCall } from "../config/api";
+import { stripMarkdown } from "../utils/markdown";
 import "../styles/news-page.css";
 
 interface NewsItem {
@@ -483,7 +484,7 @@ export default function AiNewsPage() {
                     <Link to={`/ai-news/${featured._id}`} className="news-article-title">
                       {featured.title}
                     </Link>
-                    <p className="news-preview">{featured.content}</p>
+                    <p className="news-preview">{stripMarkdown(featured.content)}</p>
                     <div className="news-card-footer">
                       <div className="news-item-meta">
                         <span className="news-byline-source">{featured.source || "User"}</span>
@@ -521,7 +522,7 @@ export default function AiNewsPage() {
                     <Link to={`/ai-news/${item._id}`} className="news-article-title">
                       {item.title}
                     </Link>
-                    <p className="news-preview">{item.content}</p>
+                    <p className="news-preview">{stripMarkdown(item.content)}</p>
                     <div className="news-card-footer">
                       <div className="news-item-meta">
                         <span className="news-byline-source">{item.source || "User"}</span>

--- a/apps/client/src/styles/news-page.css
+++ b/apps/client/src/styles/news-page.css
@@ -704,6 +704,138 @@
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--news-accent) 15%, transparent);
 }
 
+/* Smart tags: chip input + autocomplete + keyword suggestions */
+.news-tags-field {
+  position: relative;
+}
+
+.news-tags-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  min-height: 2.7rem;
+  box-sizing: border-box;
+  transition: all 0.15s ease;
+}
+
+.news-tags-chips:focus-within {
+  border-color: var(--news-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--news-accent) 15%, transparent);
+}
+
+.news-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.4rem 0.25rem 0.55rem;
+  background: color-mix(in srgb, var(--news-accent) 12%, white);
+  color: var(--news-accent-dark);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.news-tag-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.news-tag-chip-remove:hover {
+  background: color-mix(in srgb, var(--news-accent) 25%, white);
+}
+
+.news-tags-input {
+  flex: 1;
+  min-width: 100px;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 0.9rem;
+  font-family: inherit;
+  color: #111827;
+  padding: 0.25rem 0;
+}
+
+.news-tag-suggestions {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.35rem);
+  right: 0;
+  left: 0;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  background: #ffffff;
+  border: 1px solid var(--news-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.news-tag-suggestion-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-family: inherit;
+  color: #111827;
+}
+
+.news-tag-suggestion-item:hover {
+  background: var(--news-bg-subtle);
+}
+
+.news-tag-keyword-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.news-tag-keyword-label {
+  font-size: 0.8rem;
+  color: var(--news-fg-muted);
+}
+
+.news-tag-suggestion-chip {
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  border: 1px dashed var(--news-border);
+  background: transparent;
+  color: var(--news-fg-muted);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.news-tag-suggestion-chip:hover {
+  border-color: var(--news-accent);
+  color: var(--news-accent);
+}
+
 .news-form-buttons {
   display: flex;
   flex-wrap: wrap;

--- a/apps/client/src/styles/news-page.css
+++ b/apps/client/src/styles/news-page.css
@@ -1080,21 +1080,6 @@
   color: var(--news-fg-muted);
 }
 
-.news-details-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-top: 2.5rem;
-  padding-top: 1.75rem;
-  border-top: 1px solid var(--news-border);
-}
-
-.news-details-footer .btn-reset {
-  margin: 0;
-}
-
 /* ===== Loading / error states ===== */
 .news-loading-container {
   min-height: 100vh;

--- a/apps/client/src/styles/news-page.css
+++ b/apps/client/src/styles/news-page.css
@@ -1,399 +1,600 @@
-/* Loading state container */
-.news-loading-container {
+@import url('https://fonts.googleapis.com/css2?family=Heebo:wght@400;500;600;700;800;900&display=swap');
+
+.news-page {
+  --news-fg: #111827;
+  --news-fg-muted: #6b7280;
+  --news-fg-subtle: #9ca3af;
+  --news-border: #e5e7eb;
+  --news-bg: #ffffff;
+  --news-bg-subtle: #f9fafb;
+  /* --primary-color / --primary-hover are the project's brand tokens,
+     defined in styles/tender-board-page.css and already reused site-wide
+     (top nav, footer, landing page, etc). Reused here, not redefined. */
+  --news-accent: var(--primary-color, #10a37f);
+  --news-accent-dark: var(--primary-hover, #0f9c6b);
+  --news-danger: #dc2626;
+  --news-radius: 10px;
+
   min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: #f8fafc;
-  padding: 2rem;
+  background: var(--news-bg);
+  color: var(--news-fg);
+  font-family: "Heebo", system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
-.news-loading-content {
-  text-align: center;
+.news-page * {
+  box-sizing: border-box;
 }
 
-.news-spinner {
-  width: 72px;
-  height: 72px;
-  margin: 0 auto 1rem;
-  border: 8px solid rgba(15, 23, 42, 0.15);
-  border-top-color: #2563eb;
-  border-radius: 50%;
-  animation: spin 1s linear infinite;
+/* ===== Masthead ===== */
+.news-masthead {
+  border-bottom: 1px solid var(--news-border);
+  background: var(--news-bg);
 }
 
-@keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
-.news-loading-text {
-  color: #334155;
-  font-size: 1rem;
-}
-
-/* Main page container */
-.news-page-container {
-  padding: 2rem 1rem;
-  max-width: 980px;
+.news-masthead-inner {
+  max-width: 1180px;
   margin: 0 auto;
-  background: #f8fafc;
-}
-
-/* Main card wrapper */
-.news-card-wrapper {
-  background: #ffffff;
-  border-radius: 28px;
-  box-shadow: 0 28px 90px rgba(15, 23, 42, 0.12);
-  padding: 2rem;
-  border: 1px solid #e2e8f0;
-}
-
-/* Header section */
-.news-header-section {
+  padding: 2rem 1.5rem 1.5rem;
   display: flex;
+  align-items: flex-start;
   justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.news-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.news-brand-mark {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--news-accent);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: -0.02em;
+}
+
+.news-brand-text h1 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--news-fg);
+}
+
+.news-brand-text p {
+  margin: 0.15rem 0 0;
+  color: var(--news-fg-muted);
+  font-size: 0.9rem;
+}
+
+.news-toolbar {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 1.5rem 1.25rem;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 1.75rem;
-  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
-.news-header-content {
-  min-width: 0;
+.news-search-wrap {
+  position: relative;
+  min-width: 240px;
+  flex: 1;
+  max-width: 360px;
 }
 
-.news-item-meta {
+.news-search-icon {
+  position: absolute;
+  top: 50%;
+  right: 0.85rem;
+  transform: translateY(-50%);
+  color: var(--news-fg-subtle);
+  pointer-events: none;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  color: #64748b;
-  font-size: 0.95rem;
-  margin-top: 0.5rem;
-}
-
-.news-date {
-  font-weight: 600;
-  color: #475569;
-}
-
-.news-header-title {
-  margin: 0;
-  font-size: 2rem;
-  color: #111827;
-}
-
-.news-header-subtitle {
-  margin: 0.75rem 0 0;
-  color: #64748b;
-  font-size: 0.95rem;
-}
-
-/* Add news button */
-.btn-add-news {
-  background: #14b8a6;
-  color: #ffffff;
-  border: none;
-  border-radius: 16px;
-  padding: 0.95rem 1.5rem;
-  font-weight: 700;
-  box-shadow: 0 16px 40px rgba(20, 184, 166, 0.2);
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.btn-add-news:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 50px rgba(20, 184, 166, 0.3);
-}
-
-.btn-add-news:active {
-  transform: translateY(0);
-}
-
-/* Search section */
-.news-search-section {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 1.5rem;
-  align-items: center;
 }
 
 .news-search-input {
-  flex: 1;
-  min-width: 240px;
-  padding: 0.95rem 1rem;
-  border-radius: 16px;
-  border: 1px solid #cbd5e1;
-  background: #f8fafc;
-  color: #111827;
-  font-size: 1rem;
-  transition: all 0.2s ease;
+  width: 100%;
+  padding: 0.6rem 2.4rem 0.6rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--news-border);
+  background: var(--news-bg-subtle);
+  color: var(--news-fg);
+  font-size: 0.9rem;
+  font-family: inherit;
+  transition: all 0.15s ease;
 }
 
 .news-search-input:focus {
   outline: none;
-  border-color: #2563eb;
-  background: #ffffff;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  border-color: var(--news-accent);
+  background: var(--news-bg);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--news-accent) 15%, transparent);
+}
+
+.news-tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.news-tag-pill {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--news-border);
+  background: var(--news-bg);
+  color: var(--news-fg-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.news-tag-pill:hover {
+  border-color: var(--news-accent);
+  color: var(--news-accent);
+}
+
+.news-tag-pill.active {
+  background: var(--news-accent);
+  border-color: var(--news-accent);
+  color: #fff;
+}
+
+/* ===== Add news button ===== */
+.btn-add-news {
+  background: var(--news-accent);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.3rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  white-space: nowrap;
+}
+
+.btn-add-news:hover {
+  background: var(--news-accent-dark);
+}
+
+/* ===== Main content ===== */
+.news-main {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.news-error-message {
+  margin-bottom: 1.5rem;
+  color: #991b1b;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: var(--news-radius);
+  padding: 0.9rem 1.1rem;
+  font-size: 0.9rem;
 }
 
 .news-results-count {
-  color: #64748b;
-  font-size: 0.95rem;
+  color: var(--news-fg-subtle);
+  font-size: 0.85rem;
+  margin: -1rem 0 1.5rem;
 }
 
-/* Error message */
-.news-error-message {
-  margin-bottom: 1.5rem;
-  color: #b91c1c;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 16px;
-  padding: 1rem 1.25rem;
-  animation: slideDown 0.3s ease;
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-/* Form container */
-.news-form-container {
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  border-radius: 24px;
-  padding: 1.75rem;
-  margin-bottom: 2rem;
-}
-
-.news-form-title {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  color: #111827;
-  font-size: 1.2rem;
-}
-
-.news-form-inputs {
-  display: grid;
-  gap: 1rem;
-}
-
-.news-input-field {
-  padding: 1rem 1rem;
-  width: 100%;
-  border-radius: 16px;
-  border: 1px solid #cbd5e1;
-  background: #ffffff;
-  color: #111827;
-  box-sizing: border-box;
-  font-size: 1rem;
-  font-family: inherit;
-  transition: all 0.2s ease;
-}
-
-.news-input-field:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-.news-textarea {
-  padding: 1rem 1rem;
-  width: 100%;
-  border-radius: 16px;
-  border: 1px solid #cbd5e1;
-  background: #ffffff;
-  color: #111827;
-  resize: vertical;
-  min-height: 160px;
-  box-sizing: border-box;
-  font-size: 1rem;
-  font-family: inherit;
-  transition: all 0.2s ease;
-}
-
-.news-textarea:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-/* Form buttons */
-.news-form-buttons {
+/* ===== Meta / tags shared ===== */
+.news-item-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--news-fg-subtle);
+  font-size: 0.85rem;
 }
 
-.btn-submit {
-  background: #2563eb;
-  color: #ffffff;
-  border: none;
-  border-radius: 16px;
-  padding: 0.95rem 1.4rem;
+.news-date {
+  font-weight: 500;
+  color: var(--news-fg-subtle);
+}
+
+.news-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.75rem;
+}
+
+.news-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  background: var(--news-bg-subtle);
+  color: var(--news-fg-muted);
+  border: 1px solid var(--news-border);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+/* ===== Compact article list ===== */
+.news-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.news-list-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  padding: 1.4rem 0;
+  border-bottom: 1px solid var(--news-border);
+  max-width: 100%;
+}
+
+.news-list-row:last-child {
+  border-bottom: none;
+}
+
+/* Lead (top) story - same column widths as every other row, distinguished
+   only by typography + a small accent-colored badge, so alignment stays
+   consistent across the whole list. */
+.news-list-row--lead .news-article-title {
+  font-size: 1.4rem;
+  -webkit-line-clamp: 3;
+}
+
+.news-list-row--lead .news-preview {
+  font-size: 0.95rem;
+  -webkit-line-clamp: 3;
+}
+
+.news-lead-badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--news-accent);
+  color: #fff;
+  font-size: 0.68rem;
   font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.news-list-image-link {
+  display: block;
+  flex-shrink: 0;
+  width: 220px;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--news-radius);
+  overflow: hidden;
+  background: var(--news-bg-subtle);
+}
+
+.news-list-image,
+.news-list-image-placeholder {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.35s ease;
+}
+
+.news-list-row:hover .news-list-image {
+  transform: scale(1.04);
+}
+
+.news-list-image-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #e5e7eb, #f3f4f6);
+  color: #cbd5e1;
+  font-size: 1.8rem;
+  font-weight: 800;
+}
+
+.news-list-body {
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.news-card-eyebrow {
+  align-self: flex-start;
+  color: var(--news-accent);
+  font-weight: 700;
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 0.35rem;
+}
+
+.news-article-title {
+  color: var(--news-fg);
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.4;
+  text-decoration: none;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.news-article-title:hover {
+  color: var(--news-accent);
+}
+
+.news-preview {
+  margin: 0.4rem 0 0;
+  max-width: 100%;
+  color: var(--news-fg-muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.news-card-footer {
+  margin-top: 0.6rem;
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.news-card-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+/* ===== Buttons ===== */
+.btn-edit,
+.btn-delete {
+  background: transparent;
+  border: none;
+  padding: 0.3rem 0.55rem;
+  border-radius: 6px;
   cursor: pointer;
-  transition: all 0.3s ease;
+  font-size: 0.78rem;
+  font-weight: 600;
+  transition: all 0.15s ease;
 }
 
-.btn-submit:hover:not(:disabled) {
-  background: #1d4ed8;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3);
+.btn-edit {
+  color: var(--news-fg-muted);
 }
 
-.btn-submit:disabled {
-  opacity: 0.7;
-  cursor: not-allowed;
+.btn-edit:hover {
+  background: var(--news-bg-subtle);
+  color: var(--news-fg);
+}
+
+.btn-delete {
+  color: var(--news-danger);
+}
+
+.btn-delete:hover {
+  background: #fef2f2;
 }
 
 .btn-reset {
   background: #ffffff;
-  color: #334155;
-  border: 1px solid #cbd5e1;
-  border-radius: 16px;
-  padding: 0.95rem 1.4rem;
+  color: var(--news-fg-muted);
+  border: 1px solid var(--news-border);
+  border-radius: 999px;
+  padding: 0.7rem 1.2rem;
   cursor: pointer;
-  transition: all 0.2s ease;
-  font-weight: 500;
+  transition: all 0.15s ease;
+  font-weight: 600;
+  font-size: 0.88rem;
 }
 
 .btn-reset:hover {
-  background: #f8fafc;
-  border-color: #94a3b8;
+  background: var(--news-bg-subtle);
+  border-color: #cbd5e1;
 }
 
-/* News grid */
-.news-grid {
-  display: grid;
-  gap: 1rem;
+.btn-submit {
+  background: var(--news-accent);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.7rem 1.3rem;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
 }
 
-.news-empty-message {
-  margin: 0;
-  color: #475569;
-  font-size: 1rem;
+.btn-submit:hover:not(:disabled) {
+  background: var(--news-accent-dark);
 }
 
-/* News article card */
-.news-article-card {
+.btn-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-cancel {
   background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 24px;
-  padding: 1.6rem;
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
-  transition: all 0.3s ease;
+  color: var(--news-fg-muted);
+  border: 1px solid var(--news-border);
+  border-radius: 999px;
+  padding: 0.75rem 1.2rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-weight: 600;
 }
 
-.news-article-card:hover {
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
-  transform: translateY(-2px);
+.btn-cancel:hover {
+  background: var(--news-bg-subtle);
 }
 
-.news-article-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.news-article-title {
-  margin: 0;
-  color: #111827;
-  font-size: 1.1rem;
+.btn-confirm-delete {
+  background: var(--news-danger);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.2rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
   font-weight: 700;
 }
 
-.news-article-source {
-  color: #64748b;
-  font-size: 0.85rem;
-  margin-top: 0.25rem;
+.btn-confirm-delete:hover:not(:disabled) {
+  background: #b91c1c;
 }
 
-.news-article-actions {
+.btn-confirm-delete:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.load-more-wrapper {
+  margin-top: 2.5rem;
   display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+  justify-content: center;
 }
 
-/* Article action buttons */
-.btn-edit {
-  background: #f8fafc;
-  color: #0f172a;
-  border: 1px solid #cbd5e1;
-  border-radius: 16px;
-  padding: 0.75rem 1rem;
+.load-more-btn {
+  background: #ffffff;
+  color: var(--news-fg);
+  border: 1px solid var(--news-border);
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 700;
+  font-size: 0.9rem;
   cursor: pointer;
-  transition: all 0.2s ease;
-  font-weight: 500;
+  transition: all 0.15s ease;
 }
 
-.btn-edit:hover {
-  background: #e2e8f0;
-  border-color: #94a3b8;
+.load-more-btn:hover {
+  border-color: var(--news-fg);
 }
 
-.btn-delete {
-  background: #ef4444;
-  color: #ffffff;
-  border: none;
-  border-radius: 16px;
-  padding: 0.75rem 1rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-weight: 500;
+/* ===== Empty state ===== */
+.news-empty {
+  padding: 4rem 2rem;
+  border: 1px dashed var(--news-border);
+  border-radius: var(--news-radius);
+  background: var(--news-bg-subtle);
+  text-align: center;
 }
 
-.btn-delete:hover {
-  background: #dc2626;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+.news-empty h3 {
+  margin: 0 0 0.5rem;
+  color: var(--news-fg);
+  font-size: 1.1rem;
 }
 
-.news-article-content {
-  margin: 1rem 0 0;
-  color: #475569;
-  line-height: 1.75;
+.news-empty p {
+  margin: 0 0 1.25rem;
+  color: var(--news-fg-muted);
+  font-size: 0.9rem;
 }
 
-.news-details-footer {
+.news-empty .btn-add-news {
+  margin: 0 auto;
+}
+
+.news-empty-message {
+  margin: 3rem 0;
+  color: var(--news-fg-muted);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+/* ===== Skeleton loading ===== */
+.news-skeleton-list {
   display: flex;
-  justify-content: flex-end;
-  margin-top: 1.5rem;
+  flex-direction: column;
 }
 
-.news-details-footer .btn-reset {
-  margin: 0;
+.news-skeleton-row {
+  display: flex;
+  gap: 1.25rem;
+  padding: 1.4rem 0;
+  border-bottom: 1px solid var(--news-border);
 }
 
-/* Delete modal */
+.news-skeleton-row .news-skeleton-image {
+  flex-shrink: 0;
+  width: 220px;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--news-radius);
+}
+
+.news-skeleton-body {
+  flex: 1;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  justify-content: center;
+}
+
+.news-skeleton-line {
+  height: 0.85rem;
+  border-radius: 4px;
+}
+
+.news-skeleton-line.short {
+  width: 55%;
+}
+
+.news-skeleton-shimmer {
+  background: linear-gradient(90deg, #f1f5f9 25%, #e5e7eb 37%, #f1f5f9 63%);
+  background-size: 400% 100%;
+  animation: news-shimmer 1.4s ease infinite;
+}
+
+@keyframes news-shimmer {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+/* ===== Modal (create / edit / delete) ===== */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  background: rgba(15, 23, 42, 0.5);
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 1rem;
   z-index: 1000;
-  animation: fadeIn 0.3s ease;
+  animation: news-fade-in 0.2s ease;
 }
 
-@keyframes fadeIn {
+@keyframes news-fade-in {
   from {
     opacity: 0;
   }
@@ -404,18 +605,25 @@
 
 .modal-content {
   background: #ffffff;
-  border-radius: 24px;
+  border-radius: 16px;
   padding: 2rem;
   width: 100%;
   max-width: 440px;
-  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.16);
-  animation: slideUp 0.3s ease;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.2);
+  animation: news-slide-up 0.2s ease;
+  font-family: "Heebo", system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
-@keyframes slideUp {
+.modal-content.news-form-modal {
+  max-width: 560px;
+  max-height: 88vh;
+  overflow-y: auto;
+}
+
+@keyframes news-slide-up {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(16px);
   }
   to {
     opacity: 1;
@@ -425,9 +633,9 @@
 
 .modal-title {
   margin: 0;
-  color: #111827;
-  font-size: 1.3rem;
-  font-weight: 700;
+  color: var(--news-fg, #111827);
+  font-size: 1.25rem;
+  font-weight: 800;
 }
 
 .modal-message {
@@ -443,114 +651,381 @@
   justify-content: flex-end;
 }
 
-.btn-cancel {
-  background: #f8fafc;
-  color: #0f172a;
-  border: 1px solid #cbd5e1;
-  border-radius: 16px;
-  padding: 0.95rem 1.2rem;
+.news-form-title {
+  margin: 0 0 1.25rem;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: var(--news-fg, #111827);
+}
+
+.news-form-inputs {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.news-input-field {
+  padding: 0.75rem 0.9rem;
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
+  box-sizing: border-box;
+  font-size: 0.92rem;
+  font-family: inherit;
+  transition: all 0.15s ease;
+}
+
+.news-input-field:focus {
+  outline: none;
+  border-color: var(--news-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--news-accent) 15%, transparent);
+}
+
+.news-textarea {
+  padding: 0.75rem 0.9rem;
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #111827;
+  resize: vertical;
+  min-height: 160px;
+  box-sizing: border-box;
+  font-size: 0.92rem;
+  font-family: inherit;
+  line-height: 1.5;
+  transition: all 0.15s ease;
+}
+
+.news-textarea:focus {
+  outline: none;
+  border-color: var(--news-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--news-accent) 15%, transparent);
+}
+
+.news-form-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+/* Custom file picker - same border/height/radius as the other form
+   fields; the real <input type=file> stays in the DOM and focusable
+   (visually-hidden, not display:none) so keyboard + screen readers
+   still work via the native control. */
+.news-file-field {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.4rem;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  box-sizing: border-box;
   cursor: pointer;
-  transition: all 0.2s ease;
-  font-weight: 500;
+  transition: all 0.15s ease;
 }
 
-.btn-cancel:hover {
-  background: #e2e8f0;
-  border-color: #94a3b8;
+.news-file-field:focus-within {
+  border-color: var(--news-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--news-accent) 15%, transparent);
 }
 
-.btn-confirm-delete {
-  background: #ef4444;
-  color: #ffffff;
-  border: none;
-  border-radius: 16px;
-  padding: 0.95rem 1.2rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  font-weight: 700;
-}
-
-.btn-confirm-delete:hover:not(:disabled) {
-  background: #dc2626;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
-}
-
-.btn-confirm-delete:disabled {
-  opacity: 0.7;
+.news-file-field.is-disabled {
+  opacity: 0.6;
   cursor: not-allowed;
 }
 
-.news-tag-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
+.news-file-input-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.news-tag {
+.news-file-button {
+  flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.75rem;
-  background: #eef2ff;
-  color: #3730a3;
-  border-radius: 999px;
-  font-size: 0.8rem;
+  justify-content: center;
+  padding: 0.45rem 1rem;
+  border-radius: 8px;
+  background: var(--news-accent);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.news-file-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--news-fg-muted);
+  font-size: 0.88rem;
+}
+
+/* Image upload (news form) */
+.news-image-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.news-image-preview-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.news-image-preview {
+  max-width: 100%;
+  max-height: 200px;
+  border-radius: 10px;
+  border: 1px solid var(--news-border);
+  object-fit: cover;
+}
+
+.news-upload-status {
+  color: var(--news-fg-muted);
+  font-size: 0.85rem;
+}
+
+/* ===== Details page ===== */
+.news-details-page {
+  min-height: 100vh;
+  background: var(--news-bg);
+  font-family: "Heebo", system-ui, Avenir, Helvetica, Arial, sans-serif;
+}
+
+.news-details-container {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 5rem;
+}
+
+.news-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--news-fg-muted);
+  text-decoration: none;
+  font-size: 0.88rem;
   font-weight: 600;
+  margin-bottom: 1.75rem;
 }
 
-.news-preview {
-  margin: 1rem 0 0;
-  color: #475569;
-  line-height: 1.6;
+.news-back-link:hover {
+  color: var(--news-fg);
 }
 
-.news-empty {
-  padding: 3rem;
-  border: 1px dashed #cbd5e1;
-  border-radius: 24px;
-  background: #f8fafc;
+.news-details-eyebrow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.9rem;
+}
+
+.news-header-title {
+  margin: 0 0 1rem;
+  font-size: 2.3rem;
+  line-height: 1.2;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--news-fg);
+}
+
+.news-byline {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--news-fg-muted);
+  font-size: 0.9rem;
+  padding-bottom: 1.75rem;
+  margin-bottom: 1.75rem;
+  border-bottom: 1px solid var(--news-border);
+}
+
+.news-byline-source {
+  font-weight: 700;
+  color: var(--news-fg);
+}
+
+.news-byline-dot {
+  color: var(--news-fg-subtle);
+}
+
+.news-details-image {
+  display: block;
+  width: 100%;
+  max-height: 460px;
+  object-fit: cover;
+  border-radius: var(--news-radius);
+  margin-bottom: 2rem;
+}
+
+.news-article-content {
+  color: #1f2937;
+  font-size: 1.08rem;
+  line-height: 1.85;
+}
+
+.news-article-content p {
+  margin: 0 0 1.15rem;
+}
+
+.news-article-content p:last-child {
+  margin-bottom: 0;
+}
+
+.news-article-content h1,
+.news-article-content h2,
+.news-article-content h3 {
+  font-weight: 800;
+  line-height: 1.3;
+  margin: 1.75rem 0 0.75rem;
+  color: var(--news-fg);
+}
+
+.news-article-content ul,
+.news-article-content ol {
+  margin: 0 0 1.15rem;
+  padding-inline-start: 1.5rem;
+}
+
+.news-article-content li {
+  margin-bottom: 0.4rem;
+}
+
+.news-article-content a {
+  color: var(--news-accent);
+}
+
+.news-article-content img {
+  max-width: 100%;
+  border-radius: 10px;
+  margin: 0.5rem 0;
+}
+
+.news-article-content code {
+  background: var(--news-bg-subtle);
+  padding: 0.15rem 0.4rem;
+  border-radius: 6px;
+  font-size: 0.9em;
+}
+
+.news-article-content pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 10px;
+  overflow-x: auto;
+  margin: 0 0 1.15rem;
+}
+
+.news-article-content pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.news-article-content blockquote {
+  margin: 0 0 1.15rem;
+  padding-inline-start: 1rem;
+  border-inline-start: 3px solid var(--news-border);
+  color: var(--news-fg-muted);
+}
+
+.news-details-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2.5rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--news-border);
+}
+
+.news-details-footer .btn-reset {
+  margin: 0;
+}
+
+/* ===== Loading / error states ===== */
+.news-loading-container {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #ffffff;
+  padding: 2rem;
+}
+
+.news-loading-content {
   text-align: center;
 }
 
-.news-empty h3 {
-  margin: 0 0 0.75rem;
-  color: #111827;
+.news-spinner {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 1rem;
+  border: 3px solid #e5e7eb;
+  border-top-color: var(--news-accent);
+  border-radius: 50%;
+  animation: news-spin 0.8s linear infinite;
 }
 
-.news-empty p {
-  margin: 0 0 1.25rem;
-  color: #64748b;
+@keyframes news-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
-.news-empty .btn-add-news {
-  margin: 0 auto;
+.news-loading-text {
+  color: #6b7280;
+  font-size: 0.95rem;
 }
 
-.load-more-wrapper {
-  margin-top: 1.5rem;
-  display: flex;
-  justify-content: center;
-}
+/* ===== Responsive ===== */
+@media (max-width: 760px) {
+  .news-list-row--lead .news-article-title {
+    font-size: 1.2rem;
+  }
 
-.load-more-btn {
-  background: #2563eb;
-  color: #ffffff;
-  border: none;
-  border-radius: 16px;
-  padding: 0.95rem 1.5rem;
-  font-weight: 700;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
+  .news-header-title {
+    font-size: 1.7rem;
+  }
 
-.load-more-btn:hover {
-  background: #1d4ed8;
-}
+  .news-masthead-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.news-tags-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
+  .news-masthead-inner .btn-add-news {
+    align-self: flex-start;
+  }
+
+  .news-list-row {
+    flex-direction: column;
+  }
+
+  .news-list-image-link {
+    width: 100%;
+    aspect-ratio: 16 / 9;
+  }
 }

--- a/apps/client/src/utils/markdown.ts
+++ b/apps/client/src/utils/markdown.ts
@@ -1,0 +1,20 @@
+// Reduces Markdown source to plain, readable text - for short previews
+// where rendering full Markdown risks cutting a construct (e.g. "**") mid-way.
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/~~(.*?)~~/g, "$1")
+    .replace(/^\s{0,3}>\s?/gm, "")
+    .replace(/^\s{0,3}([-*+]|\d+\.)\s+/gm, "")
+    .replace(/^\s{0,3}([-*_]\s*){3,}$/gm, "")
+    .replace(/\n{2,}/g, " ")
+    .replace(/\n/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}

--- a/apps/server/src/controllers/newsController.ts
+++ b/apps/server/src/controllers/newsController.ts
@@ -21,6 +21,18 @@ export const newsController = {
     }
   },
 
+  // GET /api/news/tags
+  async getAllTags(req: Request, res: Response) {
+    try {
+      const tags = await newsService.getAllTags();
+      return res.status(200).json(tags);
+    } catch (error: any) {
+      return res.status(500).json({
+        message: error.message || "Internal server error",
+      });
+    }
+  },
+
   // GET /api/news/:id
   async getNewsById(req: Request<NewsParams>, res: Response) {
     try {

--- a/apps/server/src/controllers/uploadController.ts
+++ b/apps/server/src/controllers/uploadController.ts
@@ -1,18 +1,10 @@
 import { Request, Response } from "express";
-import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { v4 as uuidv4 } from "uuid";
 import logger from "../logger";
 import { getOrganizationIdForLog } from "../utils/forumLogContext";
-
-// אתחול החיבור מול AWS עם הגדרת משתני הסביבה
-const s3 = new S3Client({
-  region: process.env.AWS_REGION || "",
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
-  },
-});
+import { s3 } from "../utils/s3Client";
 
 // הגדרת המבנה הצפוי של גוף הבקשה (Interface)
 interface UploadRequestBody {
@@ -27,6 +19,11 @@ const UPLOAD_CONTEXTS: Record<string, { prefix: string; allowedTypes: string[]; 
   tenderResume: {
     prefix: "uploads/tenders",
     allowedTypes: ["application/pdf"],
+    maxSizeBytes: 5 * 1024 * 1024,
+  },
+  newsImage: {
+    prefix: "uploads/news",
+    allowedTypes: ["image/jpeg", "image/png", "image/webp", "image/gif"],
     maxSizeBytes: 5 * 1024 * 1024,
   },
 };

--- a/apps/server/src/models/news.ts
+++ b/apps/server/src/models/news.ts
@@ -5,6 +5,7 @@ export interface INews extends Document {
     content: string;
     source?: string;
     tags?: string[];
+    imageUrl?: string;
     createdAt: Date;
     updatedAt: Date;
 }
@@ -28,6 +29,10 @@ const NewsSchema = new Schema(
     tags:{
         type:[String],
         default:[]
+    },
+    imageUrl:{
+        type:String,
+        trim:true
     }
 },
 {

--- a/apps/server/src/repositories/newsRepository.ts
+++ b/apps/server/src/repositories/newsRepository.ts
@@ -19,6 +19,11 @@ export const newsRepository = {
     return await News.findById(id);
   },
 
+  // Get every distinct tag used across all news
+  async findAllTags(): Promise<string[]> {
+    return await News.distinct("tags");
+  },
+
   // Create news
   async create(data: Partial<INews>): Promise<INews> {
     return await News.create(data);

--- a/apps/server/src/routes/newsRouter.ts
+++ b/apps/server/src/routes/newsRouter.ts
@@ -6,6 +6,8 @@ const newsRouter = Router();
 
 // ===== Public (everyone can read) =====
 newsRouter.get("/", newsController.getAllNews);
+// Must be registered before "/:id" - otherwise Express matches "tags" as an id
+newsRouter.get("/tags", newsController.getAllTags);
 newsRouter.get("/:id", newsController.getNewsById);
 
 // ===== Admin only =====

--- a/apps/server/src/services/newsService.ts
+++ b/apps/server/src/services/newsService.ts
@@ -1,12 +1,31 @@
 import { INews } from "../models/news";
 import { newsRepository } from "../repositories/newsRepository";
 import logger from "../logger";
+import { getPresignedViewUrl } from "../utils/s3Client";
+
+// ה-bucket שבו נשמרות תמונות החדשות חוסם קריאה ציבורית ישירה, לכן בכל
+// הגשה מוחלף ה-URL הקבוע בקישור צפייה חתום וזמני
+async function withResolvedImage(item: INews): Promise<INews> {
+  if (!item.imageUrl) return item;
+
+  try {
+    item.imageUrl = await getPresignedViewUrl(item.imageUrl);
+  } catch (error: any) {
+    logger.warn("Failed to sign news image URL", {
+      id: item._id,
+      error: error.message,
+    });
+  }
+
+  return item;
+}
 
 export const newsService = {
   // Get all news
   async getAllNews(page = 1, limit = 10): Promise<INews[]> {
     logger.info("Fetching all news");
-    return await newsRepository.findAll(page, limit);
+    const news = await newsRepository.findAll(page, limit);
+    return Promise.all(news.map(withResolvedImage));
   },
 
   // Get news by ID
@@ -18,7 +37,7 @@ export const newsService = {
       throw new Error("News not found");
     }
 
-    return news;
+    return withResolvedImage(news);
   },
 
   // Create news

--- a/apps/server/src/services/newsService.ts
+++ b/apps/server/src/services/newsService.ts
@@ -40,6 +40,13 @@ export const newsService = {
     return withResolvedImage(news);
   },
 
+  // Get every distinct tag used across all news, sorted for display
+  async getAllTags(): Promise<string[]> {
+    logger.info("Fetching all news tags");
+    const tags = await newsRepository.findAllTags();
+    return tags.filter(Boolean).sort((a, b) => a.localeCompare(b, "he"));
+  },
+
   // Create news
   async createNews(data: Partial<INews>): Promise<INews> {
     logger.info("Creating news", { data });

--- a/apps/server/src/utils/s3Client.ts
+++ b/apps/server/src/utils/s3Client.ts
@@ -1,0 +1,26 @@
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+export const s3 = new S3Client({
+  region: process.env.AWS_REGION || "",
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID || "",
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "",
+  },
+});
+
+const VIEW_URL_EXPIRES_SECONDS = 60 * 60;
+
+// ה-bucket חוסם קריאה ציבורית, אז כדי להציג קובץ צריך קישור צפייה חתום
+// זמנית עם אותם credentials ששימשו להעלאה (יש להם הרשאת GetObject)
+export async function getPresignedViewUrl(
+  fileUrl: string,
+  expiresIn = VIEW_URL_EXPIRES_SECONDS
+): Promise<string> {
+  const key = decodeURIComponent(new URL(fileUrl).pathname.replace(/^\//, ""));
+  const command = new GetObjectCommand({
+    Bucket: process.env.AWS_BUCKET_NAME,
+    Key: key,
+  });
+  return getSignedUrl(s3, command, { expiresIn });
+}


### PR DESCRIPTION
## Summary
- News items support an optional image, uploaded through the existing S3 presigned-URL flow (new `newsImage` upload context); the server signs a short-lived view URL per image on read since the bucket blocks anonymous public `GetObject`
- Article content renders as Markdown (react-markdown + remark-gfm) on the details page; list/lead previews strip Markdown syntax down to clean plain text instead of showing raw `##`/`**`
- Redesigned the news page as a compact editorial list (masthead, search + tag filter, uniform image/text rows, relative timestamps, skeleton loading, modal create/edit form with an accessible custom file picker) reusing the project's existing `--primary-color`/`--primary-hover` brand tokens instead of introducing new colors
- Smart tag input: `GET /api/news/tags` (repository/service/controller/route) backs autocomplete and the filter pills; tags are chip-based with case-insensitive duplicate prevention and basic keyword suggestions from the title/content (Hebrew-prefix-aware so e.g. "וטכנולוגיה" isn't suggested as a separate tag from "טכנולוגיה")
- Removed a duplicate "back to news" link on the article page

## Test plan
- [x] `npm run typecheck` (client) and `npx tsc --noEmit` (server) pass
- [x] `npm test` — existing `newsService` unit tests pass unchanged
- [x] Manually verified in a running instance (desktop + mobile viewports): list page, article page with real Markdown content, create/edit modal, image upload end-to-end (presigned PUT + signed view URL GET), tag autocomplete/chips/keyword suggestions, admin edit/delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)