### PR TITLE
fix(cd-staging): fix client build OOM causing stale staging deploy

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -97,6 +97,6 @@ jobs:
 
             cd apps/client
             npm ci
-            VITE_API_URL=/api VITE_BASE_PATH=/ npm run build
+            NODE_OPTIONS=--max-old-space-size=4096 VITE_API_URL=/api VITE_BASE_PATH=/ npm run build
             sudo rm -rf /var/www/safeai/*
             sudo cp -r dist/. /var/www/safeai/

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -193,6 +193,7 @@ server {
    ```
    ה-`--transpile-only` נדרש כי `ts-node` (עם type-checking מלא) נכשל על שגיאת TS לא-קשורה ב-`seedDevData.ts` (`User.findOne({ email })`, TS2353) שלא מופיעה ב-`npm run build` הרגיל (`tsc`) שמשמש את ה-Dockerfile — ככל הנראה הבדל בהתנהגות type-checking בין השניים. הסקריפט עצמו בטוח להרצה חוזרת (idempotent, בודק לפי מפתח ייחודי).
 9. **403 מהסביבה של Claude עצמה, לא מהשרת.** בדיקת `curl` לדומיין ה-staging מתוך sandbox של Claude Code החזירה `403` עם `x-deny-reason: host_not_allowed` — זה ה-proxy של סביבת ה-agent (allowlist דומיינים), **לא** אינדיקציה לתקלה אמיתית באתר. תמיד לוודא זמינות אמיתית מדפדפן/מכונה רגילה, לא מתוך session של Claude.
+10. **`vite build` נגמר לו הזיכרון על ה-EC2 של staging** (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`, קורס עם exit code 134). קרה אחרי מיזוג גדול שהגדיל משמעותית את באנדל ה-client (landing v2, dashboard pages, dark mode, וכו'). ה-`server`/`litellm` דרך Docker כן עלו בהצלחה באותה ריצה — רק שלב בניית ה-client על ה-host עצמו נכשל, ולכן ה-API עבד אבל הקבצים הסטטיים **לא התעדכנו** (המשיכו להגיש את הגרסה הישנה). **תיקון**: `NODE_OPTIONS=--max-old-space-size=4096` לפני `npm run build` בשלב ה-deploy (`cd-staging.yml`) — נותן ל-V8 heap ceiling גבוה יותר מברירת המחדל שהוא מחשב לפי זיכרון המכונה. אם זה יקרה שוב גם עם ה-heap המוגדל, יש לבדוק כמות RAM בפועל על ה-EC2 (`free -h`) — יתכן שצריך גם swap, או להעביר את בניית ה-client ל-CI (יותר זיכרון) ולהעתיק רק את ה-`dist/` המוכן ל-host דרך scp/rsync במקום לבנות שם.
 
 ## 11. מה עוד לא מכוסה
 


### PR DESCRIPTION
## Summary
Live incident on `dev.safeai613.com` after [PR #361](https://github.com/SafeAI613/SafeAI-613/pull/361) merged: reported as a 502 on `/api/*`.

Root cause investigation (workflow run [33601363028](https://github.com/SafeAI613/SafeAI-613/actions/runs/33601363028)):
1. **First failure**: `litellm` container failed its healthcheck within the timeout window → `server` (which depends on `litellm: condition: service_healthy`) never started, after the old `server` container had already been stopped → 502 on all `/api/*`. This looked like the known Neon Postgres cold-start flake documented in `docs/DEPLOYMENT.md` §10.
2. Re-ran the failed job. `litellm` came up healthy in ~1s this time (confirms #1 was transient) and `server` started successfully — so the API should be back.
3. **But** the same re-run then failed at a later, unrelated step: building the client directly on the EC2 host now runs out of memory (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`, exit 134). This branch's merge grew the client bundle substantially (dark mode support, landing v2, dashboard pages, etc.), and V8's default heap ceiling on that host isn't enough anymore. Net effect: the API is back up, but staging's static client files were never rebuilt/copied — the site is currently serving the **stale, pre-merge frontend**.

## Fix
Give the client build step a larger V8 heap ceiling: `NODE_OPTIONS=--max-old-space-size=4096` before `npm run build` in `cd-staging.yml`. Minimal, scoped, reversible.

Also documented this as a new entry (#10) in `docs/DEPLOYMENT.md` §10, per the file's own instruction to log every real deploy failure encountered — including a fallback next step (check `free -h` on the EC2 box / move the client build into CI) if the heap bump alone isn't enough.

## Test plan
- [ ] Merge, let `cd-staging.yml` run, confirm the "Deploy to staging" job completes (client build no longer OOMs)
- [ ] Confirm `dev.safeai613.com` serves the current frontend (dark mode toggle, new landing/news pages visible) — can't verify from this sandbox, its own network policy blocks direct access to the domain (see DEPLOYMENT.md §10.9)
- [ ] If it OOMs again even with the raised ceiling, check actual RAM on the EC2 host (`free -h`) — may need swap or to move client builds into CI

https://claude.ai/code/session_01XtfeXrmFmsMZWSUgnBZLeT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtfeXrmFmsMZWSUgnBZLeT)_