### PR TITLE
fix(org): admin audit notifications + approve/reject confirmation UX

### DIFF
--- a/apps/client/src/features/organizations/components/PendingOrganizationsTable.tsx
+++ b/apps/client/src/features/organizations/components/PendingOrganizationsTable.tsx
@@ -12,12 +12,14 @@ interface PendingOrganizationsTableProps {
   organizations: Organization[];
   onApprove: (id: string) => void;
   onReject: (id: string) => void;
+  busyId: string | null;
 }
 
-export const PendingOrganizationsTable: React.FC<PendingOrganizationsTableProps> = ({ 
-  organizations, 
-  onApprove, 
-  onReject 
+export const PendingOrganizationsTable: React.FC<PendingOrganizationsTableProps> = ({
+  organizations,
+  onApprove,
+  onReject,
+  busyId,
 }) => {
   if (organizations.length === 0) {
     return <div className="pending-orgs-empty">כעת אין ארגונים ממתינים לאישור</div>;
@@ -44,19 +46,21 @@ export const PendingOrganizationsTable: React.FC<PendingOrganizationsTableProps>
               </span>
             </td>
             <td>
-              <button 
-                className="btn-approve" 
+              <button
+                className="btn-approve"
                 onClick={() => onApprove(org._id)}
+                disabled={busyId === org._id}
                 style={{ marginLeft: '8px', cursor: 'pointer' }}
               >
-                אישור
+                {busyId === org._id ? "מעבד..." : "אישור"}
               </button>
-              <button 
-                className="btn-reject" 
+              <button
+                className="btn-reject"
                 onClick={() => onReject(org._id)}
+                disabled={busyId === org._id}
                 style={{ cursor: 'pointer' }}
               >
-                דחייה
+                {busyId === org._id ? "מעבד..." : "דחייה"}
               </button>
             </td>
           </tr>

--- a/apps/client/src/features/organizations/pages/PendingOrganizationsPage.tsx
+++ b/apps/client/src/features/organizations/pages/PendingOrganizationsPage.tsx
@@ -15,6 +15,7 @@ export const PendingOrganizationsPage = () => {
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchOrganizations = async () => {
@@ -36,24 +37,36 @@ export const PendingOrganizationsPage = () => {
   }, []);
 
   const handleApprove = async (id: string) => {
+    const org = organizations.find((o) => o._id === id);
+    if (!window.confirm(`לאשר את הארגון "${org?.name ?? ""}"?`)) return;
+
     try {
+      setBusyId(id);
       await updateOrganizationStatus(id, "approved");
-      setOrganizations((prev) => prev.filter((org) => org._id !== id));
+      setOrganizations((prev) => prev.filter((o) => o._id !== id));
       alert("הארגון אושר בהצלחה בבסיס הנתונים!");
     } catch (err: unknown) {
       console.error(err);
       alert(`שגיאה בעדכון הארגון: ${err instanceof Error ? err.message : "נכשלה הפעולה"}`);
+    } finally {
+      setBusyId(null);
     }
   };
 
   const handleReject = async (id: string) => {
+    const org = organizations.find((o) => o._id === id);
+    if (!window.confirm(`לדחות את הארגון "${org?.name ?? ""}"? הפעולה אינה הפיכה.`)) return;
+
     try {
+      setBusyId(id);
       await updateOrganizationStatus(id, "rejected");
-      setOrganizations((prev) => prev.filter((org) => org._id !== id));
+      setOrganizations((prev) => prev.filter((o) => o._id !== id));
       alert("הארגון נדחה בהצלחה בבסיס הנתונים!");
     } catch (err: unknown) {
       console.error(err);
       alert(`שגיאה בעדכון הארגון: ${err instanceof Error ? err.message : "נכשלה הפעולה"}`);
+    } finally {
+      setBusyId(null);
     }
   };
 
@@ -65,10 +78,11 @@ export const PendingOrganizationsPage = () => {
       <h1 className="pending-orgs-title">אישור ארגונים</h1>
       <p className="pending-orgs-subtitle">לפניך רשימת הארגונים הממתינים לאישור הגישה שלהם.</p>
       
-      <PendingOrganizationsTable 
-        organizations={organizations} 
+      <PendingOrganizationsTable
+        organizations={organizations}
         onApprove={handleApprove}
         onReject={handleReject}
+        busyId={busyId}
       />
     </div>
   );

--- a/apps/server/src/controllers/organizationController.ts
+++ b/apps/server/src/controllers/organizationController.ts
@@ -476,7 +476,8 @@ export async function suspendOrganizationHandler(
   res: Response
 ) {
   try {
-    const updated = await setOrganizationActive(req.params.id, false);
+    const actingAdminEmail = (req as any).user?.email;
+    const updated = await setOrganizationActive(req.params.id, false, actingAdminEmail);
     res.json({ success: true, message: "Organization suspended", organization: updated });
   } catch (error: any) {
     logger.error("Failed to suspend organization", {
@@ -497,7 +498,8 @@ export async function activateOrganizationHandler(
   res: Response
 ) {
   try {
-    const updated = await setOrganizationActive(req.params.id, true);
+    const actingAdminEmail = (req as any).user?.email;
+    const updated = await setOrganizationActive(req.params.id, true, actingAdminEmail);
     res.json({ success: true, message: "Organization reactivated", organization: updated });
   } catch (error: any) {
     logger.error("Failed to reactivate organization", {
@@ -613,7 +615,8 @@ export async function approveOrganizationHandler(
   res: Response
 ) {
   try {
-    const updated = await approveOrganization(req.params.id);
+    const actingAdminEmail = (req as any).user?.email;
+    const updated = await approveOrganization(req.params.id, actingAdminEmail);
     res.json({ success: true, message: "Organization approved", organization: updated });
   } catch (error: any) {
     logger.error("Failed to approve organization", {
@@ -634,7 +637,8 @@ export async function rejectOrganizationHandler(
   res: Response
 ) {
   try {
-    const updated = await rejectOrganization(req.params.id);
+    const actingAdminEmail = (req as any).user?.email;
+    const updated = await rejectOrganization(req.params.id, actingAdminEmail);
     res.json({ success: true, message: "Organization rejected", organization: updated });
   } catch (error: any) {
     logger.error("Failed to reject organization", {

--- a/apps/server/src/services/organizationService.ts
+++ b/apps/server/src/services/organizationService.ts
@@ -3,7 +3,13 @@ import * as repo from "../repositories/organizationRepository";
 import * as userRepo from "../repositories/userRepository";
 import { aggregateUsageStats } from "../repositories/usageRepository";
 import { register } from "./authService";
-import { sendOrgApprovalRequestEmail, sendOrgApprovedEmail, sendOrgStatusEmail, sendInviteEmail } from "../utils/email";
+import {
+  sendOrgApprovalRequestEmail,
+  sendOrgApprovedEmail,
+  sendOrgStatusEmail,
+  sendInviteEmail,
+  sendOrgAdminActionEmail,
+} from "../utils/email";
 import logger from "../logger";
 
 function generateTemporaryPassword(): string {
@@ -342,7 +348,28 @@ export async function publicRequestOrganization(data: {
   return organization;
 }
 
-export async function approveOrganization(orgId: string) {
+async function notifyOtherAdmins(
+  kind: "approved" | "rejected" | "suspended" | "reactivated",
+  orgName: string,
+  actingAdminEmail?: string,
+) {
+  if (!actingAdminEmail) return;
+  try {
+    const users = await userRepo.getUsers();
+    const otherAdmins = users.filter(
+      (u: any) => u.role === "admin" && u.email !== actingAdminEmail
+    );
+    await Promise.all(
+      otherAdmins.map((admin: any) =>
+        sendOrgAdminActionEmail(admin.email, kind, orgName, actingAdminEmail)
+      )
+    );
+  } catch (error) {
+    logger.error("Failed to notify other admins about org action", { error, kind });
+  }
+}
+
+export async function approveOrganization(orgId: string, actingAdminEmail?: string) {
   const organization = await repo.getOrganizationById(orgId);
   if (!organization) {
     throw new Error("Organization not found");
@@ -369,12 +396,13 @@ export async function approveOrganization(orgId: string) {
       organizationId: orgId,
     });
   }
+  await notifyOtherAdmins("approved", (organization as any).name, actingAdminEmail);
 
   logger.info("Organization approved", { organizationId: orgId });
   return updated;
 }
 
-export async function rejectOrganization(orgId: string) {
+export async function rejectOrganization(orgId: string, actingAdminEmail?: string) {
   const organization = await repo.getOrganizationById(orgId);
   if (!organization) {
     throw new Error("Organization not found");
@@ -401,6 +429,7 @@ export async function rejectOrganization(orgId: string) {
       organizationId: orgId,
     });
   }
+  await notifyOtherAdmins("rejected", (organization as any).name, actingAdminEmail);
 
   logger.info("Organization rejected", { organizationId: orgId });
   return updated;
@@ -423,7 +452,11 @@ export async function listAllOrganizationsWithStats() {
   return repo.getOrganizationsWithUserCount();
 }
 
-export async function setOrganizationActive(orgId: string, isActive: boolean) {
+export async function setOrganizationActive(
+  orgId: string,
+  isActive: boolean,
+  actingAdminEmail?: string,
+) {
   const organization = await repo.getOrganizationById(orgId);
   if (!organization) {
     throw new Error("Organization not found");
@@ -455,6 +488,11 @@ export async function setOrganizationActive(orgId: string, isActive: boolean) {
       organizationId: orgId,
     });
   }
+  await notifyOtherAdmins(
+    isActive ? "reactivated" : "suspended",
+    (organization as any).name,
+    actingAdminEmail,
+  );
 
   logger.info("Organization active state changed", { organizationId: orgId, isActive });
   return updated;

--- a/apps/server/src/utils/email.ts
+++ b/apps/server/src/utils/email.ts
@@ -843,6 +843,85 @@ export async function sendOrgStatusEmail(
   }
 }
 
+const ORG_ADMIN_ACTION_COPY = {
+  approved: (orgName: string) => `אישר את הארגון "${orgName}"`,
+  rejected: (orgName: string) => `דחה את הארגון "${orgName}"`,
+  suspended: (orgName: string) => `השעה את הארגון "${orgName}"`,
+  reactivated: (orgName: string) => `הפעיל מחדש את הארגון "${orgName}"`,
+} as const;
+
+/**
+ * Audit notification: let the OTHER admins know one of their peers took an
+ * approve/reject/suspend/reactivate action on an organization, so the team
+ * has visibility into moderation actions it didn't itself perform.
+ */
+export async function sendOrgAdminActionEmail(
+  adminEmail: string,
+  kind: keyof typeof ORG_ADMIN_ACTION_COPY,
+  orgName: string,
+  actingAdminEmail: string,
+) {
+  const dashboardUrl = `${FRONTEND_URL}/safeai-ui`;
+  const safeOrgName = escapeHtml(orgName);
+  const safeActingAdminEmail = escapeHtml(actingAdminEmail);
+  const summary = ORG_ADMIN_ACTION_COPY[kind](orgName);
+  const safeSummary = ORG_ADMIN_ACTION_COPY[kind](safeOrgName);
+
+  const mailOptions = {
+    from: EMAIL_FROM,
+    to: adminEmail,
+    subject: sanitizeHeaderValue(`עדכון ניהול ארגונים: ${summary}`),
+    html: `
+      <!DOCTYPE html>
+      <html dir="rtl" lang="he">
+      <head><meta charset="UTF-8">
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+          .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+          .header { background: #555; color: white; padding: 30px; text-align: center; border-radius: 10px 10px 0 0; }
+          .content { background: #f9f9f9; padding: 30px; border-radius: 0 0 10px 10px; }
+          .button { display: inline-block; padding: 15px 30px; background: #555; color: white; text-decoration: none; border-radius: 5px; margin: 20px 0; }
+          .footer { text-align: center; margin-top: 20px; color: #666; font-size: 12px; }
+        </style>
+      </head>
+      <body>
+        <div class="container">
+          <div class="header"><h1>עדכון ניהול ארגונים</h1></div>
+          <div class="content">
+            <p>שלום,</p>
+            <p>מנהל המערכת <strong>${safeActingAdminEmail}</strong> ${safeSummary}.</p>
+            <p style="text-align: center;">
+              <a href="${dashboardUrl}" class="button">מעבר למסך ניהול הארגונים</a>
+            </p>
+          </div>
+          <div class="footer"><p>© 2026 SafeAI. כל הזכויות שמורות.</p></div>
+        </div>
+      </body>
+      </html>
+    `,
+    text: `מנהל המערכת ${actingAdminEmail} ${summary}.\n${dashboardUrl}\n\n© 2026 SafeAI`,
+  };
+
+  try {
+    const info = await withRetry(async () => {
+      const transporter = await createTransporter();
+      return transporter.sendMail(mailOptions);
+    });
+
+    if (process.env.NODE_ENV !== "production") {
+      logger.debug("📧 Org Admin Action Email (DEV MODE):");
+      logger.info("To:", adminEmail);
+      logger.info("Action:", kind);
+    }
+    return info;
+  } catch (error) {
+    logger.error("Failed to send org admin action email:", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // best-effort
+  }
+}
+
 /**
  * Notify the tender's publisher that a new applicant registered
  */


### PR DESCRIPTION
## Issue
Closes #283

## Summary
- #283 (emails to admins): admins previously only got emailed when a new org signup came in - once one admin acted on it, the rest of the team had no visibility into who approved/rejected/suspended/reactivated an org unless they checked the dashboard. The acting admin's email is now threaded through to the service layer and every *other* admin gets a short audit notice.
- #283 (UX): the pending-organizations approve/reject buttons fired immediately on click with no confirmation and no disabled state during the request, unlike the already-hardened suspend/activate flow elsewhere in the app. Brought them up to the same standard - a `confirm()` dialog (reject is irreversible) and a disabled "מעבד..." state while in flight.

Reimplementation of #295, which predates the `apps/` monorepo restructure and could no longer be merged cleanly (structural conflicts against the current file layout, not a normal merge conflict). Same change, applied fresh against current `develop`.

**Note on scope:** the original PR also updated `organizationController.test.ts` for the new `actingAdminEmail` parameter. That test file doesn't exist in current `develop` (no controller-level tests currently cover these handlers), so there was nothing to update — not omitted, just not applicable.

## Test plan
- [x] `npx jest organization` — 46/46 pass
- [x] `tsc --noEmit` on touched client/server files — no new errors
- [x] `npx eslint` on touched files — 0 errors
- [x] Production build succeeds
- [x] Full server suite — 15/15 suites, 125/125 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn)_