### PR TITLE
SCRUM-320: unify duplicated aggregation/permission logic in orgs & usage

### DIFF
--- a/apps/server/src/controllers/organizationController.ts
+++ b/apps/server/src/controllers/organizationController.ts
@@ -22,6 +22,7 @@ import {
   getMyOrganization,
 } from "../services/organizationService";
 import { sanitizeUser } from "../utils/sanitizeUser";
+import { isOrganizationAccessAllowed } from "../utils/organizationAccess";
 import logger from "../logger";
 
 /**
@@ -96,9 +97,7 @@ export async function getOrganizationHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
-
-    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -130,10 +129,9 @@ export async function updateOrganizationHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
     const isAdmin = user.role === "admin";
 
-    if (!isAdmin && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -199,11 +197,7 @@ export async function getOrganizationUsersHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const orgOwnerId = organization.ownerId?._id
-        ? organization.ownerId._id.toString()
-        : organization.ownerId.toString();
-
-    if (user.role !== "admin" && orgOwnerId !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied - You are not the owner" });
     }
 
@@ -237,9 +231,7 @@ export async function addUserToOrganizationHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
-
-    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -278,9 +270,7 @@ export async function createOrganizationMemberHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
-
-    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -328,9 +318,7 @@ export async function addUserByEmailToOrganizationHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
-
-    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -373,9 +361,7 @@ export async function removeUserFromOrganizationHandler(
       return res.status(404).json({ error: "User not found or not in an organization" });
     }
 
-    const ownerId = (targetOrg.ownerId as any)?._id ?? targetOrg.ownerId;
-
-    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, targetOrg)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -444,9 +430,7 @@ export async function topUpOrganizationWalletHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
-
-    if (user.role !== "admin" && ownerId.toString() !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 
@@ -542,11 +526,7 @@ export async function getOrganizationStatsHandler(
       return res.status(404).json({ error: "Organization not found" });
     }
 
-    const orgOwnerId = organization.ownerId?._id
-      ? organization.ownerId._id.toString()
-      : organization.ownerId.toString();
-
-    if (user.role !== "admin" && orgOwnerId !== user.userId) {
+    if (!isOrganizationAccessAllowed(user, organization)) {
       return res.status(403).json({ error: "Access denied" });
     }
 

--- a/apps/server/src/controllers/usageController.ts
+++ b/apps/server/src/controllers/usageController.ts
@@ -5,10 +5,16 @@
  */
 
 import { Request, Response } from "express";
-import { UsageLog } from "../models";
-import { User } from "../models/user";
+import { getUserById, updateUser } from "../repositories/userRepository";
+import {
+  aggregateUsageStats,
+  countFailedRequests,
+  countRequests,
+  getDailyUsage as getDailyUsageStats,
+  getUsageByModel as getUsageByModelStats,
+  getCostBreakdownByProvider,
+} from "../repositories/usageRepository";
 import logger from "../logger";
-import mongoose from "mongoose";
 
 /**
  * Get overall usage statistics for the authenticated user
@@ -22,41 +28,8 @@ export async function getUsageStats(req: Request, res: Response) {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    const stats = await UsageLog.aggregate([
-      {
-        $match: {
-          userId: new mongoose.Types.ObjectId(userId),
-          timestamp: { $gte: startDate },
-          success: true,
-        },
-      },
-      {
-        $group: {
-          _id: null,
-          totalRequests: { $sum: 1 },
-          successfulRequests: { $sum: 1 },
-          totalTokens: { $sum: "$totalTokens" },
-          totalCost: { $sum: "$cost" },
-          avgResponseTime: { $avg: "$responseTime" },
-          avgTokensPerRequest: { $avg: "$totalTokens" },
-        },
-      },
-    ]);
-
-    const failedRequests = await UsageLog.countDocuments({
-      userId: new mongoose.Types.ObjectId(userId),
-      timestamp: { $gte: startDate },
-      success: false,
-    });
-
-    const result = stats[0] || {
-      totalRequests: 0,
-      successfulRequests: 0,
-      totalTokens: 0,
-      totalCost: 0,
-      avgResponseTime: 0,
-      avgTokensPerRequest: 0,
-    };
+    const result = await aggregateUsageStats(userId, startDate);
+    const failedRequests = await countFailedRequests(userId, startDate);
 
     res.json({
       ...result,
@@ -84,29 +57,7 @@ export async function getDailyUsage(req: Request, res: Response) {
     startDate.setDate(startDate.getDate() - days);
     startDate.setHours(0, 0, 0, 0);
 
-    const dailyStats = await UsageLog.aggregate([
-      {
-        $match: {
-          userId: new mongoose.Types.ObjectId(userId),
-          timestamp: { $gte: startDate },
-          success: true,
-        },
-      },
-      {
-        $group: {
-          _id: {
-            $dateToString: { format: "%Y-%m-%d", date: "$timestamp" },
-          },
-          requests: { $sum: 1 },
-          tokens: { $sum: "$totalTokens" },
-          cost: { $sum: "$cost" },
-          avgResponseTime: { $avg: "$responseTime" },
-        },
-      },
-      {
-        $sort: { _id: 1 },
-      },
-    ]);
+    const dailyStats = await getDailyUsageStats(userId, startDate);
 
     res.json(dailyStats);
   } catch (error) {
@@ -127,31 +78,7 @@ export async function getUsageByModel(req: Request, res: Response) {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    const modelStats = await UsageLog.aggregate([
-      {
-        $match: {
-          userId: new mongoose.Types.ObjectId(userId),
-          timestamp: { $gte: startDate },
-          success: true,
-        },
-      },
-      {
-        $group: {
-          _id: {
-            model: "$modelName",
-            provider: "$provider",
-          },
-          requests: { $sum: 1 },
-          tokens: { $sum: "$totalTokens" },
-          cost: { $sum: "$cost" },
-          avgTokensPerRequest: { $avg: "$totalTokens" },
-          isFree: { $first: "$isFree" },
-        },
-      },
-      {
-        $sort: { requests: -1 },
-      },
-    ]);
+    const modelStats = await getUsageByModelStats(userId, startDate);
 
     res.json(modelStats);
   } catch (error) {
@@ -169,7 +96,7 @@ export async function getLimitsStatus(req: Request, res: Response) {
     const userId = user.userId; // JWT payload has userId, not _id
 
     // Fetch full user from database
-    const fullUser = await User.findById(userId);
+    const fullUser = await getUserById(userId);
     if (!fullUser) {
       return res.status(404).json({ error: "User not found" });
     }
@@ -185,14 +112,8 @@ export async function getLimitsStatus(req: Request, res: Response) {
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
     const [requestsLastMinute, requestsLastDay] = await Promise.all([
-      UsageLog.countDocuments({
-        userId: new mongoose.Types.ObjectId(userId),
-        timestamp: { $gte: oneMinuteAgo },
-      }),
-      UsageLog.countDocuments({
-        userId: new mongoose.Types.ObjectId(userId),
-        timestamp: { $gte: oneDayAgo },
-      }),
+      countRequests(userId, oneMinuteAgo),
+      countRequests(userId, oneDayAgo),
     ]);
 
     const response: any = {
@@ -243,7 +164,7 @@ export async function getCostBreakdown(req: Request, res: Response) {
     const userId = user.userId; // JWT payload has userId, not _id
 
     // Fetch full user from database
-    const fullUser = await User.findById(userId);
+    const fullUser = await getUserById(userId);
     if (!fullUser) {
       return res.status(404).json({ error: "User not found" });
     }
@@ -256,29 +177,7 @@ export async function getCostBreakdown(req: Request, res: Response) {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    const costStats = await UsageLog.aggregate([
-      {
-        $match: {
-          userId: new mongoose.Types.ObjectId(userId),
-          timestamp: { $gte: startDate },
-          success: true,
-        },
-      },
-      {
-        $group: {
-          _id: {
-            provider: "$provider",
-            isFree: "$isFree",
-          },
-          totalCost: { $sum: "$cost" },
-          requests: { $sum: 1 },
-          tokens: { $sum: "$totalTokens" },
-        },
-      },
-      {
-        $sort: { totalCost: -1 },
-      },
-    ]);
+    const costStats = await getCostBreakdownByProvider(userId, startDate);
 
     const totalCost = costStats.reduce((sum, item) => sum + item.totalCost, 0);
     const freeCost = costStats
@@ -332,11 +231,7 @@ export async function updateUserLimits(req: Request, res: Response) {
       }
     }
 
-    const user = await User.findByIdAndUpdate(
-      userId,
-      { $set: updateData },
-      { new: true }
-    );
+    const user = await updateUser(userId as string, { $set: updateData });
 
     if (!user) {
       return res.status(404).json({ error: "User not found" });

--- a/apps/server/src/repositories/usageRepository.ts
+++ b/apps/server/src/repositories/usageRepository.ts
@@ -1,0 +1,155 @@
+import mongoose from "mongoose";
+import { UsageLog } from "../models";
+import logger from "../logger";
+
+export interface UsageStatsSummary {
+  totalRequests: number;
+  successfulRequests: number;
+  totalTokens: number;
+  totalCost: number;
+  avgResponseTime: number;
+  avgTokensPerRequest: number;
+}
+
+const EMPTY_USAGE_STATS: UsageStatsSummary = {
+  totalRequests: 0,
+  successfulRequests: 0,
+  totalTokens: 0,
+  totalCost: 0,
+  avgResponseTime: 0,
+  avgTokensPerRequest: 0,
+};
+
+function toObjectIds(userIds: string | string[]) {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+  return ids.map((id) => new mongoose.Types.ObjectId(id));
+}
+
+/**
+ * Shared aggregation behind per-user usage stats and per-organization usage
+ * summaries - previously hand-copied in three places with a subtle bug: one
+ * copy matched userId as a raw string against an ObjectId field, which
+ * silently returns zero results in an aggregation $match (unlike find()).
+ */
+export async function aggregateUsageStats(
+  userIds: string | string[],
+  since?: Date
+): Promise<UsageStatsSummary> {
+  const match: Record<string, any> = {
+    userId: { $in: toObjectIds(userIds) },
+    success: true,
+  };
+  if (since) {
+    match.timestamp = { $gte: since };
+  }
+
+  const stats = await UsageLog.aggregate([
+    { $match: match },
+    {
+      $group: {
+        _id: null,
+        totalRequests: { $sum: 1 },
+        successfulRequests: { $sum: 1 },
+        totalTokens: { $sum: "$totalTokens" },
+        totalCost: { $sum: "$cost" },
+        avgResponseTime: { $avg: "$responseTime" },
+        avgTokensPerRequest: { $avg: "$totalTokens" },
+      },
+    },
+  ]);
+
+  return stats[0] ? { ...EMPTY_USAGE_STATS, ...stats[0] } : { ...EMPTY_USAGE_STATS };
+}
+
+export async function countRequests(userId: string, since: Date) {
+  return UsageLog.countDocuments({
+    userId: new mongoose.Types.ObjectId(userId),
+    timestamp: { $gte: since },
+  });
+}
+
+export async function countFailedRequests(userId: string, since: Date) {
+  return UsageLog.countDocuments({
+    userId: new mongoose.Types.ObjectId(userId),
+    timestamp: { $gte: since },
+    success: false,
+  });
+}
+
+export async function getDailyUsage(userId: string, since: Date) {
+  return UsageLog.aggregate([
+    {
+      $match: {
+        userId: new mongoose.Types.ObjectId(userId),
+        timestamp: { $gte: since },
+        success: true,
+      },
+    },
+    {
+      $group: {
+        _id: { $dateToString: { format: "%Y-%m-%d", date: "$timestamp" } },
+        requests: { $sum: 1 },
+        tokens: { $sum: "$totalTokens" },
+        cost: { $sum: "$cost" },
+        avgResponseTime: { $avg: "$responseTime" },
+      },
+    },
+    { $sort: { _id: 1 } },
+  ]);
+}
+
+export async function getUsageByModel(userId: string, since: Date) {
+  return UsageLog.aggregate([
+    {
+      $match: {
+        userId: new mongoose.Types.ObjectId(userId),
+        timestamp: { $gte: since },
+        success: true,
+      },
+    },
+    {
+      $group: {
+        _id: { model: "$modelName", provider: "$provider" },
+        requests: { $sum: 1 },
+        tokens: { $sum: "$totalTokens" },
+        cost: { $sum: "$cost" },
+        avgTokensPerRequest: { $avg: "$totalTokens" },
+        isFree: { $first: "$isFree" },
+      },
+    },
+    { $sort: { requests: -1 } },
+  ]);
+}
+
+export async function getCostBreakdownByProvider(userId: string, since: Date) {
+  return UsageLog.aggregate([
+    {
+      $match: {
+        userId: new mongoose.Types.ObjectId(userId),
+        timestamp: { $gte: since },
+        success: true,
+      },
+    },
+    {
+      $group: {
+        _id: { provider: "$provider", isFree: "$isFree" },
+        totalCost: { $sum: "$cost" },
+        requests: { $sum: 1 },
+        tokens: { $sum: "$totalTokens" },
+      },
+    },
+    { $sort: { totalCost: -1 } },
+  ]);
+}
+
+export async function createUsageLog(logData: any) {
+  try {
+    return await UsageLog.create(logData);
+  } catch (error: any) {
+    logger.error("Failed to create usage log in DB", {
+      error: error.message,
+      stack: error.stack,
+    });
+    throw error;
+  }
+}

--- a/apps/server/src/repositories/userRepository.ts
+++ b/apps/server/src/repositories/userRepository.ts
@@ -50,6 +50,25 @@ export async function updateUser(userId: string, data: any) {
   }).lean();
 }
 
+export async function incrementUserMonthlySpend(userId: string, amount: number) {
+  await User.updateOne(
+    { _id: userId },
+    { $inc: { "costLimits.currentMonthSpent": amount } }
+  );
+}
+
+export async function resetUserMonthlyBudget(userId: string, resetDate: Date) {
+  await User.updateOne(
+    { _id: userId },
+    {
+      $set: {
+        "costLimits.currentMonthSpent": 0,
+        "costLimits.lastResetDate": resetDate,
+      },
+    }
+  );
+}
+
 export async function deleteUser(userId: string) {
   return User.findByIdAndDelete(userId).lean();
 }

--- a/apps/server/src/services/__tests__/organizationService.test.ts
+++ b/apps/server/src/services/__tests__/organizationService.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 import * as organizationService from "../organizationService";
 import * as repo from "../../repositories/organizationRepository";
 import * as userRepo from "../../repositories/userRepository";
+import * as usageRepo from "../../repositories/usageRepository";
 import {
   sendOrgApprovedEmail,
   sendOrgStatusEmail,
@@ -9,20 +10,17 @@ import {
   sendInviteEmail,
 } from "../../utils/email";
 import { register } from "../authService";
-import { UsageLog } from "../../models";
 
 jest.mock("../../repositories/organizationRepository");
 jest.mock("../../repositories/userRepository");
+jest.mock("../../repositories/usageRepository");
 jest.mock("../../utils/email");
 jest.mock("../authService", () => ({ register: jest.fn() }));
-jest.mock("../../models", () => ({
-  UsageLog: { aggregate: jest.fn() },
-}));
 
 const mockedRepo = jest.mocked(repo);
 const mockedUserRepo = jest.mocked(userRepo);
+const mockedUsageRepo = jest.mocked(usageRepo);
 const mockedRegister = jest.mocked(register);
-const mockedUsageLog = jest.mocked(UsageLog);
 const mockedSendInviteEmail = jest.mocked(sendInviteEmail);
 
 beforeEach(() => {
@@ -589,23 +587,18 @@ describe("organizationService.getOrganizationUsageSummary", () => {
       { _id: "u1", organizationId: "org1" },
       { _id: "u2", organizationId: "org1" },
     ] as any);
-    mockedUsageLog.aggregate.mockResolvedValue([
-      { totalRequests: 5, totalTokens: 1000, totalCost: 2.5 },
-    ] as any);
+    mockedUsageRepo.aggregateUsageStats.mockResolvedValue({
+      totalRequests: 5,
+      successfulRequests: 5,
+      totalTokens: 1000,
+      totalCost: 2.5,
+      avgResponseTime: 0,
+      avgTokensPerRequest: 0,
+    });
 
     const result = await organizationService.getOrganizationUsageSummary("org1");
 
-    expect(mockedUsageLog.aggregate).toHaveBeenCalledWith([
-      { $match: { userId: { $in: ["u1", "u2"] }, success: true } },
-      {
-        $group: {
-          _id: null,
-          totalRequests: { $sum: 1 },
-          totalTokens: { $sum: "$totalTokens" },
-          totalCost: { $sum: "$cost" },
-        },
-      },
-    ]);
+    expect(mockedUsageRepo.aggregateUsageStats).toHaveBeenCalledWith(["u1", "u2"]);
     expect(result).toEqual({
       userCount: 2,
       totalRequests: 5,
@@ -618,7 +611,14 @@ describe("organizationService.getOrganizationUsageSummary", () => {
     mockedUserRepo.getUsersByOrganization.mockResolvedValue([
       { _id: "u1", organizationId: "org1" },
     ] as any);
-    mockedUsageLog.aggregate.mockResolvedValue([] as any);
+    mockedUsageRepo.aggregateUsageStats.mockResolvedValue({
+      totalRequests: 0,
+      successfulRequests: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      avgResponseTime: 0,
+      avgTokensPerRequest: 0,
+    });
 
     const result = await organizationService.getOrganizationUsageSummary("org1");
 

--- a/apps/server/src/services/organizationService.ts
+++ b/apps/server/src/services/organizationService.ts
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import * as repo from "../repositories/organizationRepository";
 import * as userRepo from "../repositories/userRepository";
-import { UsageLog } from "../models";
+import { aggregateUsageStats } from "../repositories/usageRepository";
 import { register } from "./authService";
 import { sendOrgApprovalRequestEmail, sendOrgApprovedEmail, sendOrgStatusEmail, sendInviteEmail } from "../utils/email";
 import logger from "../logger";
@@ -462,21 +462,13 @@ export async function setOrganizationActive(orgId: string, isActive: boolean) {
 
 export async function getOrganizationUsageSummary(orgId: string) {
   const users = await getOrganizationUsers(orgId);
-  const userIds = users.map((u: any) => u._id);
+  const userIds = users.map((u: any) => u._id.toString());
 
-  const stats = await UsageLog.aggregate([
-    { $match: { userId: { $in: userIds }, success: true } },
-    {
-      $group: {
-        _id: null,
-        totalRequests: { $sum: 1 },
-        totalTokens: { $sum: "$totalTokens" },
-        totalCost: { $sum: "$cost" },
-      },
-    },
-  ]);
+  if (userIds.length === 0) {
+    return { userCount: 0, totalRequests: 0, totalTokens: 0, totalCost: 0 };
+  }
 
-  const summary = stats[0] || { totalRequests: 0, totalTokens: 0, totalCost: 0 };
+  const summary = await aggregateUsageStats(userIds);
   return {
     userCount: users.length,
     totalRequests: summary.totalRequests,

--- a/apps/server/src/services/usageTracker.ts
+++ b/apps/server/src/services/usageTracker.ts
@@ -5,8 +5,8 @@
  * Logs each request to the database and updates user's monthly spending.
  */
 
-import { UsageLog } from "../models";
-import { User } from "../models/user";
+import { getUserById, incrementUserMonthlySpend, resetUserMonthlyBudget } from "../repositories/userRepository";
+import { aggregateUsageStats, createUsageLog } from "../repositories/usageRepository";
 import logger from "../logger";
 
 interface LogUsageParams {
@@ -97,14 +97,11 @@ export async function logUsage(params: LogUsageParams): Promise<void> {
       logData.profileId = profileId;
     }
 
-    await UsageLog.create(logData);
+    await createUsageLog(logData);
 
     // Update user's monthly spending if not free and in MANAGED mode
     if (!isFree && mode === "MANAGED" && usageData.cost > 0) {
-      await User.updateOne(
-        { _id: userId },
-        { $inc: { "costLimits.currentMonthSpent": usageData.cost } }
-      );
+      await incrementUserMonthlySpend(userId, usageData.cost);
     }
 
     logger.info("Usage logged successfully", {
@@ -126,7 +123,7 @@ export async function logUsage(params: LogUsageParams): Promise<void> {
  */
 export async function checkAndResetMonthlyBudget(userId: string): Promise<void> {
   try {
-    const user = await User.findById(userId);
+    const user = await getUserById(userId);
     if (!user) return;
 
     const lastReset = new Date(user.costLimits?.lastResetDate || user.createdAt);
@@ -138,15 +135,7 @@ export async function checkAndResetMonthlyBudget(userId: string): Promise<void> 
       (now.getMonth() - lastReset.getMonth());
 
     if (monthsPassed >= 1) {
-      await User.updateOne(
-        { _id: userId },
-        {
-          $set: {
-            "costLimits.currentMonthSpent": 0,
-            "costLimits.lastResetDate": now,
-          },
-        }
-      );
+      await resetUserMonthlyBudget(userId, now);
 
       logger.info("Monthly budget reset", { userId });
     }
@@ -163,31 +152,7 @@ export async function getUserUsageStats(userId: string, days: number = 7) {
     const startDate = new Date();
     startDate.setDate(startDate.getDate() - days);
 
-    const stats = await UsageLog.aggregate([
-      {
-        $match: {
-          userId: userId,
-          timestamp: { $gte: startDate },
-          success: true,
-        },
-      },
-      {
-        $group: {
-          _id: null,
-          totalRequests: { $sum: 1 },
-          totalTokens: { $sum: "$totalTokens" },
-          totalCost: { $sum: "$cost" },
-          avgResponseTime: { $avg: "$responseTime" },
-        },
-      },
-    ]);
-
-    return stats[0] || {
-      totalRequests: 0,
-      totalTokens: 0,
-      totalCost: 0,
-      avgResponseTime: 0,
-    };
+    return await aggregateUsageStats(userId, startDate);
   } catch (error) {
     logger.error("Failed to get usage stats", { error, userId });
     return {

--- a/apps/server/src/utils/organizationAccess.ts
+++ b/apps/server/src/utils/organizationAccess.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared owner/admin access check for organization-scoped routes. Previously
+ * hand-copied in organizationController.ts across ~9 handlers, sometimes as
+ * `ownerId?._id ?? ownerId` and sometimes as a ternary of the same logic -
+ * centralized so a future change to the admin-bypass rule only needs to
+ * happen in one place (SCRUM-320).
+ */
+
+interface OwnedByOrganization {
+  ownerId: { _id?: unknown } | unknown;
+}
+
+interface RequestingUser {
+  role: string;
+  userId: string;
+}
+
+export function getOrganizationOwnerId(organization: OwnedByOrganization): string {
+  const ownerId = (organization.ownerId as any)?._id ?? organization.ownerId;
+  return ownerId.toString();
+}
+
+export function isOrganizationAccessAllowed(
+  user: RequestingUser,
+  organization: OwnedByOrganization
+): boolean {
+  return user.role === "admin" || getOrganizationOwnerId(organization) === user.userId;
+}


### PR DESCRIPTION
## Summary
Addresses the tech-debt findings in [SCRUM-320](https://safeai613.atlassian.net/browse/SCRUM-320): three places where organizations/payments code was duplicated across the server.

- **New `usageRepository.ts`** (+ two small `userRepository.ts` additions) so `usageController`, `usageTracker`, and `organizationService` stop calling `UsageLog`/`User` Mongoose models directly, per the service→repository→model pattern in CLAUDE.md.
- **Single shared `aggregateUsageStats()`** replaces the same `$match`/`$group` cost/token pipeline that was hand-copied in three places. This also fixes a latent bug: `usageTracker.getUserUsageStats` matched `userId` as a raw string against an `ObjectId` schema field inside an aggregation `$match`, which silently returns zero results (unlike `find()`, aggregation doesn't auto-cast).
- **New `isOrganizationAccessAllowed()` helper** (`utils/organizationAccess.ts`) replaces the owner/admin permission check that was repeated ~9 times (in two slightly different spellings) across `organizationController.ts`.

No behavior changes intended beyond the `getUserUsageStats` bug fix above; all handler responses and route contracts stay the same.

## Test plan
- [x] `npx tsc --noEmit` passes on `apps/server`
- [x] Full server test suite passes (97/97), including updated `organizationService.test.ts` (now mocks `usageRepository` instead of the raw `UsageLog` model)
- [x] `npx eslint` on all changed files — 0 errors (only pre-existing `no-explicit-any` warnings, consistent with the rest of the codebase)