### PR TITLE
Smart search: switch to AI candidate-id filtering (no embeddings)

### DIFF
--- a/apps/server/src/services/__tests__/tenderBoardService.test.ts
+++ b/apps/server/src/services/__tests__/tenderBoardService.test.ts
@@ -302,11 +302,11 @@ describe("Tender Board Feature Tests", () => {
   });
 
   describe("GET /tender-board/smart-search", () => {
-    it("should perform smart search using AI mongo query translation", async () => {
-      const mockMongoQuery = { productType: "אפליקציה" };
+    it("should perform smart search using AI candidate-id filtering", async () => {
+      const mockMatchedIds = ["1"];
       const mockTendersResult = [{ _id: "1", title: "מכרז אפליקציה בצפון" }];
 
-      AIService.generateSearchQuery = jest.fn().mockResolvedValue(mockMongoQuery);
+      AIService.generateSearchResultIds = jest.fn().mockResolvedValue(mockMatchedIds);
       (service.smartSearchTenders as jest.Mock).mockResolvedValue(mockTendersResult);
 
       const res = await request(app)

--- a/apps/server/src/services/tenderBoardAIService.ts
+++ b/apps/server/src/services/tenderBoardAIService.ts
@@ -31,10 +31,10 @@ const TenderZodSchema = z.object({
   additionalDetails: z.string(),
 });
 
-// ✅ הסכמה מצפה ל-{ query: {...} }
-const SearchQueryZodSchema = z.object({
-  query: z.record(z.string(), z.any())
-    .describe("אובייקט שאילתת MongoDB תקני"),
+// ה-AI מקבל רשימת מכרזים מועמדים (id + שדות תיאוריים) וטקסט חיפוש, ומחזיר
+// אך ורק את ה-IDים הרלוונטיים - לא בונה שאילתת Mongo בעצמו.
+const SearchResultIdsZodSchema = z.object({
+  ids: z.array(z.string()).describe("מערך של IDים של המכרזים הרלוונטיים לבקשת החיפוש, מסודר מהמתאים ביותר"),
 });
 
 // סכמת הגארדרייל הנושאי — בודקת אם הטקסט שהוזן אכן מתאר בקשה ליצירת מכרז
@@ -110,35 +110,19 @@ const TENDER_SYSTEM_PROMPT = `אתה מנתח מכרזים. תפקידך: לקב
 == דוגמה לפלט תקין ==
 {"title":"foo","shortDescription":"bar baz","timeRequired":{"value":30,"unit":"ימים"},"budget":50000,"productType":"אפליקציה","aiApplicationType":"צאטבוט","agentsRequired":["foo agent"],"wantsEmails":false,"additionalDetails":""}`;
 
-const SEARCH_SYSTEM_PROMPT = `אתה מנוע חיפוש MongoDB. תפקידך: לקבל בקשת חיפוש בשפה חופשית ולהחזיר JSON בלבד — שאילתת filter תקנית עבור Mongoose.
+const SEARCH_BY_ID_SYSTEM_PROMPT = `אתה מנוע חיפוש מכרזים. תפקידך: לקבל רשימת מכרזים (כל מכרז עם id ושדות תיאוריים) ובקשת חיפוש בשפה חופשית, ולהחזיר JSON בלבד עם מערך של IDים של המכרזים הרלוונטיים ביותר לבקשה.
 
 == כללי פלט ==
 - החזר JSON בלבד. אסור להוסיף הסבר, כותרת, markdown, קוד-בלוק או כל טקסט אחר.
-- חובה לעטוף את השאילתה תחת המפתח "query" — תמיד, ללא יוצא מן הכלל.
-- מבנה הפלט: {"query": { ...שאילתת MongoDB... }}
+- מבנה הפלט: {"ids": ["<id1>", "<id2>", ...]}
+- החזר אך ורק IDים שמופיעים ברשימה שקיבלת — אסור להמציא ID.
+- אל תחזיר את פרטי המכרז עצמו, רק את ה-ID שלו.
+- אם אין מכרזים מתאימים — החזר: {"ids": []}
+- סדר את ה-IDים לפי רמת ההתאמה לבקשה, מהמתאים ביותר למתאים פחות.
 
-== השדות הזמינים לחיפוש ==
-title, shortDescription, productType, budget, timeRequired, aiApplicationType, additionalDetails
-
-== חוקי בניית השאילתה ==
-1. חיפוש טקסט חופשי — השתמש ב-$regex עם $options:"i". חלץ מילות מפתח בלבד, אל תשים את הבקשה המלאה.
-2. חיפוש במספר שדות במקביל — השתמש ב-$or.
-3. התאמה לשדות enum — השתמש בערך העברי המדויק בלבד, ללא $regex, ללא שינוי תו אחד:
-   aiApplicationType: "התממשקות פשוטה" | "צאטבוט" | "אייגנט" | "מולטי אייגנט"
-   productType: "אפליקציה" | "אתר" | "תוכנת desktop" | "הטמעה של פיצר במערכת קיימת" | "ייעוץ" | "הקמת תשתית לאייגנט" | "אחר"
-4. אם הבקשה מתאימה לערך enum — השתמש בהתאמה מדויקת בלבד, לא ב-$regex.
-5. אם אין מספיק מידע לבניית שאילתה — החזר: {"query": {}}
-
-== דוגמאות ==
-
+== דוגמה ==
 בקשה: "אני רוצה צאטבוטים"
-פלט: {"query": {"aiApplicationType": "צאטבוט"}}
-
-בקשה: "אייגנטים לניהול foo"
-פלט: {"query": {"aiApplicationType": "אייגנט", "$or": [{"title": {"$regex": "foo", "$options": "i"}}, {"shortDescription": {"$regex": "foo", "$options": "i"}}]}}
-
-בקשה: "מערכת לניהול bar"
-פלט: {"query": {"$or": [{"title": {"$regex": "bar", "$options": "i"}}, {"shortDescription": {"$regex": "bar", "$options": "i"}}]}}`;
+פלט: {"ids": ["foo123", "bar456"]}`;
 
 const GUARDRAIL_SYSTEM_PROMPT = `אתה שומר סף (Guardrail) עבור לוח מכרזים המיועד אך ורק לפרויקטים בתחום פיתוח תוכנה, טכנולוגיה וייעוץ AI.
 תפקידך: לקרוא את פרטי המכרז שסופקו, ולהחליט אם הוא אכן שייך לתחום המותר, ולהחזיר JSON בלבד לפי הסכמה.
@@ -279,29 +263,37 @@ export class TBAIService {
     }
   }
 
-  static async generateSearchQuery(userSearchText: string): Promise<Record<string, any>> {
+  /**
+   * מקבלת רשימת מכרזים מועמדים (id + שדות תיאוריים בלבד) ואת טקסט החיפוש של
+   * הלקוח, ומחזירה אך ורק מערך של IDים של המכרזים הרלוונטיים — לא בונה שאילתת
+   * Mongo ולא משתמשת ב-embeddings. הקריאה שולחת ל-AI רק את ה-id והשדות
+   * התיאוריים (לא את המסמך המלא), כדי לחסוך בטוקנים.
+   */
+  static async generateSearchResultIds(
+    userSearchText: string,
+    tenders: Array<{ id: string; [key: string]: any }>
+  ): Promise<string[]> {
     const startTime = Date.now();
     try {
-      logger.info("Starting AI search query generation", { searchText: userSearchText });
+      logger.info("Starting AI search-by-id generation", {
+        searchText: userSearchText,
+        candidateCount: tenders.length,
+      });
 
-      // ← קריאה ל-callAI הגנרי
       const raw = await callAI({
-        userPrompt: `בקשת החיפוש: "${userSearchText}"`,
-        systemPrompt: SEARCH_SYSTEM_PROMPT,
-        schema: z.record(z.string(), z.any()), // מקבלים any object — נעשה normalize בעצמנו
+        userPrompt: `בקשת החיפוש: "${userSearchText}"\n\nרשימת המכרזים:\n${JSON.stringify(tenders)}`,
+        systemPrompt: SEARCH_BY_ID_SYSTEM_PROMPT,
+        schema: SearchResultIdsZodSchema,
         temperature: 0.1,
       });
 
-      // ✅ תיקון 2: fallback — אם Gemini לא עטף ב-query, עוטפים בעצמנו
-      const normalized = (raw as any).query !== undefined
-        ? (raw as any)
-        : { query: raw };
+      const validIds = new Set(tenders.map((t) => t.id));
+      const ids = raw.ids.filter((id) => validIds.has(id));
 
-      const parsedData = SearchQueryZodSchema.parse(normalized);
-      const query = parsedData?.query && Object.keys(parsedData.query).length > 0 ? parsedData.query : {};
-
-      logger.info("AI search query generation completed", {
-        query: JSON.stringify(query),
+      logger.info("AI search-by-id generation completed", {
+        searchText: userSearchText,
+        matchedCount: ids.length,
+        responseTime: Date.now() - startTime,
       });
 
       await saveTenderLog({
@@ -309,18 +301,16 @@ export class TBAIService {
         status: "SUCCESS",
         metaData: {
           searchText: userSearchText,
-          query,
+          candidateCount: tenders.length,
+          matchedCount: ids.length,
           responseTime: Date.now() - startTime,
         },
       });
 
-      // Returns the raw (not-yet-sanitized) filter object — the caller
-      // (tenderBoardService.smartSearchTenders) is responsible for sanitizing
-      // it against an allowlist before executing it against the database.
-      return query;
+      return ids;
 
     } catch (error: any) {
-      logger.error("Error in AIService.generateSearchQuery", {
+      logger.error("Error in AIService.generateSearchResultIds", {
         error,
         searchText: userSearchText,
       });

--- a/apps/server/src/services/tenderBoardService.ts
+++ b/apps/server/src/services/tenderBoardService.ts
@@ -486,51 +486,6 @@ export async function createSmartTender(text: string) {
   }
 }
 
-// Only these tender fields, and only these operators on them, may appear in an
-// AI-generated search filter — blocks $where/$expr/$function-style NoSQL injection
-// via prompt injection in the free-text search box.
-const SEARCHABLE_TENDER_FIELDS = [
-  "title",
-  "shortDescription",
-  "productType",
-  "budget",
-  "timeRequired",
-  "aiApplicationType",
-  "additionalDetails",
-];
-
-function isAllowedFieldValue(value: unknown): boolean {
-  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-    return true;
-  }
-  if (value && typeof value === "object" && !Array.isArray(value)) {
-    return Object.keys(value).every((key) => key === "$regex" || key === "$options");
-  }
-  return false;
-}
-
-function sanitizeSearchFilter(filter: unknown): Record<string, any> {
-  if (!filter || typeof filter !== "object" || Array.isArray(filter)) return {};
-
-  const sanitized: Record<string, any> = {};
-
-  for (const [key, value] of Object.entries(filter as Record<string, unknown>)) {
-    if (key === "$or" || key === "$and") {
-      if (Array.isArray(value)) {
-        const clauses = value.map(sanitizeSearchFilter).filter((clause) => Object.keys(clause).length > 0);
-        if (clauses.length > 0) sanitized[key] = clauses;
-      }
-      continue;
-    }
-
-    if (SEARCHABLE_TENDER_FIELDS.includes(key) && isAllowedFieldValue(value)) {
-      sanitized[key] = value;
-    }
-  }
-
-  return sanitized;
-}
-
 /**
  * ========================================================
  * אפיון אוטומטי + המלצת פיתוח (SCRUM-287/291/293) - agent-facing
@@ -640,17 +595,36 @@ export async function setTenderSpecificationPublished(id: string, isPublished: b
   return result;
 }
 
+// מספר המכרזים המקסימלי שנשלח ל-AI כמועמדים לחיפוש (מגביל טוקנים; המכרזים
+// הראשונים לפי סדר ה-DB, ללא מיון מקדים לפי רלוונטיות).
+const SEARCH_CANDIDATE_LIMIT = 100;
+
 export async function smartSearchTenders(searchText: string) {
   try {
     logger.info("Received search text for smart search", { searchText });
 
-    const mongoFilter = await TBAIService.generateSearchQuery(searchText);
+    const allTenders = await repo.getTenders();
+    const candidateTenders = allTenders.slice(0, SEARCH_CANDIDATE_LIMIT);
 
-    const safeFilter = sanitizeSearchFilter(mongoFilter);
+    const tendersForAI = candidateTenders.map((t: any) => ({
+      id: String(t._id),
+      title: t.title,
+      shortDescription: t.shortDescription,
+      productType: t.productType,
+      aiApplicationType: t.aiApplicationType,
+      timeRequired: t.timeRequired,
+      budget: t.budget,
+      additionalDetails: t.additionalDetails,
+    }));
 
-    logger.info("Executing smart search with filter", { filter: JSON.stringify(safeFilter) });
-    console.log("Executing smart search with filter:", JSON.stringify(safeFilter));
-    return await repo.getTenders(safeFilter);
+    const matchedIds = await TBAIService.generateSearchResultIds(searchText, tendersForAI);
+
+    logger.info("Smart search matched tender ids", { searchText, count: matchedIds.length });
+
+    const tenderById = new Map(candidateTenders.map((t: any) => [String(t._id), t]));
+    return matchedIds
+      .map((id) => tenderById.get(id))
+      .filter(Boolean);
   } catch (error: any) {
     if (error?.message === "RATE_LIMIT") {
       logger.warn("Rate limit reached on AI search", { searchText });


### PR DESCRIPTION
## Summary
Replaces the current "AI builds a raw MongoDB filter query" smart-search implementation with an LLM candidate-filtering approach:

- The first 100 tenders are fetched and sent to the AI as `{id, title, shortDescription, productType, aiApplicationType, timeRequired, budget, additionalDetails}` (not the full document).
- The AI (`TBAIService.generateSearchResultIds`) returns only the IDs of the relevant tenders, ordered by match quality — no MongoDB query is built or executed from AI output, so the previous allowlist/injection-sanitization layer (`sanitizeSearchFilter`) is no longer needed and was removed as dead code.
- Controller/route/signature (`smartSearchTenders(searchText)`) is unchanged — this is purely an internal reimplementation.

## Why
The team had three different smart-search implementations sitting in history:
1. **Current `develop`**: AI-generated raw Mongo filter query.
2. **Atlas Vector Search + embeddings** (on `agents/logger`/`featur/tender-bord`, #376/#378): every tender gets a `contentEmbedding`, search does `$vectorSearch` + a second AI relevance pass.
3. **This PR**: AI re-ranks/filters a candidate list by ID, no embeddings, no query-building.

This PR is a clean re-port of Tamar's own July 14 attempt at (3) (commit `1579301` on `fix/llm-tender-search`, "replace MongoDB Atlas vector search with LLM-based filtering") onto current `develop` — that original branch predates the monorepo restructure (`client/`/`server/` → `apps/client/`/`apps/server/`) and bundles unrelated CI/lint commits already covered by other PRs, so re-implementing directly against current `develop` was cleaner than merging it. Deliberately does **not** pull in the embeddings-based rewrite from #376/#378.

## Known limitation (carried over from the original design, not introduced here)
`SEARCH_CANDIDATE_LIMIT = 100` takes the first 100 tenders in whatever order `repo.getTenders()` returns them — not a relevance-based pre-filter. If the board grows past ~100 open tenders, some may never be considered. Flagging for awareness; not fixed here since the ask was to restore this exact approach.

## Verification
- `tsc --noEmit`: clean
- Full server Jest suite: 153/153 passing (updated the smart-search controller test's mock from `generateSearchQuery` to `generateSearchResultIds`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKtfdUfKe7gESpy5m9LcZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKtfdUfKe7gESpy5m9LcZL)_