### PR TITLE
Block "+" in registration email addresses

### DIFF
--- a/apps/client/src/features/auth/RegisterForm.tsx
+++ b/apps/client/src/features/auth/RegisterForm.tsx
@@ -42,6 +42,7 @@ export default function RegisterForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
+  const [emailError, setEmailError] = useState<string | null>(null);
   const [agreedToPrivacyPolicy, setAgreedToPrivacyPolicy] = useState(false);
   const navigate = useNavigate();
 
@@ -63,6 +64,13 @@ export default function RegisterForm() {
     // };
     // fetchOrganizations();
   }, []);
+
+  const validateEmail = (email: string): string | null => {
+    if (email.includes("+")) {
+      return 'לא ניתן להשתמש בתו "+" בכתובת המייל';
+    }
+    return null;
+  };
 
   const validatePassword = (password: string): string[] => {
     const errors: string[] = [];
@@ -86,6 +94,15 @@ export default function RegisterForm() {
     setLoading(true);
     setError(null);
     setPasswordErrors([]);
+    setEmailError(null);
+
+    // Validate email
+    const emailValidationError = validateEmail(formData.email);
+    if (emailValidationError) {
+      setEmailError(emailValidationError);
+      setLoading(false);
+      return;
+    }
 
     // Validate passwords match
     if (formData.password !== formData.confirmPassword) {
@@ -160,6 +177,10 @@ export default function RegisterForm() {
     if (name === "password" && passwordErrors.length > 0) {
       setPasswordErrors([]);
     }
+
+    if (name === "email") {
+      setEmailError(validateEmail(value));
+    }
   };
 
   return (
@@ -193,6 +214,9 @@ export default function RegisterForm() {
               placeholder="your@email.com"
               autoComplete="email"
             />
+            {emailError && (
+              <span style={{ color: "#dc3545", fontSize: "12px" }}>{emailError}</span>
+            )}
           </div>
 
           <div className="form-group">

--- a/apps/server/src/utils/__tests__/validation.test.ts
+++ b/apps/server/src/utils/__tests__/validation.test.ts
@@ -1,12 +1,31 @@
 import { describe, it, expect } from '@jest/globals';
+import { registerSchema } from '../validation';
 
-// Example test file - replace with actual tests for your validation utilities
-describe('Validation Utils', () => {
-  it('should pass example test', () => {
-    expect(true).toBe(true);
+describe('registerSchema', () => {
+  const baseData = {
+    password: 'Password1',
+    name: 'Test User',
+    organizationId: '6a00e26b1e9d916a4da16fd7',
+  };
+
+  it('rejects an email containing "+"', () => {
+    const result = registerSchema.safeParse({
+      ...baseData,
+      email: 'user+tag@example.com',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message.includes('+'))).toBe(true);
+    }
   });
 
-  it('should perform basic arithmetic', () => {
-    expect(1 + 1).toBe(2);
+  it('accepts a valid email without "+"', () => {
+    const result = registerSchema.safeParse({
+      ...baseData,
+      email: 'user@example.com',
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/server/src/utils/validation.ts
+++ b/apps/server/src/utils/validation.ts
@@ -8,7 +8,12 @@ import { z } from "zod";
  * Registration validation schema
  */
 export const registerSchema = z.object({
-  email: z.string().email("כתובת אימייל לא תקינה"),
+  email: z
+    .string()
+    .email("כתובת אימייל לא תקינה")
+    .refine((email) => !email.includes("+"), {
+      message: 'לא ניתן להשתמש בתו "+" בכתובת המייל',
+    }),
   password: z
     .string()
     .min(8, "הסיסמה חייבת להכיל לפחות 8 תווים")


### PR DESCRIPTION
## Summary
- Reject emails containing `+` (e.g. `user+tag@example.com`) during registration, enforced server-side via a `refine()` on `registerSchema.email`.
- Mirror the same check client-side in `RegisterForm` with live inline feedback under the email field.
- Replace the placeholder `validation.test.ts` stub with real coverage for `registerSchema`'s new email rule.

## Test plan
- [x] `npx jest` in `apps/server` — 70/70 tests pass, including the new email validation tests.
- [x] `npm run typecheck` in `apps/client` — passes.
- [x] `npm run lint` in `apps/client` — no new warnings/errors introduced.
- [x] Manually verified in-browser by the requester.

🤖 Generated with [Claude Code](https://claude.com/claude-code)