### PR TITLE
test(models): cover ProviderKey schema no longer exposing plaintext apiKey

### DIFF
--- a/apps/server/src/models/__tests__/providerKey.test.ts
+++ b/apps/server/src/models/__tests__/providerKey.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "@jest/globals";
+import { ProviderKey } from "../providerKey";
+
+describe("ProviderKey model (#277)", () => {
+  it("does not define a plaintext apiKey field in the schema", () => {
+    expect(ProviderKey.schema.path("apiKey")).toBeUndefined();
+  });
+
+  it("never exposes apiKeyEncrypted via toJSON", () => {
+    const doc = new ProviderKey({
+      provider: "openai",
+      apiKeyEncrypted: "encrypted-value",
+      keyPrefix: "sk-***",
+    });
+
+    const json = doc.toJSON() as any;
+
+    expect(json.apiKeyEncrypted).toBeUndefined();
+    expect(json.apiKey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Issue
Closes #277

## Note on scope
The actual fix — removing the dead `apiKey: String` field from `ProviderKeySchema` — was already landed directly on `develop` by a separate commit (`a3aaaaf`, "fix: remove unused plaintext apiKey field from ProviderKey model") before this reimplementation started. This PR only adds the regression test coverage that #285 proposed alongside its own copy of that fix, so it isn't lost.

Reimplementation of #285, which predates the `apps/` monorepo restructure and could no longer be merged cleanly (structural conflicts against the current file layout, not a normal merge conflict).

## מה נבדק
`ProviderKey` no longer defines `apiKey` in its schema, and `toJSON` never exposes `apiKeyEncrypted` or `apiKey`.

## טסטים
- [x] `npx jest src/models/__tests__/providerKey.test.ts` — 2/2 pass
- [x] Manually re-added `apiKey: String` to the schema locally to confirm the first test fails, then reverted
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` — 0 errors
- [x] Full server suite — 16/16 suites, 127/127 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn)_