### PR TITLE
SCRUM-297: Org/Payments Log Agent (fetch, classify, evaluate, LLM report, evals)

### DIFF
--- a/apps/agents/org-payments-log-agent/.env.example
+++ b/apps/agents/org-payments-log-agent/.env.example
@@ -1,0 +1,11 @@
+# --- MongoDB Atlas (this agent's only integration point - reads applicationlogs) ---
+MONGO_URI=REPLACE_WITH_MONGODB_ATLAS_URI
+
+# --- LLM provider used for summarize_node (Gemini - project's only LLM provider) ---
+GEMINI_API_KEY=REPLACE_WITH_KEY
+LLM_MODEL=gemini-flash-latest
+
+# --- LangSmith tracing / monitoring ---
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=REPLACE_WITH_LANGSMITH_KEY
+LANGCHAIN_PROJECT=safeai-org-payments-log-agent

--- a/apps/agents/org-payments-log-agent/.gitignore
+++ b/apps/agents/org-payments-log-agent/.gitignore
@@ -1,0 +1,6 @@
+venv/
+.venv/
+.env
+__pycache__/
+.pytest_cache/
+evals/results/

--- a/apps/agents/org-payments-log-agent/README.md
+++ b/apps/agents/org-payments-log-agent/README.md
@@ -1,0 +1,88 @@
+# SafeAI Org & Payments Log Agent
+
+Standalone, read-only LangGraph agent that fetches organization/wallet activity
+from the `applicationlogs` MongoDB collection, classifies it, detects wallet
+top-up anomalies, and prints a report - narrated by an LLM when anomalies are
+found, or a short "all clear" message otherwise.
+
+This agent only reads the `applicationlogs` collection. It never writes to the
+database, never modifies any organization, and never sends anything - it is
+report-only, so there is no human-in-the-loop (HITL) gate.
+
+## Setup
+
+```
+python -m venv .venv
+.venv/Scripts/activate   # Windows
+pip install -r requirements.txt
+cp .env.example .env     # then fill in real values
+```
+
+## Graph
+
+```
+fetch_node -> classify_node -> evaluator_node
+  -> [GATE: anomalies_gate, automated - routes by whether anomalies were found]
+       found     -> summarize_node (LLM) -> guardrails_node -> present_node
+       not found -> present_node
+```
+
+`anomalies_gate` is the only Gate in this agent, and it's fully automated
+(not HITL) - there is no user action this agent needs to pause for.
+
+## Rule-based classification and anomaly detection
+
+`classify_node` and `evaluator_node` are deliberately rule-based, not LLM-backed:
+the log messages they read are fixed strings written by the server's own
+`logger.info(...)` calls (`organizationService.ts` / `organizationRepository.ts`),
+so a substring match is exact, cheap, and - unlike an LLM call - can be graded
+unambiguously in `evals/eval.py`. The anomaly rule is 3+ wallet top-ups for the
+same organization inside a rolling 24-hour window.
+
+## LLM usage
+
+`summarize_node` is this agent's one real LLM component: it turns the structured
+anomaly list into a short natural-language paragraph for the admin (Gemini, via
+`google-genai` - `GEMINI_API_KEY` / `LLM_MODEL` in `.env`). It only runs on the
+"anomalies found" path.
+
+## GuardRails
+
+`guardrails_node` redacts any 24-hex-character, Mongo-ObjectId-shaped token in
+the LLM's summary that isn't one of the anomaly list's own organization ids -
+i.e. anything the LLM may have hallucinated or copied in from elsewhere (a raw
+`userId`, for example) is replaced with `[REDACTED]` before the admin sees it.
+
+## CLI usage
+
+```
+python agent/cli.py
+python agent/cli.py --start 2026-08-01 --end 2026-08-31
+```
+
+`--start`/`--end` (both optional, `YYYY-MM-DD`) restrict the log query to that
+date range; omitting them fetches all matching logs.
+
+## LangSmith
+
+Tracing is optional and controlled by `LANGCHAIN_TRACING_V2` in `.env` (along
+with `LANGCHAIN_API_KEY` / `LANGCHAIN_PROJECT`). The `summarize_node` LLM call
+is decorated with `@traceable`. The agent works without tracing configured.
+
+## Evals
+
+`evals/eval.py` checks (1) classification/anomaly-detection accuracy against a
+labeled fixture set (no LLM/DB access needed), and (2) the `summarize_node`
+output's non-leakage and non-emptiness (requires a real `GEMINI_API_KEY` in
+`.env`). Results are written as CSV to the gitignored `evals/results/`
+directory.
+
+```
+python evals/eval.py
+```
+
+## Extensions (not implemented)
+
+`agent/tools.py` exists as a placeholder for optional extensions (RAG,
+web-search, code-exec, MCP) mentioned in the spec as recommended, not required.
+This agent's scope (read-only log reporting) doesn't call for any of them.

--- a/apps/agents/org-payments-log-agent/agent/cli.py
+++ b/apps/agents/org-payments-log-agent/agent/cli.py
@@ -1,0 +1,33 @@
+import argparse
+from datetime import datetime
+
+from config import load_config
+from graph import build_graph
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%d")
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Org/payments log agent - reports organization wallet activity anomalies."
+    )
+    parser.add_argument(
+        "--start", type=_parse_date, default=None, help="Start date (YYYY-MM-DD), optional."
+    )
+    parser.add_argument(
+        "--end", type=_parse_date, default=None, help="End date (YYYY-MM-DD), optional."
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> None:
+    args = parse_args(argv)
+    graph = build_graph(load_config())
+    result = graph.invoke({"start_date": args.start, "end_date": args.end})
+    print(result["report"])
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/agents/org-payments-log-agent/agent/config.py
+++ b/apps/agents/org-payments-log-agent/agent/config.py
@@ -1,0 +1,26 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class ConfigError(RuntimeError):
+    pass
+
+
+def _require(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise ConfigError(f"Missing required environment variable: {name}")
+    return value
+
+
+class Config:
+    def __init__(self):
+        self.gemini_api_key = _require("GEMINI_API_KEY")
+        self.llm_model = os.environ.get("LLM_MODEL", "gemini-flash-latest")
+
+
+def load_config() -> Config:
+    return Config()

--- a/apps/agents/org-payments-log-agent/agent/db.py
+++ b/apps/agents/org-payments-log-agent/agent/db.py
@@ -1,0 +1,28 @@
+import os
+from pymongo import MongoClient
+from pymongo.database import Database
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_database() -> Database:
+    """
+    Connects to MongoDB Atlas using the connection string from the .env file
+    and returns the database object.
+    """
+    mongo_uri = os.getenv("MONGO_URI")
+    if not mongo_uri:
+        raise ValueError("MONGO_URI is not set in the .env file")
+
+    client = MongoClient(mongo_uri)
+
+    db = client["safeai"]
+    return db
+
+
+if __name__ == "__main__":
+    # Quick manual check: run this file directly to verify the connection works
+    db = get_database()
+    print("Connected to database:", db.name)
+    print("Collections found:", db.list_collection_names())

--- a/apps/agents/org-payments-log-agent/agent/fetch_logs.py
+++ b/apps/agents/org-payments-log-agent/agent/fetch_logs.py
@@ -1,0 +1,60 @@
+from datetime import datetime
+from typing import Optional
+
+from db import get_database
+
+# Matches the info/warn/error log messages written by organizationService.ts /
+# organizationRepository.ts (e.g. "Organization approved", "Organization wallet
+# topped up successfully (Mock)", "User added to organization").
+_ORG_PAYMENT_MESSAGE_PATTERN = "organization|wallet"
+
+
+def transform_record(raw: dict) -> dict:
+    """
+    Converts a single raw applicationlogs document into a convenient, minimal
+    structure. The full "context" dict is preserved (not flattened) because it
+    carries fields such as organizationId/amount that downstream nodes
+    (classification, anomaly detection) need to group and filter on.
+    """
+    return {
+        "level": raw.get("level", "info"),
+        "message": raw.get("message", ""),
+        "context": raw.get("context") or {},
+        "timestamp": raw.get("timestamp"),
+    }
+
+
+def fetch_org_payment_logs(
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> list[dict]:
+    """
+    Fetches log records related to organization/wallet activity from the
+    applicationlogs collection, optionally restricted to a [start_date, end_date]
+    timestamp range, and converts each one using transform_record().
+
+    Returns a list of dicts, each containing: level, message, context, timestamp.
+    """
+    db = get_database()
+    collection = db["applicationlogs"]
+
+    query: dict = {"message": {"$regex": _ORG_PAYMENT_MESSAGE_PATTERN, "$options": "i"}}
+
+    timestamp_filter = {}
+    if start_date is not None:
+        timestamp_filter["$gte"] = start_date
+    if end_date is not None:
+        timestamp_filter["$lte"] = end_date
+    if timestamp_filter:
+        query["timestamp"] = timestamp_filter
+
+    raw_records = list(collection.find(query))
+
+    return [transform_record(raw) for raw in raw_records]
+
+
+if __name__ == "__main__":
+    logs = fetch_org_payment_logs()
+    print(f"Found {len(logs)} organization/payment log records")
+    if logs:
+        print("Example record:", logs[0])

--- a/apps/agents/org-payments-log-agent/agent/graph.py
+++ b/apps/agents/org-payments-log-agent/agent/graph.py
@@ -1,18 +1,19 @@
 from langgraph.graph import StateGraph, END
 
 from graph_state import GraphState
-from nodes import fetch_node
+from nodes import classify_node, fetch_node
 
-# Minimal graph for this Story (שליפה וסינון לוגים): fetch_node only.
-# classify_node / evaluator_node / the Gate / summarize_node / guardrails_node /
-# present_node will be added and wired in here by the following Stories
-# (SCRUM-299, SCRUM-300).
+# Growing graph, one Story at a time: fetch -> classify -> END.
+# evaluator_node / the Gate / summarize_node / guardrails_node / present_node
+# will replace this END and be wired in by later Stories.
 graph_builder = StateGraph(GraphState)
 
 graph_builder.add_node("fetch", fetch_node)
+graph_builder.add_node("classify", classify_node)
 
 graph_builder.set_entry_point("fetch")
-graph_builder.add_edge("fetch", END)
+graph_builder.add_edge("fetch", "classify")
+graph_builder.add_edge("classify", END)
 
 graph = graph_builder.compile()
 

--- a/apps/agents/org-payments-log-agent/agent/graph.py
+++ b/apps/agents/org-payments-log-agent/agent/graph.py
@@ -1,19 +1,22 @@
 from langgraph.graph import StateGraph, END
 
 from graph_state import GraphState
-from nodes import classify_node, fetch_node
+from nodes import classify_node, evaluator_node, fetch_node
 
-# Growing graph, one Story at a time: fetch -> classify -> END.
-# evaluator_node / the Gate / summarize_node / guardrails_node / present_node
-# will replace this END and be wired in by later Stories.
+# Growing graph, one Story at a time: fetch -> classify -> evaluator -> END.
+# The Gate (conditional_edges) / summarize_node (LLM) / guardrails_node /
+# present_node will replace this END and be wired in by SCRUM-300 (Story:
+# דוח + LLM + Gate + Guardrails).
 graph_builder = StateGraph(GraphState)
 
 graph_builder.add_node("fetch", fetch_node)
 graph_builder.add_node("classify", classify_node)
+graph_builder.add_node("evaluate", evaluator_node)
 
 graph_builder.set_entry_point("fetch")
 graph_builder.add_edge("fetch", "classify")
-graph_builder.add_edge("classify", END)
+graph_builder.add_edge("classify", "evaluate")
+graph_builder.add_edge("evaluate", END)
 
 graph = graph_builder.compile()
 
@@ -21,3 +24,4 @@ graph = graph_builder.compile()
 if __name__ == "__main__":
     result = graph.invoke({})
     print(f"Fetched {len(result['records'])} records")
+    print(f"Anomalies found: {len(result['anomalies'])}")

--- a/apps/agents/org-payments-log-agent/agent/graph.py
+++ b/apps/agents/org-payments-log-agent/agent/graph.py
@@ -1,27 +1,48 @@
+from functools import partial
+
 from langgraph.graph import StateGraph, END
 
+from config import Config
 from graph_state import GraphState
-from nodes import classify_node, evaluator_node, fetch_node
+from nodes import (
+    anomalies_gate,
+    classify_node,
+    evaluator_node,
+    fetch_node,
+    guardrails_node,
+    present_node,
+    summarize_node,
+)
 
-# Growing graph, one Story at a time: fetch -> classify -> evaluator -> END.
-# The Gate (conditional_edges) / summarize_node (LLM) / guardrails_node /
-# present_node will replace this END and be wired in by SCRUM-300 (Story:
-# דוח + LLM + Gate + Guardrails).
-graph_builder = StateGraph(GraphState)
 
-graph_builder.add_node("fetch", fetch_node)
-graph_builder.add_node("classify", classify_node)
-graph_builder.add_node("evaluate", evaluator_node)
+def build_graph(agent_config: Config):
+    builder = StateGraph(GraphState)
 
-graph_builder.set_entry_point("fetch")
-graph_builder.add_edge("fetch", "classify")
-graph_builder.add_edge("classify", "evaluate")
-graph_builder.add_edge("evaluate", END)
+    builder.add_node("fetch", fetch_node)
+    builder.add_node("classify", classify_node)
+    builder.add_node("evaluate", evaluator_node)
+    # GATE (anomalies_gate): automated conditional edge, not human - routes to
+    # the detailed (LLM) path only when evaluator_node actually found anomalies.
+    builder.add_node("summarize", partial(summarize_node, agent_config=agent_config))
+    builder.add_node("guardrails", guardrails_node)
+    builder.add_node("present", present_node)
 
-graph = graph_builder.compile()
+    builder.set_entry_point("fetch")
+    builder.add_edge("fetch", "classify")
+    builder.add_edge("classify", "evaluate")
+    builder.add_conditional_edges(
+        "evaluate",
+        anomalies_gate,
+        {"summarize": "summarize", "present": "present"},
+    )
+    builder.add_edge("summarize", "guardrails")
+    builder.add_edge("guardrails", "present")
+    builder.add_edge("present", END)
+
+    return builder.compile()
 
 
 if __name__ == "__main__":
+    graph = build_graph(Config())
     result = graph.invoke({})
-    print(f"Fetched {len(result['records'])} records")
-    print(f"Anomalies found: {len(result['anomalies'])}")
+    print(result["report"])

--- a/apps/agents/org-payments-log-agent/agent/graph.py
+++ b/apps/agents/org-payments-log-agent/agent/graph.py
@@ -1,0 +1,22 @@
+from langgraph.graph import StateGraph, END
+
+from graph_state import GraphState
+from nodes import fetch_node
+
+# Minimal graph for this Story (שליפה וסינון לוגים): fetch_node only.
+# classify_node / evaluator_node / the Gate / summarize_node / guardrails_node /
+# present_node will be added and wired in here by the following Stories
+# (SCRUM-299, SCRUM-300).
+graph_builder = StateGraph(GraphState)
+
+graph_builder.add_node("fetch", fetch_node)
+
+graph_builder.set_entry_point("fetch")
+graph_builder.add_edge("fetch", END)
+
+graph = graph_builder.compile()
+
+
+if __name__ == "__main__":
+    result = graph.invoke({})
+    print(f"Fetched {len(result['records'])} records")

--- a/apps/agents/org-payments-log-agent/agent/graph_state.py
+++ b/apps/agents/org-payments-log-agent/agent/graph_state.py
@@ -1,8 +1,12 @@
+from datetime import datetime
 from typing import List, TypedDict
 
 
 class GraphState(TypedDict, total=False):
+    start_date: datetime  # optional, set by cli.py from CLI args
+    end_date: datetime  # optional, set by cli.py from CLI args
     records: List[dict]  # raw log records from fetch_node
     classified: List[dict]  # populated by classify_node (Story: סיווג וזיהוי חריגות)
     anomalies: List[dict]  # populated by evaluator_node (Story: סיווג וזיהוי חריגות)
-    summary: str  # populated by summarize_node (Story: דוח + LLM + Gate), only on the "anomalies found" path
+    summary: str  # populated by summarize_node (LLM), only on the "anomalies found" path
+    report: str  # populated by present_node - the final text shown to the admin

--- a/apps/agents/org-payments-log-agent/agent/graph_state.py
+++ b/apps/agents/org-payments-log-agent/agent/graph_state.py
@@ -1,0 +1,8 @@
+from typing import List, TypedDict
+
+
+class GraphState(TypedDict, total=False):
+    records: List[dict]  # raw log records from fetch_node
+    classified: List[dict]  # populated by classify_node (Story: סיווג וזיהוי חריגות)
+    anomalies: List[dict]  # populated by evaluator_node (Story: סיווג וזיהוי חריגות)
+    summary: str  # populated by summarize_node (Story: דוח + LLM + Gate), only on the "anomalies found" path

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import json
+import re
 
 from google import genai
 from langsmith import traceable
@@ -149,3 +150,32 @@ def summarize_node(state: GraphState, agent_config: Config) -> dict:
     anomalies_json = json.dumps(state.get("anomalies", []), default=str)
     prompt = _SUMMARY_PROMPT_TEMPLATE.format(anomalies_json=anomalies_json)
     return {"summary": _call_llm(prompt, agent_config)}
+
+
+# Matches Mongo ObjectIds (24 hex chars) - e.g. a raw userId that must never be
+# shown to the admin unless it's one of the organization ids the report is
+# already, legitimately, about.
+_OBJECT_ID_PATTERN = re.compile(r"\b[0-9a-fA-F]{24}\b")
+
+
+def _redact_unknown_ids(text: str, known_ids: set) -> str:
+    return _OBJECT_ID_PATTERN.sub(
+        lambda m: m.group(0) if m.group(0) in known_ids else "[REDACTED]", text
+    )
+
+
+def guardrails_node(state: GraphState) -> dict:
+    """
+    LangGraph node that filters the LLM-generated summary before it's shown
+    to the admin: any id-like token that isn't one of the organization ids
+    already present in "anomalies" (i.e. anything the LLM may have
+    hallucinated or copied in from elsewhere) is redacted.
+    """
+    summary = state.get("summary")
+    if not summary:
+        return {}
+
+    known_org_ids = {
+        str(a["organization_id"]) for a in state.get("anomalies", []) if a.get("organization_id")
+    }
+    return {"summary": _redact_unknown_ids(summary, known_org_ids)}

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from pymongo.errors import PyMongoError
 
 from fetch_logs import fetch_org_payment_logs
@@ -13,6 +15,11 @@ _EVENT_TYPE_PATTERNS = [
     ("wallet balance incremented", "topup"),
     ("active state changed", "status_change"),
 ]
+
+# Anomaly rule (per Epic scope decision): 3+ topups for the same organization
+# within a 24-hour window.
+_TOPUP_ANOMALY_THRESHOLD = 3
+_TOPUP_ANOMALY_WINDOW = timedelta(hours=24)
 
 
 def fetch_node(state: GraphState) -> dict:
@@ -54,3 +61,48 @@ def classify_node(state: GraphState) -> dict:
         for record in state.get("records", [])
     ]
     return {"classified": classified}
+
+
+def _find_topup_anomalies(classified: list[dict]) -> list[dict]:
+    """
+    Groups "topup" events by organizationId and flags any organization with
+    at least _TOPUP_ANOMALY_THRESHOLD topups inside a rolling
+    _TOPUP_ANOMALY_WINDOW window.
+    """
+    topups_by_org: dict[str, list] = {}
+    for record in classified:
+        if record.get("event_type") != "topup":
+            continue
+        org_id = record.get("context", {}).get("organizationId")
+        if org_id is None:
+            continue
+        topups_by_org.setdefault(org_id, []).append(record["timestamp"])
+
+    anomalies = []
+    for org_id, timestamps in topups_by_org.items():
+        timestamps = sorted(timestamps)
+        for i in range(len(timestamps) - _TOPUP_ANOMALY_THRESHOLD + 1):
+            window = timestamps[i : i + _TOPUP_ANOMALY_THRESHOLD]
+            if window[-1] - window[0] <= _TOPUP_ANOMALY_WINDOW:
+                anomalies.append(
+                    {
+                        "organization_id": org_id,
+                        "type": "excessive_topups",
+                        "count": len(window),
+                        "window_start": window[0],
+                        "window_end": window[-1],
+                    }
+                )
+                break  # one anomaly entry per organization is enough
+
+    return anomalies
+
+
+def evaluator_node(state: GraphState) -> dict:
+    """
+    LangGraph node that inspects the classified records and flags
+    organizations that crossed the configured anomaly threshold, adding the
+    result to the state under "anomalies".
+    """
+    anomalies = _find_topup_anomalies(state.get("classified", []))
+    return {"anomalies": anomalies}

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -1,7 +1,12 @@
 from datetime import timedelta
 
+import json
+
+from google import genai
+from langsmith import traceable
 from pymongo.errors import PyMongoError
 
+from config import Config
 from fetch_logs import fetch_org_payment_logs
 from graph_state import GraphState
 
@@ -114,3 +119,33 @@ def anomalies_gate(state: GraphState) -> str:
     were found, or straight to the short "all clear" report otherwise.
     """
     return "summarize" if state.get("anomalies") else "present"
+
+
+_SUMMARY_PROMPT_TEMPLATE = """You are writing a short status report for a system
+administrator about suspicious organization wallet activity detected in the logs.
+
+For each anomaly below, write one clear sentence explaining what was found and why
+it's worth a look (do not invent details beyond what's given; do not address the
+administrator directly with imperative instructions - just report the facts).
+
+Anomalies (JSON):
+{anomalies_json}
+"""
+
+
+@traceable
+def _call_llm(prompt: str, config: Config) -> str:
+    client = genai.Client(api_key=config.gemini_api_key)
+    response = client.models.generate_content(model=config.llm_model, contents=prompt)
+    return response.text
+
+
+def summarize_node(state: GraphState, agent_config: Config) -> dict:
+    """
+    LangGraph node (LLM) that turns the structured "anomalies" list into a
+    short natural-language summary for the admin. Only runs on the
+    "anomalies found" path (see anomalies_gate).
+    """
+    anomalies_json = json.dumps(state.get("anomalies", []), default=str)
+    prompt = _SUMMARY_PROMPT_TEMPLATE.format(anomalies_json=anomalies_json)
+    return {"summary": _call_llm(prompt, agent_config)}

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -1,0 +1,20 @@
+from pymongo.errors import PyMongoError
+
+from fetch_logs import fetch_org_payment_logs
+from graph_state import GraphState
+
+
+def fetch_node(state: GraphState) -> dict:
+    """
+    LangGraph node that fetches organization/payment log records and adds
+    them to the state under "records".
+    """
+    try:
+        records = fetch_org_payment_logs()
+    except PyMongoError as e:
+        raise RuntimeError(
+            "Failed to connect to the database while fetching organization/payment "
+            "logs. Check your MONGO_URI and network connection."
+        ) from e
+
+    return {"records": records}

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -106,3 +106,11 @@ def evaluator_node(state: GraphState) -> dict:
     """
     anomalies = _find_topup_anomalies(state.get("classified", []))
     return {"anomalies": anomalies}
+
+
+def anomalies_gate(state: GraphState) -> str:
+    """
+    The Gate: routes to the LLM-backed detailed report path when anomalies
+    were found, or straight to the short "all clear" report otherwise.
+    """
+    return "summarize" if state.get("anomalies") else "present"

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -31,10 +31,13 @@ _TOPUP_ANOMALY_WINDOW = timedelta(hours=24)
 def fetch_node(state: GraphState) -> dict:
     """
     LangGraph node that fetches organization/payment log records and adds
-    them to the state under "records".
+    them to the state under "records". Reads an optional "start_date"/
+    "end_date" from the initial state (set by cli.py from CLI args).
     """
     try:
-        records = fetch_org_payment_logs()
+        records = fetch_org_payment_logs(
+            start_date=state.get("start_date"), end_date=state.get("end_date")
+        )
     except PyMongoError as e:
         raise RuntimeError(
             "Failed to connect to the database while fetching organization/payment "
@@ -179,3 +182,23 @@ def guardrails_node(state: GraphState) -> dict:
         str(a["organization_id"]) for a in state.get("anomalies", []) if a.get("organization_id")
     }
     return {"summary": _redact_unknown_ids(summary, known_org_ids)}
+
+
+def present_node(state: GraphState) -> dict:
+    """
+    LangGraph node that produces the final text report shown to the admin.
+    Two shapes, depending on the Gate's outcome: a short "all clear" message,
+    or a detailed report built from the (guarded) LLM summary plus the raw
+    anomaly list.
+    """
+    anomalies = state.get("anomalies", [])
+    if not anomalies:
+        return {"report": "✅ הכל תקין — לא נמצאו חריגות בטווח שנבדק."}
+
+    lines = ["⚠️ נמצאו חריגות:", "", state.get("summary", ""), "", "פירוט:"]
+    for anomaly in anomalies:
+        lines.append(
+            f"- ארגון {anomaly['organization_id']}: "
+            f"{anomaly['count']} טעינות ארנק בין {anomaly['window_start']} ל-{anomaly['window_end']}"
+        )
+    return {"report": "\n".join(lines)}

--- a/apps/agents/org-payments-log-agent/agent/nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/nodes.py
@@ -3,6 +3,17 @@ from pymongo.errors import PyMongoError
 from fetch_logs import fetch_org_payment_logs
 from graph_state import GraphState
 
+# Ordered (message substring, event_type) pairs. Matched case-insensitively,
+# first match wins. These substrings mirror the exact logger.info/error calls
+# in apps/server/src/services/organizationService.ts and organizationRepository.ts.
+_EVENT_TYPE_PATTERNS = [
+    ("approved", "approval"),
+    ("rejected", "rejection"),
+    ("topped up", "topup"),
+    ("wallet balance incremented", "topup"),
+    ("active state changed", "status_change"),
+]
+
 
 def fetch_node(state: GraphState) -> dict:
     """
@@ -18,3 +29,28 @@ def fetch_node(state: GraphState) -> dict:
         ) from e
 
     return {"records": records}
+
+
+def classify_event_type(message: str) -> str:
+    """
+    Classifies a single log message into an event type (approval / rejection /
+    topup / status_change), or "other" if it doesn't match a known pattern.
+    Deliberately rule-based (not LLM) - see SCRUM-299 for the reasoning.
+    """
+    lowered = message.lower()
+    for substring, event_type in _EVENT_TYPE_PATTERNS:
+        if substring in lowered:
+            return event_type
+    return "other"
+
+
+def classify_node(state: GraphState) -> dict:
+    """
+    LangGraph node that classifies each fetched record by event type and adds
+    the result to the state under "classified".
+    """
+    classified = [
+        {**record, "event_type": classify_event_type(record.get("message", ""))}
+        for record in state.get("records", [])
+    ]
+    return {"classified": classified}

--- a/apps/agents/org-payments-log-agent/agent/test_fetch_logs.py
+++ b/apps/agents/org-payments-log-agent/agent/test_fetch_logs.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+from fetch_logs import transform_record, fetch_org_payment_logs
+
+
+def test_transform_record_with_context():
+    raw = {
+        "level": "info",
+        "message": "Organization approved",
+        "context": {"organizationId": "org-1"},
+        "timestamp": "2026-08-01T00:00:00Z",
+    }
+    result = transform_record(raw)
+    assert result == {
+        "level": "info",
+        "message": "Organization approved",
+        "context": {"organizationId": "org-1"},
+        "timestamp": "2026-08-01T00:00:00Z",
+    }
+
+
+def test_transform_record_missing_context_and_level():
+    # Simulates an older/minimal log record without "context" or "level".
+    raw = {"message": "Organization created", "timestamp": "2026-08-01T00:00:00Z"}
+    result = transform_record(raw)
+    assert result == {
+        "level": "info",
+        "message": "Organization created",
+        "context": {},
+        "timestamp": "2026-08-01T00:00:00Z",
+    }
+
+
+def test_fetch_org_payment_logs_no_records():
+    # Simulates the database returning zero matching records.
+    # We mock get_database() so this test doesn't need a real connection.
+    with patch("fetch_logs.get_database") as mock_get_db:
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = []
+        mock_get_db.return_value = {"applicationlogs": mock_collection}
+
+        result = fetch_org_payment_logs()
+        assert result == []
+
+
+def test_fetch_org_payment_logs_multiple_records():
+    # Simulates the database returning several raw records at once,
+    # verifying that fetch_org_payment_logs transforms each one correctly.
+    with patch("fetch_logs.get_database") as mock_get_db:
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = [
+            {
+                "level": "info",
+                "message": "Organization wallet topped up successfully (Mock)",
+                "context": {"organizationId": "org-1", "amount": 100},
+                "timestamp": "2026-08-01T00:00:00Z",
+            },
+            {"message": "Organization rejected", "timestamp": "2026-08-02T00:00:00Z"},
+        ]
+        mock_get_db.return_value = {"applicationlogs": mock_collection}
+
+        result = fetch_org_payment_logs()
+        assert result == [
+            {
+                "level": "info",
+                "message": "Organization wallet topped up successfully (Mock)",
+                "context": {"organizationId": "org-1", "amount": 100},
+                "timestamp": "2026-08-01T00:00:00Z",
+            },
+            {
+                "level": "info",
+                "message": "Organization rejected",
+                "context": {},
+                "timestamp": "2026-08-02T00:00:00Z",
+            },
+        ]
+
+
+def test_fetch_org_payment_logs_filters_by_message_pattern():
+    # Verifies the Mongo query filters on the organization/wallet message pattern.
+    with patch("fetch_logs.get_database") as mock_get_db:
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = []
+        mock_get_db.return_value = {"applicationlogs": mock_collection}
+
+        fetch_org_payment_logs()
+
+        called_query = mock_collection.find.call_args[0][0]
+        assert called_query == {
+            "message": {"$regex": "organization|wallet", "$options": "i"}
+        }
+
+
+def test_fetch_org_payment_logs_date_range():
+    # Verifies start_date/end_date are translated into a timestamp range filter.
+    with patch("fetch_logs.get_database") as mock_get_db:
+        mock_collection = MagicMock()
+        mock_collection.find.return_value = []
+        mock_get_db.return_value = {"applicationlogs": mock_collection}
+
+        start = datetime(2026, 8, 1)
+        end = datetime(2026, 8, 31)
+        fetch_org_payment_logs(start_date=start, end_date=end)
+
+        called_query = mock_collection.find.call_args[0][0]
+        assert called_query["timestamp"] == {"$gte": start, "$lte": end}

--- a/apps/agents/org-payments-log-agent/agent/test_nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/test_nodes.py
@@ -6,6 +6,7 @@ from nodes import (
     classify_event_type,
     classify_node,
     evaluator_node,
+    guardrails_node,
     summarize_node,
 )
 
@@ -192,5 +193,36 @@ def test_summarize_node_returns_llm_text(client_cls):
     assert result == {
         "summary": "Organization org-1 had 3 wallet top-ups within 24 hours."
     }
+
+
+# ---------------------------------------------------------------------------
+# guardrails_node
+# ---------------------------------------------------------------------------
+
+
+def test_guardrails_node_passes_through_known_organization_id():
+    state = {
+        "summary": "Organization 507f1f77bcf86cd799439011 looks suspicious.",
+        "anomalies": [{"organization_id": "507f1f77bcf86cd799439011"}],
+    }
+    result = guardrails_node(state)
+    assert result == {
+        "summary": "Organization 507f1f77bcf86cd799439011 looks suspicious."
+    }
+
+
+def test_guardrails_node_redacts_unknown_id_like_token():
+    state = {
+        "summary": "User 507f1f77bcf86cd799439099 triggered this from org 507f1f77bcf86cd799439011.",
+        "anomalies": [{"organization_id": "507f1f77bcf86cd799439011"}],
+    }
+    result = guardrails_node(state)
+    assert result == {
+        "summary": "User [REDACTED] triggered this from org 507f1f77bcf86cd799439011."
+    }
+
+
+def test_guardrails_node_no_summary_is_noop():
+    assert guardrails_node({"anomalies": []}) == {}
 
 

--- a/apps/agents/org-payments-log-agent/agent/test_nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/test_nodes.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
-from nodes import anomalies_gate, classify_event_type, classify_node, evaluator_node
+from nodes import (
+    anomalies_gate,
+    classify_event_type,
+    classify_node,
+    evaluator_node,
+    summarize_node,
+)
 
 
 def test_classify_event_type_approval():
@@ -151,5 +158,39 @@ def test_anomalies_gate_routes_to_summarize_when_anomalies_found():
 def test_anomalies_gate_routes_to_present_when_no_anomalies():
     assert anomalies_gate({"anomalies": []}) == "present"
     assert anomalies_gate({}) == "present"
+
+
+# ---------------------------------------------------------------------------
+# summarize_node (LLM, mocked)
+# ---------------------------------------------------------------------------
+
+
+def _config():
+    config = MagicMock()
+    config.gemini_api_key = "test-key"
+    config.llm_model = "gemini-1.5-pro"
+    return config
+
+
+@patch("nodes.genai.Client")
+def test_summarize_node_returns_llm_text(client_cls):
+    client_cls.return_value.models.generate_content.return_value.text = (
+        "Organization org-1 had 3 wallet top-ups within 24 hours."
+    )
+    state = {
+        "anomalies": [
+            {
+                "organization_id": "org-1",
+                "type": "excessive_topups",
+                "count": 3,
+                "window_start": datetime(2026, 8, 1, 0, 0),
+                "window_end": datetime(2026, 8, 1, 20, 0),
+            }
+        ]
+    }
+    result = summarize_node(state, _config())
+    assert result == {
+        "summary": "Organization org-1 had 3 wallet top-ups within 24 hours."
+    }
 
 

--- a/apps/agents/org-payments-log-agent/agent/test_nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/test_nodes.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from nodes import classify_event_type, classify_node, evaluator_node
+from nodes import anomalies_gate, classify_event_type, classify_node, evaluator_node
 
 
 def test_classify_event_type_approval():
@@ -137,3 +137,19 @@ def test_evaluator_node_tracks_multiple_organizations_independently():
     result = evaluator_node(state)
     org_ids = {a["organization_id"] for a in result["anomalies"]}
     assert org_ids == {"org-1"}
+
+
+# ---------------------------------------------------------------------------
+# anomalies_gate
+# ---------------------------------------------------------------------------
+
+
+def test_anomalies_gate_routes_to_summarize_when_anomalies_found():
+    assert anomalies_gate({"anomalies": [{"organization_id": "org-1"}]}) == "summarize"
+
+
+def test_anomalies_gate_routes_to_present_when_no_anomalies():
+    assert anomalies_gate({"anomalies": []}) == "present"
+    assert anomalies_gate({}) == "present"
+
+

--- a/apps/agents/org-payments-log-agent/agent/test_nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/test_nodes.py
@@ -1,0 +1,139 @@
+from datetime import datetime, timedelta
+
+from nodes import classify_event_type, classify_node, evaluator_node
+
+
+def test_classify_event_type_approval():
+    assert classify_event_type("Organization approved") == "approval"
+
+
+def test_classify_event_type_rejection():
+    assert classify_event_type("Organization rejected") == "rejection"
+
+
+def test_classify_event_type_topup_mock_message():
+    assert (
+        classify_event_type("Organization wallet topped up successfully (Mock)")
+        == "topup"
+    )
+
+
+def test_classify_event_type_topup_increment_message():
+    assert (
+        classify_event_type("Organization wallet balance incremented in DB")
+        == "topup"
+    )
+
+
+def test_classify_event_type_status_change():
+    assert classify_event_type("Organization active state changed") == "status_change"
+
+
+def test_classify_event_type_other_for_unrecognized_message():
+    assert classify_event_type("Organization created in DB") == "other"
+
+
+def test_classify_node_adds_event_type_to_every_record():
+    state = {
+        "records": [
+            {"message": "Organization approved", "context": {}},
+            {"message": "Organization rejected", "context": {}},
+        ]
+    }
+    result = classify_node(state)
+    assert [r["event_type"] for r in result["classified"]] == ["approval", "rejection"]
+
+
+def _topup_record(org_id: str, ts: datetime) -> dict:
+    return {
+        "message": "Organization wallet topped up successfully (Mock)",
+        "context": {"organizationId": org_id},
+        "timestamp": ts,
+        "event_type": "topup",
+    }
+
+
+def test_evaluator_node_no_anomalies_below_threshold():
+    base = datetime(2026, 8, 1, 12, 0, 0)
+    state = {
+        "classified": [
+            _topup_record("org-1", base),
+            _topup_record("org-1", base + timedelta(hours=1)),
+        ]
+    }
+    result = evaluator_node(state)
+    assert result["anomalies"] == []
+
+
+def test_evaluator_node_flags_three_topups_within_24_hours():
+    base = datetime(2026, 8, 1, 12, 0, 0)
+    state = {
+        "classified": [
+            _topup_record("org-1", base),
+            _topup_record("org-1", base + timedelta(hours=10)),
+            _topup_record("org-1", base + timedelta(hours=20)),
+        ]
+    }
+    result = evaluator_node(state)
+    assert len(result["anomalies"]) == 1
+    assert result["anomalies"][0]["organization_id"] == "org-1"
+    assert result["anomalies"][0]["count"] == 3
+
+
+def test_evaluator_node_boundary_exactly_24_hours_apart_still_flags():
+    # Boundary case called out explicitly in the Story's DoD: exactly 3
+    # topups where the first and last are exactly 24h apart still counts.
+    base = datetime(2026, 8, 1, 0, 0, 0)
+    state = {
+        "classified": [
+            _topup_record("org-1", base),
+            _topup_record("org-1", base + timedelta(hours=12)),
+            _topup_record("org-1", base + timedelta(hours=24)),
+        ]
+    }
+    result = evaluator_node(state)
+    assert len(result["anomalies"]) == 1
+
+
+def test_evaluator_node_three_topups_spread_over_more_than_24_hours_does_not_flag():
+    base = datetime(2026, 8, 1, 0, 0, 0)
+    state = {
+        "classified": [
+            _topup_record("org-1", base),
+            _topup_record("org-1", base + timedelta(hours=12)),
+            _topup_record("org-1", base + timedelta(hours=24, minutes=1)),
+        ]
+    }
+    result = evaluator_node(state)
+    assert result["anomalies"] == []
+
+
+def test_evaluator_node_ignores_non_topup_events():
+    base = datetime(2026, 8, 1, 12, 0, 0)
+    state = {
+        "classified": [
+            {
+                "message": "Organization approved",
+                "context": {"organizationId": "org-1"},
+                "timestamp": base,
+                "event_type": "approval",
+            },
+        ]
+    }
+    result = evaluator_node(state)
+    assert result["anomalies"] == []
+
+
+def test_evaluator_node_tracks_multiple_organizations_independently():
+    base = datetime(2026, 8, 1, 12, 0, 0)
+    state = {
+        "classified": [
+            _topup_record("org-1", base),
+            _topup_record("org-1", base + timedelta(hours=1)),
+            _topup_record("org-1", base + timedelta(hours=2)),
+            _topup_record("org-2", base),
+        ]
+    }
+    result = evaluator_node(state)
+    org_ids = {a["organization_id"] for a in result["anomalies"]}
+    assert org_ids == {"org-1"}

--- a/apps/agents/org-payments-log-agent/agent/test_nodes.py
+++ b/apps/agents/org-payments-log-agent/agent/test_nodes.py
@@ -6,7 +6,9 @@ from nodes import (
     classify_event_type,
     classify_node,
     evaluator_node,
+    fetch_node,
     guardrails_node,
+    present_node,
     summarize_node,
 )
 
@@ -226,3 +228,43 @@ def test_guardrails_node_no_summary_is_noop():
     assert guardrails_node({"anomalies": []}) == {}
 
 
+# ---------------------------------------------------------------------------
+# fetch_node: optional start_date/end_date threading (added for cli.py, Story 3)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_node_passes_date_range_from_state():
+    start = datetime(2026, 8, 1)
+    end = datetime(2026, 8, 31)
+    with patch("nodes.fetch_org_payment_logs") as mock_fetch:
+        mock_fetch.return_value = []
+        fetch_node({"start_date": start, "end_date": end})
+        mock_fetch.assert_called_once_with(start_date=start, end_date=end)
+
+
+# ---------------------------------------------------------------------------
+# present_node
+# ---------------------------------------------------------------------------
+
+
+def test_present_node_all_clear_report():
+    result = present_node({"anomalies": []})
+    assert "הכל תקין" in result["report"]
+
+
+def test_present_node_detailed_report_includes_summary_and_anomaly_details():
+    state = {
+        "summary": "Something looks off.",
+        "anomalies": [
+            {
+                "organization_id": "org-1",
+                "count": 3,
+                "window_start": datetime(2026, 8, 1, 0, 0),
+                "window_end": datetime(2026, 8, 1, 20, 0),
+            }
+        ],
+    }
+    result = present_node(state)
+    assert "Something looks off." in result["report"]
+    assert "org-1" in result["report"]
+    assert "3" in result["report"]

--- a/apps/agents/org-payments-log-agent/agent/tools.py
+++ b/apps/agents/org-payments-log-agent/agent/tools.py
@@ -1,0 +1,7 @@
+"""
+Placeholder for optional agent extensions (RAG / Web-Search / Code-Exec / MCP).
+
+Required by the submission's folder structure (see Appendix 1), but not
+implemented - these extensions are recommended, not mandatory, for this
+agent's scope (read-only log reporting).
+"""

--- a/apps/agents/org-payments-log-agent/evals/eval.py
+++ b/apps/agents/org-payments-log-agent/evals/eval.py
@@ -1,0 +1,139 @@
+"""Eval: measures (1) rule-based classify/anomaly-detection accuracy against a
+labeled fixture set, and (2) the summarize_node (LLM) output's professionalism
+and non-leakage, per the spec's Appendix 3 note.
+
+Run with: python evals/eval.py
+Requires a real .env (GEMINI_API_KEY) for part 2 - part 1 needs no LLM/DB access.
+Writes results to evals/results/eval_results.csv
+"""
+import csv
+import os
+import re
+import sys
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "agent"))
+
+from config import load_config  # noqa: E402
+from nodes import classify_node, evaluator_node, guardrails_node, summarize_node  # noqa: E402
+
+OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "results", "eval_results.csv")
+
+_BASE = datetime(2026, 8, 1, 12, 0, 0)
+
+# --- Part 1: classification + anomaly-detection accuracy ------------------
+
+CLASSIFICATION_FIXTURES = [
+    {"message": "Organization approved", "expected_event_type": "approval"},
+    {"message": "Organization rejected", "expected_event_type": "rejection"},
+    {
+        "message": "Organization wallet topped up successfully (Mock)",
+        "expected_event_type": "topup",
+    },
+    {"message": "Organization active state changed", "expected_event_type": "status_change"},
+    {"message": "Organization created in DB", "expected_event_type": "other"},
+]
+
+ANOMALY_FIXTURE_RECORDS = [
+    {
+        "message": "Organization wallet topped up successfully (Mock)",
+        "context": {"organizationId": "org-eval-1"},
+        "timestamp": _BASE + timedelta(hours=offset),
+    }
+    for offset in (0, 5, 10)
+] + [
+    {
+        "message": "Organization wallet topped up successfully (Mock)",
+        "context": {"organizationId": "org-eval-2"},
+        "timestamp": _BASE,
+    }
+]
+EXPECTED_ANOMALY_ORG_IDS = {"org-eval-1"}
+
+
+def _run_classification_checks(writer) -> None:
+    for case in CLASSIFICATION_FIXTURES:
+        result = classify_node({"records": [{"message": case["message"], "context": {}}]})
+        actual = result["classified"][0]["event_type"]
+        writer.writerow(
+            [
+                "classification",
+                case["message"],
+                case["expected_event_type"],
+                actual,
+                actual == case["expected_event_type"],
+            ]
+        )
+
+
+def _run_anomaly_detection_check(writer) -> None:
+    classified = classify_node({"records": ANOMALY_FIXTURE_RECORDS})["classified"]
+    anomalies = evaluator_node({"classified": classified})["anomalies"]
+    actual_org_ids = {a["organization_id"] for a in anomalies}
+    writer.writerow(
+        [
+            "anomaly_detection",
+            "3 topups/24h for org-eval-1, 1 topup for org-eval-2",
+            sorted(EXPECTED_ANOMALY_ORG_IDS),
+            sorted(actual_org_ids),
+            actual_org_ids == EXPECTED_ANOMALY_ORG_IDS,
+        ]
+    )
+
+
+# --- Part 2: summarize_node output - professionalism and non-leakage ------
+
+_OBJECT_ID_RE = re.compile(r"\b[0-9a-fA-F]{24}\b")
+
+
+def _run_summary_quality_check(writer) -> None:
+    config = load_config()
+    anomalies = [
+        {
+            "organization_id": "507f1f77bcf86cd799439011",
+            "type": "excessive_topups",
+            "count": 3,
+            "window_start": _BASE,
+            "window_end": _BASE + timedelta(hours=20),
+        }
+    ]
+    state = {"anomalies": anomalies}
+    summary = summarize_node(state, config)["summary"]
+    guarded_summary = guardrails_node({**state, "summary": summary})["summary"]
+
+    known_ids = {a["organization_id"] for a in anomalies}
+    leaked_ids = [m for m in _OBJECT_ID_RE.findall(guarded_summary) if m not in known_ids]
+    is_non_empty = bool(guarded_summary and guarded_summary.strip())
+
+    writer.writerow(
+        [
+            "summary_non_leakage",
+            "known org id only, no foreign ids",
+            "no leaked ids",
+            f"leaked={leaked_ids}" if leaked_ids else "no leaked ids",
+            not leaked_ids,
+        ]
+    )
+    writer.writerow(
+        [
+            "summary_non_empty",
+            "summarize_node produces non-empty text",
+            "non-empty",
+            guarded_summary[:80],
+            is_non_empty,
+        ]
+    )
+
+
+def run() -> None:
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["check", "input", "expected", "actual", "match"])
+        _run_classification_checks(writer)
+        _run_anomaly_detection_check(writer)
+        _run_summary_quality_check(writer)
+
+
+if __name__ == "__main__":
+    run()

--- a/apps/agents/org-payments-log-agent/manifest.json
+++ b/apps/agents/org-payments-log-agent/manifest.json
@@ -1,0 +1,49 @@
+{
+  "name": "SafeAI Org & Payments Log Agent",
+  "version": "1.0.0",
+  "description": "An autonomous, read-only agent that fetches organization and wallet activity from the applicationlogs collection, detects anomalous wallet top-up patterns, and generates a natural-language activity report for administrators.",
+  "entry_point": "agent/cli.py",
+  "framework": "langgraph",
+  "interfaces": ["cli"],
+  "requires_human_approval": false,
+  "environment_variables": [
+    "MONGO_URI",
+    "GEMINI_API_KEY",
+    "LLM_MODEL",
+    "LANGCHAIN_API_KEY",
+    "LANGCHAIN_PROJECT",
+    "LANGCHAIN_TRACING_V2"
+  ],
+  "creator_name": "SafeAI613",
+  "contact_information": "REPLACE_WITH_CONTACT_EMAIL",
+  "release_date": "2026-08-30",
+  "repository_url": "https://github.com/SafeAI613/SafeAI-613/tree/develop/apps/agents/org-payments-log-agent",
+  "download_url": "REPLACE_WITH_DOWNLOAD_URL",
+  "target_audience": "System Administrators, Product Managers",
+  "professional_fields": ["Product Management", "Platform Operations", "FinTech Monitoring"],
+  "tasks_capable_of_performing": [
+    "Fetching and filtering organization/payment activity logs",
+    "Classifying log events by type (approval, rejection, topup, status change)",
+    "Detecting anomalous wallet top-up patterns (3+ within 24 hours)",
+    "Generating a natural-language activity report"
+  ],
+  "examples_of_suitable_questions": [
+    "Are there any suspicious wallet top-up patterns this month?",
+    "Summarize organization approval/rejection activity for the last week.",
+    "Which organizations had unusual wallet activity recently?"
+  ],
+  "technical_specifications": {
+    "framework": "LangGraph",
+    "llm_provider": "Google Gemini",
+    "supported_models": ["gemini-flash-latest"],
+    "features_enabled": {
+      "rag": false,
+      "web_search": false,
+      "code_execution": false,
+      "mcp_support": false
+    },
+    "required_permissions": ["database_read"]
+  },
+  "author": "SafeAI613",
+  "license": "UNLICENSED"
+}

--- a/apps/agents/org-payments-log-agent/requirements.txt
+++ b/apps/agents/org-payments-log-agent/requirements.txt
@@ -1,0 +1,7 @@
+pymongo==4.17.0
+python-dotenv==1.2.2
+dnspython==2.8.0
+langgraph==1.2.9
+langsmith==0.11.2
+google-genai==2.20.0
+pytest==9.1.1


### PR DESCRIPTION
## Summary

Implements the Sprint 1 scope of **SCRUM-297** (Epic): a read-only CLI agent under `apps/agents/org-payments-log-agent/` that reads organization/wallet activity from `applicationlogs`, detects anomalous wallet top-up patterns, and produces an LLM-narrated report for admins.

Covers 4 Jira items, each as its own set of commits (15 total, one per sub-task):

- **SCRUM-298** - fetch and filter organization/payment logs (Mongo connection, `fetch_logs.py`, `GraphState`, `fetch_node`, minimal graph, tests)
- **SCRUM-299** - classify log events and detect wallet top-up anomalies (`classify_node`, `evaluator_node`, rule-based by design, tests)
- **SCRUM-300** - LLM-narrated report with a conditional Gate and Guardrails (`anomalies_gate`, `summarize_node` via Gemini/LangSmith, `guardrails_node`, `present_node`, `agent/cli.py`, full graph wiring)
- **SCRUM-301** (Task) - submission-readiness package (`manifest.json`, `evals/eval.py`, README, requirements.txt, `.env.example`, `.gitignore`)

Architecture:
```
fetch -> classify -> evaluate -> [Gate: anomalies found?]
  yes -> summarize (LLM) -> guardrails -> present (detailed report) -> END
  no  -> present (short "all clear") -> END
```

`classify_node`/`evaluator_node` are deliberately rule-based (deterministic, gradeable); `summarize_node` is the agent's one real LLM component, narrating the evaluator's findings; `guardrails_node` redacts any id-like token in the LLM output that isn't a known organization id.

Out of scope for this PR (tracked separately, Backlog only): **SCRUM-302** - running as a scheduled daily job and emailing the summary.

## Test plan

- [x] 28 unit tests pass (`cd apps/agents/org-payments-log-agent/agent && python -m pytest`)
- [x] `evals/eval.py` verified locally (8/8 checks) with a mocked LLM
- [x] Manual end-to-end run of the full graph against a mocked DB + LLM, both paths (anomalies found / all clear)
- [x] `agent/cli.py` argument parsing (`--start`/`--end`) verified

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TD3Yhos56eVUGuYpbUGiXr

---
_Generated by [Claude Code](https://claude.ai/code/session_01TD3Yhos56eVUGuYpbUGiXr)_