### PR TITLE
fix(org): enforce admin-only org creation + force password change for temp credentials

### DIFF
--- a/apps/client/src/config/api.ts
+++ b/apps/client/src/config/api.ts
@@ -13,6 +13,7 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/auth/verify-email/${token}`,
     forgotPassword: `${API_BASE_URL}/auth/forgot-password`,
     resetPassword: `${API_BASE_URL}/auth/reset-password`,
+    changePassword: `${API_BASE_URL}/auth/change-password`,
     googleLogin: `${API_BASE_URL}/auth/google`,
     googleCallback: `${API_BASE_URL}/auth/google/callback`,
     me: `${API_BASE_URL}/auth/me`,

--- a/apps/client/src/context/authStore.ts
+++ b/apps/client/src/context/authStore.ts
@@ -9,6 +9,7 @@ export interface AuthUser {
   mode?: "BYOK" | "MANAGED";
   canCreatePosts?: boolean;
   canComment?: boolean;
+  mustChangePassword?: boolean;
 }
 
 export interface AuthContextValue {

--- a/apps/client/src/features/auth/ChangePassword.tsx
+++ b/apps/client/src/features/auth/ChangePassword.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { apiCall, API_ENDPOINTS } from "../../config/api";
+import { useAuth } from "../../context/authStore";
+
+export default function ChangePassword() {
+  const navigate = useNavigate();
+  const { user, setUser } = useAuth();
+  const [formData, setFormData] = useState({
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
+
+  const validatePassword = (password: string): string[] => {
+    const errors: string[] = [];
+    if (password.length < 8) {
+      errors.push("הסיסמה חייבת להכיל לפחות 8 תווים");
+    }
+    if (!/[A-Z]/.test(password)) {
+      errors.push("הסיסמה חייבת להכיל לפחות אות גדולה אחת");
+    }
+    if (!/[a-z]/.test(password)) {
+      errors.push("הסיסמה חייבת להכיל לפחות אות קטנה אחת");
+    }
+    if (!/[0-9]/.test(password)) {
+      errors.push("הסיסמה חייבת להכיל לפחות ספרה אחת");
+    }
+    return errors;
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+    if (e.target.name === "newPassword" && passwordErrors.length > 0) {
+      setPasswordErrors([]);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setPasswordErrors([]);
+
+    if (formData.newPassword !== formData.confirmPassword) {
+      setError("הסיסמאות אינן תואמות");
+      setLoading(false);
+      return;
+    }
+
+    const errors = validatePassword(formData.newPassword);
+    if (errors.length > 0) {
+      setPasswordErrors(errors);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      await apiCall<{ success: boolean; message: string }>(
+        API_ENDPOINTS.auth.changePassword,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            currentPassword: formData.currentPassword,
+            newPassword: formData.newPassword,
+          }),
+        }
+      );
+
+      if (user) {
+        setUser({ ...user, mustChangePassword: false });
+      }
+      navigate(user?.profileId ? "/safeai-ui" : "/login");
+    } catch (err: unknown) {
+      const errorMessage =
+        err instanceof Error ? err.message : "עדכון הסיסמה נכשל";
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-form-container">
+      <div className="auth-form-wrapper">
+        <h2 className="auth-title">עדכון סיסמה נדרש</h2>
+
+        <p style={{ textAlign: "center", color: "#666", marginBottom: "25px" }}>
+          הסיסמה שקיבלת היא זמנית — יש להחליף אותה לפני המשך השימוש
+        </p>
+
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="currentPassword">סיסמה זמנית *</label>
+            <input
+              type="password"
+              id="currentPassword"
+              name="currentPassword"
+              value={formData.currentPassword}
+              onChange={handleChange}
+              required
+              autoComplete="current-password"
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="newPassword">סיסמה חדשה *</label>
+            <input
+              type="password"
+              id="newPassword"
+              name="newPassword"
+              value={formData.newPassword}
+              onChange={handleChange}
+              required
+              autoComplete="new-password"
+            />
+            {passwordErrors.length > 0 && (
+              <div className="password-requirements">
+                <ul>
+                  {passwordErrors.map((err, idx) => (
+                    <li key={idx} style={{ color: "#dc3545", fontSize: "12px" }}>
+                      {err}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="confirmPassword">אימות סיסמה *</label>
+            <input
+              type="password"
+              id="confirmPassword"
+              name="confirmPassword"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              required
+              autoComplete="new-password"
+            />
+          </div>
+
+          {error && (
+            <div className="alert alert-error" style={{ marginBottom: "15px" }}>
+              {error}
+            </div>
+          )}
+
+          <button type="submit" className="btn btn-primary btn-full" disabled={loading}>
+            {loading ? "מעדכן..." : "עדכן סיסמה"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/auth/LoginForm.tsx
+++ b/apps/client/src/features/auth/LoginForm.tsx
@@ -17,6 +17,7 @@ interface User {
   role: string;
   mode: "BYOK" | "MANAGED";
   profileId?: string;
+  mustChangePassword?: boolean;
 }
 
 export default function LoginForm() {
@@ -115,8 +116,10 @@ export default function LoginForm() {
         // Start activity tracking for token management
         startActivityTracking();
 
-        // Check if user has a profile
-        if (!response.user.profileId) {
+        if (response.user.mustChangePassword) {
+          // Temporary password (e.g. issued when added to an organization) must be replaced first
+          navigate("/change-password");
+        } else if (!response.user.profileId) {
           // Show profile selection modal
           setLoggedInUser(response.user);
           setShowProfileModal(true);

--- a/apps/client/src/features/organizations/components/OrganizationDetail.tsx
+++ b/apps/client/src/features/organizations/components/OrganizationDetail.tsx
@@ -94,6 +94,7 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
     const workbook = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(workbook, worksheet, "משתמשים חדשים");
     XLSX.writeFile(workbook, `משתמשי-${org?.name || "ארגון"}.xlsx`);
+    setCreatedMembers([]);
   };
 
   useEffect(() => {
@@ -195,6 +196,10 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
       {createdMembers.length > 0 && (
         <div className="org-pending-card">
           <p>נוספו {createdMembers.length} משתמשים חדשים בסשן הזה. פרטי ההתחברות שיש למסור להם:</p>
+          <p className="orgs-admin-subtitle">
+            ⚠️ הסיסמאות המוצגות כאן חד-פעמיות בלבד — כל משתמש חדש יידרש להחליף אותה בכניסה הראשונה.
+            מומלץ למסור אותן למשתמשים ולמחוק את קובץ האקסל מיד לאחר מכן.
+          </p>
           <table className="orgs-table">
             <thead>
               <tr>
@@ -215,6 +220,9 @@ export const OrganizationDetail = ({ orgId, onBack }: OrganizationDetailProps) =
           </table>
           <button type="button" className="orgs-btn orgs-btn-activate" onClick={handleDownloadExcel}>
             הורדת קובץ אקסל
+          </button>
+          <button type="button" className="orgs-btn" onClick={() => setCreatedMembers([])}>
+            סגירה ומחיקת הרשימה מהמסך
           </button>
         </div>
       )}

--- a/apps/client/src/pages/OrganizationUsersPage.tsx
+++ b/apps/client/src/pages/OrganizationUsersPage.tsx
@@ -261,6 +261,7 @@ export default function OrganizationUsersPage() {
     const workbook = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(workbook, worksheet, "משתמשים חדשים");
     XLSX.writeFile(workbook, `משתמשי-${organization?.name || "ארגון"}.xlsx`);
+    setCreatedMembers([]);
   };
 
   if (loading) {
@@ -405,6 +406,10 @@ export default function OrganizationUsersPage() {
       {createdMembers.length > 0 && (
         <div className="organization-info-card">
           <p>נוספו {createdMembers.length} משתמשים חדשים בסשן הזה. פרטי ההתחברות שיש למסור להם:</p>
+          <div className="simulation-warning">
+            ⚠️ הסיסמאות המוצגות כאן חד-פעמיות בלבד — כל משתמש חדש יידרש להחליף אותה בכניסה הראשונה.
+            מומלץ למסור אותן למשתמשים ולמחוק את קובץ האקסל מיד לאחר מכן.
+          </div>
           <table className="organization-table">
             <thead>
               <tr>
@@ -425,6 +430,9 @@ export default function OrganizationUsersPage() {
           </table>
           <button type="button" className="topup-button" onClick={handleDownloadExcel}>
             הורדת קובץ אקסל
+          </button>
+          <button type="button" className="retry-button" onClick={() => setCreatedMembers([])}>
+            סגירה ומחיקת הרשימה מהמסך
           </button>
         </div>
       )}

--- a/apps/client/src/router/AppRouter.tsx
+++ b/apps/client/src/router/AppRouter.tsx
@@ -22,6 +22,7 @@ import ApiKeyDisplay from "../features/auth/ApiKeyDisplay";
 import EmailVerification from "../features/auth/EmailVerification";
 import ForgotPassword from "../features/auth/ForgotPassword";
 import ResetPassword from "../features/auth/ResetPassword";
+import ChangePassword from "../features/auth/ChangePassword";
 import RegisterFormSuccess from "../features/auth/RegisterFormSuccess";
 import TopNavigation from "../components/TopNavigation";
 import BetaBanner from "../components/BetaBanner";
@@ -133,6 +134,15 @@ export default function AppRouter() {
         />
 
         <Route path="/reset-password/:token" element={<ResetPassword />} />
+
+        <Route
+          path="/change-password"
+          element={
+            <ProtectedRoute>
+              <ChangePassword />
+            </ProtectedRoute>
+          }
+        />
 
         {/* Protected Routes */}
         <Route

--- a/apps/server/src/controllers/authController.ts
+++ b/apps/server/src/controllers/authController.ts
@@ -12,6 +12,7 @@ import {
   refreshTokenSchema,
   forgotPasswordSchema,
   resetPasswordSchema,
+  changePasswordSchema,
   verifyEmailSchema,
 } from "../utils/validation";
 import logger from "../logger";
@@ -199,6 +200,30 @@ export async function resetPasswordHandler(req: Request, res: Response) {
     res.status(400).json({
       success: false,
       error: error.message || "איפוס הסיסמה נכשל",
+    });
+  }
+}
+
+/**
+ * Change password (used to clear a forced mustChangePassword flag)
+ * POST /api/auth/change-password
+ */
+export async function changePasswordHandler(req: Request, res: Response) {
+  try {
+    const user = (req as any).user; // From authenticateToken middleware
+    const data = validateRequest(changePasswordSchema, req.body);
+    await authService.changePassword(user.userId, data.currentPassword, data.newPassword);
+
+    res.json({
+      success: true,
+      message: "הסיסמה עודכנה בהצלחה",
+    });
+  } catch (error: any) {
+    logger.error("Change password error:", { error: error.message, stack: error.stack });
+    const statusCode = error.statusCode || 400;
+    res.status(statusCode).json({
+      success: false,
+      error: error.message || "עדכון הסיסמה נכשל",
     });
   }
 }

--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -76,6 +76,10 @@ const UserSchema = new mongoose.Schema(
       type: Boolean,
       default: true,
     },
+    mustChangePassword: {
+      type: Boolean,
+      default: false,
+    },
 
     // --- Forum permissions ---
     // Opt-in: forbidden by default, an admin must explicitly grant it per user.

--- a/apps/server/src/routes/authRouter.ts
+++ b/apps/server/src/routes/authRouter.ts
@@ -11,6 +11,7 @@ import {
   verifyEmailHandler,
   forgotPasswordHandler,
   resetPasswordHandler,
+  changePasswordHandler,
   getCurrentUserHandler,
 } from "../controllers/authController";
 import {
@@ -40,6 +41,7 @@ router.get("/google/callback", googleCallbackHandler);
 
 // Protected routes (require JWT)
 router.post("/logout", authenticateToken, logoutHandler);
+router.post("/change-password", authenticateToken, changePasswordHandler);
 router.get("/me", authenticateToken, getCurrentUserHandler);
 
 export default router;

--- a/apps/server/src/routes/organizationRouter.ts
+++ b/apps/server/src/routes/organizationRouter.ts
@@ -60,7 +60,7 @@ router.get("/admin/all", requireAdmin, getAllOrganizationsHandler); // System Ad
 router.get("/my", getMyOrganizationHandler); // Current user's own organization (any status)
 
 // 2. GENERAL ORGANIZATION ROUTES
-router.post("/", createOrganizationHandler); // Admin only
+router.post("/", requireAdmin, createOrganizationHandler); // Admin only
 router.get("/", listOrganizationsHandler);    // Admin רואה הכל, Org Owner רואה את שלו
 
 // 3. PROTECTED DYNAMIC ROUTES (נתיבים עם מזהה דינמי תמיד בסוף)

--- a/apps/server/src/services/authService.ts
+++ b/apps/server/src/services/authService.ts
@@ -35,6 +35,7 @@ export async function register(data: {
   mode?: "BYOK" | "MANAGED";
   role?: string;
   skipEmailVerification?: boolean;
+  mustChangePassword?: boolean;
 }) {
   // Check if user already exists
   const existingUser = await User.findOne({ email: data.email.toLowerCase() });
@@ -110,6 +111,7 @@ export async function register(data: {
       emailVerified: !!data.skipEmailVerification,
       verificationToken,
       verificationTokenExpires,
+      mustChangePassword: !!data.mustChangePassword,
     });
 
     // Only send the verification email for the normal self-registration flow.
@@ -347,6 +349,28 @@ export async function resetPassword(token: string, newPassword: string) {
   // Invalidate all refresh tokens for security
   user.refreshTokens = [];
 
+  await user.save();
+
+  return { success: true };
+}
+
+export async function changePassword(
+  userId: string,
+  currentPassword: string,
+  newPassword: string,
+) {
+  const user = await User.findById(userId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  const isCurrentPasswordValid = await bcrypt.compare(currentPassword, user.password);
+  if (!isCurrentPasswordValid) {
+    throw { statusCode: 401, message: "הסיסמה הנוכחית שגויה" };
+  }
+
+  user.password = await bcrypt.hash(newPassword, SALT_ROUNDS);
+  user.mustChangePassword = false;
   await user.save();
 
   return { success: true };

--- a/apps/server/src/services/organizationService.ts
+++ b/apps/server/src/services/organizationService.ts
@@ -209,6 +209,7 @@ export async function createOrganizationMember(
       organizationId: orgId,
       role: data.role || "user",
       skipEmailVerification: true,
+      mustChangePassword: true,
     });
 
     logger.info("Organization member created", { organizationId: orgId, userId: user._id });

--- a/apps/server/src/utils/validation.ts
+++ b/apps/server/src/utils/validation.ts
@@ -50,6 +50,19 @@ export const forgotPasswordSchema = z.object({
 });
 
 /**
+ * Change password validation schema
+ */
+export const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1, "נא להזין את הסיסמה הנוכחית"),
+  newPassword: z
+    .string()
+    .min(8, "הסיסמה חייבת להכיל לפחות 8 תווים")
+    .regex(/[A-Z]/, "הסיסמה חייבת להכיל לפחות אות גדולה אחת")
+    .regex(/[a-z]/, "הסיסמה חייבת להכיל לפחות אות קטנה אחת")
+    .regex(/[0-9]/, "הסיסמה חייבת להכיל לפחות ספרה אחת"),
+});
+
+/**
  * Reset password validation schema
  */
 export const resetPasswordSchema = z.object({


### PR DESCRIPTION
## Issue
Closes #279
Closes #280

## Summary
- #280: `POST /organizations` was missing `requireAdmin`, so any authenticated user could create organizations despite the route being documented as admin-only.
- #279: temporary passwords generated when adding a member to an organization are now single-use — the account is flagged `mustChangePassword` and the user is forced through a new change-password screen on first login before reaching the app. The on-screen list of newly-created members (with plaintext passwords) is cleared from React state after Excel export or manual dismissal instead of persisting indefinitely, and an explicit warning is shown near the Excel download.

Reimplementation of #291, which predates the `apps/` monorepo restructure and could no longer be merged cleanly (structural conflicts against the current file layout, not a normal merge conflict). Same change, applied fresh against current `develop`. Note: `AuthContext.tsx` has since been split into `AuthContext.tsx` + `authStore.ts` (`useAuth`/`AuthUser` moved to the latter) — the `mustChangePassword` field was added to `AuthUser` there instead.

## Test plan
- [x] `npx jest organizationRouter organizationController organizationService` — all pass (46/46 for organization)
- [x] `tsc --noEmit` on touched server/client files — no new errors
- [x] `npx eslint` on touched files — 0 errors
- [x] Full server suite — 15/15 suites, 125/125 tests pass
- [x] Production build succeeds
- [ ] Manual: log in as a newly-created org member, confirm redirect to /change-password and that the temp password stops working after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxTACm86Q8AmCqqz9pioqn)_