### PR TITLE
refactor(org): unify OrganizationUsersPage on the shared API layer

### DIFF
--- a/apps/client/src/config/api.ts
+++ b/apps/client/src/config/api.ts
@@ -36,6 +36,7 @@ export const API_ENDPOINTS = {
     reject: (id: string) => `${API_BASE_URL}/organizations/${id}/reject`,
     publicRequest: `${API_BASE_URL}/organizations/public-request`,
     my: `${API_BASE_URL}/organizations/my`,
+    topUp: (id: string) => `${API_BASE_URL}/organizations/${id}/top-up`,
   },
   // Proxy key endpoints (user's own proxy key)
   proxyKey: {

--- a/apps/client/src/features/organizations/api/organizationApi.ts
+++ b/apps/client/src/features/organizations/api/organizationApi.ts
@@ -118,3 +118,25 @@ export const createOrganizationMember = async (
 export const getMyOrganization = async (): Promise<{ organization: AdminOrganization | null }> => {
   return apiCall(API_ENDPOINTS.adminOrganizations.my, { method: "GET" });
 };
+
+// עדכון שם/תיאור הארגון
+export const updateOrganizationDetails = async (
+  id: string,
+  data: { name: string; description: string }
+): Promise<{ organization: AdminOrganization }> => {
+  return apiCall(API_ENDPOINTS.adminOrganizations.detail(id), {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+};
+
+// טעינת ארנק הארגון (סימולציה)
+export const topUpOrganizationWallet = async (
+  id: string,
+  amount: number
+): Promise<{ organization: AdminOrganization }> => {
+  return apiCall(API_ENDPOINTS.adminOrganizations.topUp(id), {
+    method: "POST",
+    body: JSON.stringify({ amount }),
+  });
+};

--- a/apps/client/src/pages/OrganizationUsersPage.tsx
+++ b/apps/client/src/pages/OrganizationUsersPage.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
 import * as XLSX from "xlsx";
-import { createOrganizationMember, getMyOrganization } from "../features/organizations/api/organizationApi";
+import {
+  createOrganizationMember,
+  getMyOrganization,
+  getOrganizationUsers,
+  topUpOrganizationWallet,
+  updateOrganizationDetails,
+} from "../features/organizations/api/organizationApi";
 import "../styles/organization-wallet.css";
 
 interface User {
@@ -63,13 +68,6 @@ export default function OrganizationUsersPage() {
       setError("");
       setNoOrganization(false);
 
-      const token = localStorage.getItem("accessToken");
-
-      if (!token) {
-        setError("לא נמצא טוקן גישה. אנא התחברי מחדש.");
-        return;
-      }
-
       const { organization: myOrg } = await getMyOrganization();
 
       if (!myOrg) {
@@ -79,38 +77,11 @@ export default function OrganizationUsersPage() {
 
       setOrganization(myOrg as unknown as Organization);
 
-      const usersResponse = await axios.get(
-        `${import.meta.env.VITE_API_URL}/organizations/${myOrg._id}/users`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        }
-      );
-
-      setUsers(usersResponse.data);
+      const usersData = await getOrganizationUsers(myOrg._id);
+      setUsers(usersData as unknown as User[]);
     } catch (err: unknown) {
       console.error("Error fetching organization users:", err);
-
-      let serverError = "Failed to fetch organization users";
-
-      if (axios.isAxiosError(err)) {
-        if (err.response?.data) {
-          serverError =
-            typeof err.response.data === "string"
-              ? err.response.data
-              : err.response.data.error ||
-              err.response.data.message ||
-              JSON.stringify(err.response.data);
-        } else if (err.message) {
-          serverError = err.message;
-        }
-
-        const failedUrl = err.config?.url ? ` (נתיב: ${err.config.url})` : "";
-        setError(`${serverError}${failedUrl}`);
-      } else if (err instanceof Error) {
-        setError(err.message);
-      } else {
-        setError(serverError);
-      }
+      setError(err instanceof Error ? err.message : "Failed to fetch organization users");
     } finally {
       setLoading(false);
     }
@@ -124,37 +95,18 @@ export default function OrganizationUsersPage() {
     try {
       setIsSubmitting(true);
 
-      const token = localStorage.getItem("accessToken");
-
-      const response = await axios.post(
-        `${import.meta.env.VITE_API_URL}/organizations/${organization._id}/top-up`,
-        { amount: Number(topUpAmount) },
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        }
+      const { organization: updatedOrg } = await topUpOrganizationWallet(
+        organization._id,
+        Number(topUpAmount)
       );
 
-      alert(
-        `הארנק נטען בהצלחה! יתרה חדשה: $${response.data.organization.walletBalance}`
-      );
+      alert(`הארנק נטען בהצלחה! יתרה חדשה: $${updatedOrg.walletBalance}`);
 
-      setOrganization(response.data.organization);
+      setOrganization(updatedOrg as unknown as Organization);
       setTopUpAmount("");
     } catch (err: unknown) {
       console.error("Error topping up wallet:", err);
-
-      if (axios.isAxiosError(err)) {
-        const errorMsg =
-          err.response?.data?.error ||
-          err.response?.data?.message ||
-          "נכשל הטעינה לארנק";
-
-        alert(errorMsg);
-      } else if (err instanceof Error) {
-        alert(err.message);
-      } else {
-        alert("נכשל הטעינה לארנק");
-      }
+      alert(err instanceof Error ? err.message : "נכשל הטעינה לארנק");
     } finally {
       setIsSubmitting(false);
     }
@@ -175,33 +127,16 @@ export default function OrganizationUsersPage() {
     try {
       setIsSavingOrg(true);
 
-      const token = localStorage.getItem("accessToken");
+      const { organization: updatedOrg } = await updateOrganizationDetails(organization._id, {
+        name: editName,
+        description: editDescription,
+      });
 
-      const response = await axios.put(
-        `${import.meta.env.VITE_API_URL}/organizations/${organization._id}`,
-        { name: editName, description: editDescription },
-        {
-          headers: { Authorization: `Bearer ${token}` },
-        }
-      );
-
-      setOrganization(response.data.organization);
+      setOrganization(updatedOrg as unknown as Organization);
       setIsEditingOrg(false);
     } catch (err: unknown) {
       console.error("Error updating organization:", err);
-
-      if (axios.isAxiosError(err)) {
-        const errorMsg =
-          err.response?.data?.error ||
-          err.response?.data?.message ||
-          "נכשל עדכון פרטי הארגון";
-
-        alert(errorMsg);
-      } else if (err instanceof Error) {
-        alert(err.message);
-      } else {
-        alert("נכשל עדכון פרטי הארגון");
-      }
+      alert(err instanceof Error ? err.message : "נכשל עדכון פרטי הארגון");
     } finally {
       setIsSavingOrg(false);
     }
@@ -209,12 +144,8 @@ export default function OrganizationUsersPage() {
 
   const reloadUsers = async () => {
     if (!organization) return;
-    const token = localStorage.getItem("accessToken");
-    const usersResponse = await axios.get(
-      `${import.meta.env.VITE_API_URL}/organizations/${organization._id}/users`,
-      { headers: { Authorization: `Bearer ${token}` } }
-    );
-    setUsers(usersResponse.data);
+    const usersData = await getOrganizationUsers(organization._id);
+    setUsers(usersData as unknown as User[]);
   };
 
   const handleAddMember = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Issue
Closes #282

## Summary
`OrganizationUsersPage.tsx` called organization endpoints with raw `axios` requests, manually reading the access token from `localStorage` and duplicating error-parsing logic, while every other organization screen goes through `organizationApi.ts`'s `apiCall` wrapper (which also handles token-refresh-on-401). Replaced the raw axios calls with the shared API layer and added the two missing wrapper functions it needed (`updateOrganizationDetails`, `topUpOrganizationWallet`).

No behavior change intended - same endpoints, same payloads, same response shapes.

Reimplementation of #294, which predates the `apps/` monorepo restructure and could no longer be merged cleanly (structural conflicts against the current file layout, not a normal merge conflict). Same change, applied fresh against current `develop`.

## Test plan
- [x] `tsc --noEmit` on touched files — no new errors
- [x] `npx eslint` on touched files — 0 errors
- [x] Production build succeeds
- [ ] Manual: edit org details, top up wallet, add a member, confirm all three still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn)_