### PR TITLE
fix(client): fix status badge contrast at the design-token level (SCRUM-272)

### DIFF
--- a/apps/client/src/pages/OrganizationUsersPage.tsx
+++ b/apps/client/src/pages/OrganizationUsersPage.tsx
@@ -448,14 +448,14 @@ export default function OrganizationUsersPage() {
                   <span className="status-pill" style={{
                     backgroundColor: user.isActive ? "var(--color-success)" : "var(--color-danger)"
                   }}>
-                    {user.isActive ? "פעיל" : "לא פעיל"}
+                    {user.isActive ? "✓ פעיל" : "✕ לא פעיל"}
                   </span>
                 </td>
                 <td className="status-cell">
                   <span className="status-pill" style={{
                     backgroundColor: user.lastLogin ? "var(--color-success)" : "var(--color-danger)"
                   }}>
-                    {user.lastLogin ? "הצטרף" : "ממתין להתחברות ראשונה"}
+                    {user.lastLogin ? "✓ הצטרף" : "⏳ ממתין להתחברות ראשונה"}
                   </span>
                 </td>
                 <td>{new Date(user.createdAt).toLocaleDateString()}</td>

--- a/apps/client/src/styles/design-system.css
+++ b/apps/client/src/styles/design-system.css
@@ -39,7 +39,11 @@
   --gray-900: #0f172a;
   --gray-950: #020617;
 
-  --color-success: #16a34a;
+  /* Darkened from #16a34a/#0284c7 - those were ~3.3:1/~4.1:1 with white
+     text, below WCAG AA (4.5:1). These pass (~5:1+) so every solid-fill
+     badge using --color-success/--color-info + --text-inverse across the
+     app is AA-compliant, not just call sites that opt in individually. */
+  --color-success: #2e7d32;
   --color-success-bg: #f0fdf4;
   --color-success-border: #bbf7d0;
 
@@ -51,7 +55,7 @@
   --color-warning-bg: #fef3c7;
   --color-warning-border: #fde68a;
 
-  --color-info: #0284c7;
+  --color-info: #1565c0;
   --color-info-bg: #f0f9ff;
   --color-info-border: #bae6fd;
 


### PR DESCRIPTION
## SCRUM-272 — נגישות badges בטבלת משתמשי ארגון

## הקשר
עבר סקירה על PR #343 (`fix/SCRUM-272-status-badges-a11y`) שמתקן את בעיית הניגודיות רק עבור `OrganizationUsersPage.tsx`, על ידי hex קשיח (`#2e7d32`/`#c62828`/`#1565c0`) שמחליף את משתני ה-CSS (`var(--color-success)`, `var(--color-info)`, `var(--text-inverse)`).

בעיה: אותם משתנים (`--color-success` / `--color-info` בשילוב עם `--text-inverse`) בשימוש בעוד כ-22 קבצים נוספים בקוד, כולם עם אותה בעיית ניגודיות. תיקון hex מקומי לעמוד אחד גם משאיר את הבעיה בכל שאר המקומות, וגם מנתק את הרכיב הזה ממנגנון ה-dark mode הקיים בפרויקט.

## הפתרון (גלובלי, ברמת ה-token)
1. **`apps/client/src/styles/design-system.css`**: הוכהו `--color-success` (`#16a34a` → `#2e7d32`) ו-`--color-info` (`#0284c7` → `#1565c0`) ב-`:root` (light mode). שני אלה נכשלו ב-WCAG AA מול טקסט לבן (~3.3:1 / ~4.1:1 בהתאמה, נדרש 4.5:1); הערכים החדשים עוברים (~5:1+). `--color-danger` (`#dc2626`) כבר עבר AA (~4.83:1) ולא שונה. ערכי ה-dark mode לא נגעו בהם — שם `--text-inverse` הפוך (טקסט כהה על רקע בהיר) וכבר עומד בניגודיות גבוהה.
2. מכיוון שכל כ-23 מקומות השימוש ב-`var(--color-success)`/`var(--color-info)` משתמשים במשתנה ולא בערך קבוע, כולם מקבלים את התיקון אוטומטית בלי לגעת בקובץ שלהם.
3. **`apps/client/src/pages/OrganizationUsersPage.tsx`**: נוספו סימנים חזותיים (✓/✕/⏳) לתגיות הפעילות וההצטרפות בהתאם לטיקט, תוך שמירה על השימוש במשתני ה-theme הקיימים (ללא hex קשיח) — כך שהרכיב ממשיך לתמוך ב-dark mode כמו שאר האפליקציה.

## בדיקות
- `npx tsc --noEmit` (client) — עובר נקי
- `npx eslint` — לא ניתן להריץ בסביבה זו (חסרה תלות `@eslint/js` ב-`node_modules`, בעיית סביבה קיימת מראש ולא קשורה לשינוי)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDcv8S5szutZNxvyeu2wyb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDcv8S5szutZNxvyeu2wyb)_