### PR TITLE
perf(org): add index on Organization.status

### DIFF
--- a/apps/server/src/models/organization.ts
+++ b/apps/server/src/models/organization.ts
@@ -45,6 +45,7 @@ const OrganizationSchema = new mongoose.Schema(
 // Index for faster lookups (name's unique index is already created by
 // `unique: true` on the field above - no need to declare it again here)
 OrganizationSchema.index({ ownerId: 1 });
+OrganizationSchema.index({ status: 1 });
 
 OrganizationSchema.set("toJSON", {
   transform: (_doc, ret) => {


### PR DESCRIPTION
## Issue
Closes #278

## Summary
`Organization.status` was queried without an index (`GET /organizations/pending`, admin stats), forcing a full collection scan. Adds a single-field index on `status`.

Reimplementation of #292, which predates the `apps/` monorepo restructure and could no longer be merged cleanly (structural conflicts against the current file layout, not a normal merge conflict). Same one-line change, applied fresh against current `develop`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/models/organization.ts` — 0 errors
- [x] `npx jest organization` — 46/46 pass
- [x] Full server suite — 15/15 suites, 125/125 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn)_